### PR TITLE
Rewrite README: fix badge, add business models & architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,227 @@
 # ImpactMojo
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/impactmojo/deploy-status)](https://www.impactmojo.in)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/f9e879bf-4792-42aa-96ea-c3a3b396f8b8/deploy-status)](https://app.netlify.com/sites/impactmojo/deploys)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![GitHub Issues](https://img.shields.io/github/issues/Varnasr/ImpactMojo)](https://github.com/Varnasr/ImpactMojo/issues)
+[![GitHub Wiki](https://img.shields.io/badge/docs-Wiki-blue)](https://github.com/Varnasr/ImpactMojo/wiki)
 
 **Free Development Education for Social Impact**
 
 ImpactMojo is a free learning platform providing rigorous, practical educational content on MEAL, Theory of Change, research methods, gender studies, and development economics for NGOs, impact practitioners, and students across South Asia.
 
-🌐 **Live:** [impactmojo.in](https://www.impactmojo.in)
+**Live:** [impactmojo.in](https://www.impactmojo.in) · **Wiki:** [Documentation & Discussion](https://github.com/Varnasr/ImpactMojo/wiki) · **Issues:** [Bug Tracker](https://github.com/Varnasr/ImpactMojo/issues)
 
 ---
 
 ## About
 
-ImpactMojo addresses a critical gap in development education. Development work in India and South Asia often lacks standardized, evidence-based knowledge foundations—resulting in interventions that lack rigor and measurable impact.
+ImpactMojo addresses a critical gap in development education. Development work in India and South Asia often lacks standardized, evidence-based knowledge foundations — resulting in interventions that lack rigor and measurable impact.
 
 We provide accessible, high-quality educational materials grounded in South Asian context, designed for educators, practitioners, researchers, students, and policymakers.
 
-### What We Offer
+---
+
+## What We Offer
+
+### Learning Platform
 
 | Category | Description |
 |----------|-------------|
-| **Courses** | Comprehensive learning tracks on MEAL, Theory of Change, Research Methods, Gender Studies, and more |
-| **Labs** | Interactive tools like the Theory of Change Workbench, Sample Size Calculator, and Data Analysis Sandbox |
-| **Games** | Gamified learning experiences for development concepts |
-| **ImpactLex** | Development sector terminology dictionary with 23+ terms, formulas, and case studies |
-| **Coaching** | Premium 1-on-1 guidance for development professionals |
-| **Community** | WhatsApp PLC, Discord, and Telegram for peer learning & resources |
+| **48 Courses** | 9 flagship + 39 foundational courses across 6 learning tracks |
+| **10 Interactive Labs** | Hands-on workbenches for MEL, policy, partnerships, and more |
+| **12 Learning Games** | Economics simulations and behavioral experiments |
+| **ImpactLex Dictionary** | 500+ development terms with contextual definitions (PWA) |
+| **Dev Case Studies** | 200 evidence-based case studies from 117 countries |
+| **DevDiscourses** | 500+ curated open-access research papers, books, and grey literature |
+| **400+ Handouts** | Downloadable resources across 6 learning tracks |
+| **Learning Loops Blog** | Articles, tutorials, and case studies on development practice |
+| **Between the Logframes** | Development podcast — honest conversations on MEAL and impact work |
+
+### Business Models & Services
+
+ImpactMojo operates a hybrid model — free foundational content for all, with premium tools and professional services for practitioners and organizations.
+
+#### Workshops
+
+Intensive three-day cohort-based training for NGOs and development teams. Entire teams learn together at a single flat rate.
+
+| Plan | Price | Details |
+|------|-------|---------|
+| **Standard** | ₹12,000/cohort | Up to 6 participants, 3 days (~6 hrs/day), 19+ topics |
+| **Advanced** | ₹15,000/cohort | Deeper technical content, software training (Stata/R), post-workshop mentoring |
+
+Topics include MLE Essentials, Theory of Change, RCTs, Survey Design, Qualitative Methods, Gender Studies, Data Analysis, and custom combinations. Sliding scale available for grassroots organizations.
+
+#### Coaching
+
+One-on-one expert guidance from Dr. Varna Sri Raman on career, research design, and data analysis.
+
+| Service | Price | Sliding Scale |
+|---------|-------|---------------|
+| **Career Coaching** | ₹1,500/session | ₹400 – ₹2,000 |
+| **Research Design Consultation** | ₹2,500/session | ₹1,000 – ₹3,000 |
+| **Data Analysis Support** | ₹2,000/session | ₹800 – ₹2,500 |
+
+All sessions are 1 hour, bookable via Google Calendar. Contact: coaching@impactmojo.in
+
+#### Dojos
+
+90-minute practice-based skill sessions — learn by doing, not just lectures.
+
+- **Price:** ₹1,500 per person per session
+- **35+ practitioner skills** across 4 categories: Thinking, Evidence, Action, Communication
+- **Structured series** available (6–8 weeks)
+- **Locations:** Delhi, Bangalore, Online
+- Pay per session, no long-term commitment
+
+Example skills: pre-mortems, reading RCTs, cost-effectiveness analysis, stakeholder mapping, funder psychology, data storytelling.
+
+#### Premium Membership Tiers
+
+| Tier | Price | Key Features |
+|------|-------|-------------|
+| **Explorer** | Free | All courses, games, labs, DevDiscourses, Telegram channel |
+| **Practitioner** | ₹399/mo · ₹3,990/yr | Advanced ToC Lab, PDF/PNG export, certificates, full community |
+| **Professional** | ₹999/mo · ₹9,990/yr | + Qual Lab, VaniScribe AI, DevData Practice, DevEconomics Toolkit, Code Converter, priority coaching |
+| **Organization** | ₹1,499/user/mo | + Team dashboards, bulk licensing, dedicated support, custom training |
+
+#### Premium Tools
+
+Available to Practitioner and Professional tier subscribers:
+
+| Tool | Tier | Description |
+|------|------|-------------|
+| **Field Notes from a Dev Economist** | Free | Behind-the-scenes analysis of real development programs |
+| **RQ Builder Pro** | Practitioner | Guided research question formulation (PICO/SPIDER) |
+| **TOC Workbench Pro** | Practitioner | Publication-ready theories of change with export |
+| **Code Convert Pro** | Professional | Translate scripts between Stata, R, Python, SPSS |
+| **Qual Insights Lab Pro** | Professional | AI-assisted qualitative analysis for transcripts |
+| **VaniScribe AI** | Professional | Transcription in 10+ South Asian languages |
+| **DevData Practice** | Professional | 36 dataset generators, 840K+ rows modeled on DHS/NFHS/ASER |
+| **Visualization Cookbook** | Professional | 14 chart types with question-driven recipes |
+| **DevEconomics Toolkit** | Professional | 11 interactive Shiny apps for development econometrics |
 
 ---
 
-## Features
+## Content Inventory
 
-### Learning Platform
-- 📚 **48 Courses** — 9 flagship + 39 foundational courses across 6 learning tracks
-- 🔬 **10 Interactive Labs** — Hands-on workbenches for MEL, policy, partnerships, and more
-- 🎮 **12 Learning Games** — Economics simulations and behavioral experiments
-- 📖 **ImpactLex Dictionary** — 500+ development terms, PWA-enabled
-- 📄 **Dev Case Studies** — 200 evidence-based case studies from 117 countries
-- 📚 **DevDiscourses** — 500+ open-access research papers and books
+### Flagship Courses (9)
 
-### User Features
-- 🔖 **Bookmarks** — Save courses and content for later
-- 📝 **Personal Notes** — Take notes while learning with streak tracking
-- 📊 **Progress Tracking** — Monitor your learning journey
-- 📚 **Reading Lists** — Curated resource collections
-- ⚖️ **Course Comparison** — Compare courses side-by-side
+Deep, comprehensive learning tracks — free for all users:
+
+| Course | Description |
+|--------|-------------|
+| **MEL for Development** | Monitoring, Evaluation & Learning — frameworks, indicators, data use |
+| **Seeing Data: Visualization for Impact** | Data storytelling, chart design, accessibility |
+| **AI for Impact: Data Monitoring & Evaluation** | AI/ML applications in development M&E |
+| **Understanding Development: An Economics Perspective** | Growth, inequality, institutions, trade |
+| **Gandhi's Political Thought: Philosophy for Praxis** | Swaraj, satyagraha, applied Gandhian thought |
+| **Politics of Aspiration** | Rights, insurance, social mobility, and aspirational politics |
+| **Media for Development** | Communication, power, narrative, and practice |
+| **Social-Emotional Learning for Development** | SEL frameworks for development contexts |
+| **Constitution & Law** | Constitutional governance and development law |
+
+### Foundational Courses (39)
+
+Shorter introductory courses covering the breadth of development practice:
+
+| Track | Courses |
+|-------|---------|
+| **MEL & Research** | MEL Fundamentals, Qualitative Research Methods, Research Ethics, Observation to Insight, EDA for Humanitarian/Health/Social Data, Bivariate Analysis, Multivariate Analysis, Item Response Theory, Cost Effectiveness 101 |
+| **Economics & Policy** | Economics 101, Development Economics, Political Economy, Econometrics 101, Poverty and Inequality, Global Development Architecture, Fundraising Fundamentals |
+| **Gender & Equity** | Gender Studies 101, Women's Economic Empowerment, Sexual Rights and Health, Care Economy and Unpaid Work, Marginalized Identities and Development, Data Feminism |
+| **Governance & Society** | Indian Constitution and Development, Post-Truth Politics, Decolonizing Development, Community-Led Development, Environmental Justice |
+| **Health & Wellbeing** | Public Health 101, Climate Essentials, Social Emotional Learning, Decent Work for All, Livelihoods Fundamentals |
+| **Communication & Data** | English for Development, Visual Ethnography, Data Literacy for Development, BCC and Communications, Advocacy Fundamentals, Digital Development Ethics, Education and Pedagogy |
+
+### Interactive Labs (10)
+
+- **MEL Design Lab** — Theory of change and evaluation framework builder
+- **MEL Plan Lab** — Operational planning tool for monitoring systems
+- **Qual Insights Lab** — Thematic analysis workbench for interview/FGD data
+- **Risk Mitigation Lab** — Scenario planning and risk identification
+- **Policy Advocacy Lab** — Strategic planning for advocacy campaigns
+- **Resource Sustainability Lab** — Resource flow analysis and sustainability modeling
+- **Impact Partnerships Lab** — Partnership mapping and collaboration design
+- **Design Thinking Lab** — Structured facilitation for problem-solving
+- **Storytelling Lab** — Crafting evidence-based impact narratives
+- **Community Engagement Lab** — Participatory engagement strategy design
+
+### Learning Games (12)
+
+Economics simulations and behavioral experiments:
+
+- **Public Good Game** — Free-rider problems and collective action
+- **Prisoners' Dilemma** — Strategic interdependence and rationality
+- **Opportunity Cost Game** — Resource scarcity and trade-off decisions
+- **Network Effects Game** — Value creation and network scale
+- **Cooperation Paradox** — Self-interest vs. cooperation tensions
+- **Risk and Reward** — Risk assessment and portfolio management
+- **Bidding Wars** — Auction simulation and winner's curse
+- **Information Asymmetry** — Adverse selection and moral hazard
+- **Economics Concepts** — Supply-demand, elasticity puzzles
+- **Externality Game** — Positive and negative externalities
+- **Commons Crisis** — Tragedy of the commons and governance
+- **Real Middle India** — India's middle-class socioeconomic data explorer
+
+### Other Resources
+
+- **ImpactLex** — 500+ development terms with contextual definitions (PWA)
+- **Dev Case Studies Library** — 200 evidence-based case studies from 117 countries
+- **DevDiscourses** — 500+ curated open-access research papers, books, and grey literature
+- **400+ Handouts** — Downloadable HTML resources across 6 learning tracks
+- **Learning Loops Blog** — Articles, tutorials, case studies, platform updates
+- **Between the Logframes Podcast** — Development conversations on MEAL, ToC, and impact work
+
+### Multilingual Support
+
+Content available in 6 languages: English, Hindi, Tamil, Bengali, Telugu, Marathi
+
+---
+
+## User Features
+
+- **Bookmarks** — Save courses and content for later
+- **Personal Notes** — Take notes while learning with streak tracking
+- **Progress Tracking** — Monitor your learning journey
+- **Reading Lists** — Curated resource collections
+- **Course Comparison** — Compare courses side-by-side
+- **Certificate Generation** — Practitioner tier and above
 
 ### Account System
-- 🔐 **Secure Authentication** — Powered by Supabase
-- 👤 **User Profiles** — Track progress and preferences
-- ⭐ **Tiered Access** — Explorer (free), Practitioner, Professional, Organization tiers
-- 🌐 **Community Access** — WhatsApp PLC, Discord, and Telegram
 
-### Technical
-- 📱 **Mobile-Optimized** — Dedicated mobile experience
-- 🌍 **Multilingual** — Content in English, Hindi, Tamil, Bengali, Telugu, Marathi
-- ⚡ **Fast & Lightweight** — Static site with no heavy dependencies
-- 🔗 **Clean URLs** — SEO-friendly routing (`/courses`, `/labs`, `/about`)
-- ♿ **Accessible** — Built with accessibility standards (UserWay integration)
+- **Secure Authentication** — Powered by Supabase (Email, Google OAuth, Magic Links)
+- **User Profiles** — Track progress and preferences
+- **Tiered Access** — Explorer (free), Practitioner, Professional, Organization
+- **Community Access** — WhatsApp PLC, Discord, Telegram
+
+---
+
+## Tech Stack
+
+| Technology | Purpose |
+|------------|---------|
+| **HTML/CSS/JS** | Core frontend (no frameworks) |
+| **Supabase** | Authentication, database, Edge Functions |
+| **Netlify** | Hosting, deployment, Edge Functions (auth-gate) |
+| **Google Analytics** | Usage analytics |
+| **Formspree** | Contact form handling |
+| **UserWay** | Accessibility widget |
+| **Google Fonts** | Inter & Poppins typography |
+
+### Architecture
+
+```
+Main site (impactmojo.in)
+├── Supabase Auth ──► Login / Signup / Profiles
+├── Premium flow ──► Supabase Edge Fn (mint JWT) ──► Netlify resource sites
+│                     └── auth-gate.ts verifies JWT, sets session cookie
+├── Static content ──► Courses, Labs, Games, ImpactLex
+└── Community ──► WhatsApp PLC, Discord, Telegram
+```
+
+Premium tools are hosted as separate Netlify sites, each protected by a JWT auth-gate edge function. The main site mints a short-lived token via Supabase, which the resource site verifies and exchanges for a 24-hour session cookie.
 
 ---
 
@@ -77,7 +239,7 @@ We provide accessible, high-quality educational materials grounded in South Asia
    ```bash
    # Using Python 3
    python -m http.server 8000
-   
+
    # Using Node.js
    npx http-server
    ```
@@ -96,25 +258,44 @@ We provide accessible, high-quality educational materials grounded in South Asia
 ```
 ImpactMojo/
 ├── index.html              # Main site (desktop)
-├── mobile.html             # Mobile-optimized version
+├── mobile-index.html       # Mobile-optimized version
 ├── _redirects              # Netlify clean URL routing
 ├── manifest.json           # PWA manifest
 │
 ├── js/
 │   ├── auth.js             # Supabase authentication
-│   └── router.js           # Clean URL section router
+│   ├── router.js           # Clean URL section router
+│   ├── resource-launch.js  # JWT-based premium resource launcher
+│   ├── token-gate.js       # Client-side token verification
+│   └── premium.js          # Premium tier UI logic
 │
 ├── login.html              # User login
 ├── signup.html             # User registration
 ├── account.html            # User dashboard
-├── forgot-password.html    # Password recovery
 ├── premium.html            # Premium features & registration
 │
+├── workshops.html          # Workshop booking & info
+├── coaching.html           # 1-on-1 coaching services
+├── dojos.html              # Practice-based skill sessions
+├── catalog.html            # Complete learning catalog
 ├── blog.html               # Learning Loops blog
+├── podcast.html            # Between the Logframes podcast
+├── handouts.html           # 400+ downloadable resources
+├── testimonials.html       # Wall of Love
+│
 ├── community/
 │   └── index.html          # Community landing page
 ├── impactlex/
 │   └── index.html          # ImpactLex dictionary (PWA)
+│
+├── supabase/
+│   └── functions/
+│       └── mint-resource-token/  # JWT minting Edge Function
+│
+├── netlify-resource-template/    # Auth-gate template for resource sites
+│   ├── netlify.toml
+│   └── netlify/edge-functions/
+│       └── auth-gate.ts
 │
 ├── assets/
 │   ├── images/             # Logos, icons, illustrations
@@ -129,20 +310,6 @@ ImpactMojo/
 
 ---
 
-## Tech Stack
-
-| Technology | Purpose |
-|------------|---------|
-| **HTML/CSS/JS** | Core frontend (no frameworks) |
-| **Supabase** | Authentication & database |
-| **Netlify** | Hosting & deployment |
-| **Google Analytics** | Usage analytics |
-| **Formspree** | Contact form handling |
-| **UserWay** | Accessibility widget |
-| **Google Fonts** | Inter & Poppins typography |
-
----
-
 ## Deployment
 
 ### Automatic Deployment (Netlify)
@@ -153,6 +320,21 @@ This project deploys automatically via Netlify. Any push to `main` triggers a ne
 - Build command: None (static site)
 - Publish directory: `.` (root)
 - `_redirects` file handles clean URL routing
+
+### Premium Resource Sites
+
+Each premium tool is a separate Netlify site with a JWT auth-gate edge function:
+
+| Resource | Netlify Site | RESOURCE_ID |
+|----------|-------------|-------------|
+| RQ Builder Pro | researchquestions.netlify.app | `rq-builder` |
+| Code Convert Pro | stats-assist.netlify.app | `code-convert-pro` |
+| Qual Insights Lab | qual-lab.netlify.app | `qual-insights` |
+| VaniScribe AI | vaniscribe.netlify.app | `vaniscribe` |
+
+Each site requires two environment variables:
+- `RESOURCE_TOKEN_SECRET` — shared HMAC signing key
+- `RESOURCE_ID` — unique resource slug
 
 ### Deploy Your Own Fork
 
@@ -197,107 +379,18 @@ The authentication system requires a Supabase project with:
      updated_at timestamp with time zone default now()
    );
    ```
+3. **Edge Function** (`mint-resource-token`) deployed with:
+   - `RESOURCE_TOKEN_SECRET` — HMAC signing key
 
 ### Clean URL Routing
 
 The `_redirects` file enables clean URLs:
 - `/courses` → Opens Courses modal
-- `/labs` → Opens Labs modal  
+- `/labs` → Opens Labs modal
 - `/about` → Scrolls to About section
 - `/testimonials` → Scrolls to Wall of Love
 
 The `router.js` script handles client-side navigation after Netlify serves `index.html`.
-
----
-
-## Content & Courses
-
-### Flagship Courses (9)
-
-Deep, comprehensive learning tracks — free for all users:
-
-| Course | Description |
-|--------|-------------|
-| **MEL for Development** | Monitoring, Evaluation & Learning — frameworks, indicators, data use |
-| **Seeing Data: Visualization for Impact** | Data storytelling, chart design, accessibility |
-| **AI for Impact: Data Monitoring & Evaluation** | AI/ML applications in development M&E |
-| **Understanding Development: An Economics Perspective** | Growth, inequality, institutions, trade |
-| **Gandhi's Political Thought: Philosophy for Praxis** | Swaraj, satyagraha, applied Gandhian thought |
-| **Politics of Aspiration** | Rights, insurance, social mobility, and aspirational politics |
-| **Media for Development** | Communication, power, narrative, and practice |
-| **Social-Emotional Learning for Development** | SEL frameworks for development contexts |
-| **Constitution & Law** | Constitutional governance and development law |
-
-### Foundational Courses (39)
-
-Shorter introductory courses covering the breadth of development practice:
-
-| Track | Courses |
-|-------|---------|
-| **MEL & Research** | MEL Fundamentals, Qualitative Research Methods, Research Ethics, Observation to Insight, EDA for Humanitarian/Health/Social Data, Bivariate Analysis, Multivariate Analysis, Item Response Theory, Cost Effectiveness 101 |
-| **Economics & Policy** | Economics 101, Development Economics, Political Economy, Econometrics 101, Poverty and Inequality, Global Development Architecture, Fundraising Fundamentals |
-| **Gender & Equity** | Gender Studies 101, Women's Economic Empowerment, Sexual Rights and Health, Care Economy and Unpaid Work, Marginalized Identities and Development, Data Feminism |
-| **Governance & Society** | Indian Constitution and Development, Post-Truth Politics, Decolonizing Development, Community-Led Development, Environmental Justice |
-| **Health & Wellbeing** | Public Health 101, Climate Essentials, Social Emotional Learning, Decent Work for All, Livelihoods Fundamentals |
-| **Communication & Data** | English for Development, Visual Ethnography, Data Literacy for Development, BCC and Communications, Advocacy Fundamentals, Digital Development Ethics, Education and Pedagogy |
-
-### Interactive Labs (10)
-
-Hands-on workbenches for practical application:
-
-- **MEL Design Lab** — Theory of change and evaluation framework builder
-- **MEL Plan Lab** — Operational planning tool for monitoring systems
-- **Qual Insights Lab** — Thematic analysis workbench for interview/FGD data
-- **Risk Mitigation Lab** — Scenario planning and risk identification
-- **Policy Advocacy Lab** — Strategic planning for advocacy campaigns
-- **Resource Sustainability Lab** — Resource flow analysis and sustainability modeling
-- **Impact Partnerships Lab** — Partnership mapping and collaboration design
-- **Design Thinking Lab** — Structured facilitation for problem-solving
-- **Storytelling Lab** — Crafting evidence-based impact narratives
-- **Community Engagement Lab** — Participatory engagement strategy design
-
-### Learning Games (12)
-
-Economics simulations and behavioral experiments:
-
-- **Public Good Game** — Free-rider problems and collective action
-- **Prisoners' Dilemma** — Strategic interdependence and rationality
-- **Opportunity Cost Game** — Resource scarcity and trade-off decisions
-- **Network Effects Game** — Value creation and network scale
-- **Cooperation Paradox** — Self-interest vs. cooperation tensions
-- **Risk and Reward** — Risk assessment and portfolio management
-- **Bidding Wars** — Auction simulation and winner's curse
-- **Information Asymmetry** — Adverse selection and moral hazard
-- **Economics Concepts** — Supply-demand, elasticity puzzles
-- **Externality Game** — Positive and negative externalities
-- **Commons Crisis** — Tragedy of the commons and governance
-- **Real Middle India** — India's middle-class socioeconomic data explorer
-
-### Premium Tools
-
-Available to Practitioner and Professional tier subscribers:
-
-| Tool | Tier | Description |
-|------|------|-------------|
-| **Field Notes from a Dev Economist** | Free | Behind-the-scenes analysis of real development programs |
-| **RQ Builder Pro** | Practitioner | Guided research question formulation (PICO/SPIDER) |
-| **TOC Workbench Pro** | Practitioner | Publication-ready theories of change with export |
-| **Code Convert Pro** | Professional | Translate scripts between Stata, R, Python, SPSS |
-| **Qual Insights Lab Pro** | Professional | AI-assisted qualitative analysis for transcripts |
-| **VaniScribe AI** | Professional | Transcription in 10+ South Asian languages |
-| **DevData Practice** | Professional | 36 dataset generators, 840K+ rows modeled on DHS/NFHS/ASER |
-| **Visualization Cookbook** | Professional | 14 chart types with question-driven recipes |
-| **DevEconomics Toolkit** | Professional | 11 interactive Shiny apps for development econometrics |
-
-### Other Resources
-
-- **ImpactLex** — 500+ development terms with contextual definitions (PWA)
-- **Dev Case Studies Library** — 200 evidence-based case studies from 117 countries
-- **DevDiscourses** — 500+ curated open-access research papers, books, and grey literature
-
-### Multilingual Support
-
-Content available in 6 languages: English, Hindi, Tamil, Bengali, Telugu, Marathi
 
 ---
 
@@ -313,24 +406,29 @@ We welcome contributions! Whether improving content, fixing bugs, enhancing acce
 
 | Browser | Support |
 |---------|---------|
-| Chrome/Chromium | ✅ Latest |
-| Firefox | ✅ Latest |
-| Safari | ✅ Latest |
-| Edge | ✅ Latest |
-| Mobile Safari (iOS) | ✅ Latest |
-| Chrome Mobile | ✅ Latest |
+| Chrome/Chromium | Latest |
+| Firefox | Latest |
+| Safari | Latest |
+| Edge | Latest |
+| Mobile Safari (iOS) | Latest |
+| Chrome Mobile | Latest |
 
 ---
 
 ## Support & Contact
 
-- 🐛 **Report bugs:** [GitHub Issues](https://github.com/Varnasr/ImpactMojo/issues)
-- 💡 **Feature requests:** [GitHub Issues](https://github.com/Varnasr/ImpactMojo/issues)
-- 📧 **General inquiries:** hello@impactmojo.in
-- 📧 **Registration:** register@impactmojo.in
-- 💬 **WhatsApp PLC:** [Professional Learning Community](https://chat.whatsapp.com/EsBjbKaQfupG1HbtajTjHM) — Peer discussions & fieldwork support
-- 💬 **Discord:** [Join Server](https://discord.gg/M3ZCmUe7ab) — Tech tinkering, data tools, MPC servers & code
-- 💬 **Telegram:** [Follow Channel](https://t.me/impactmojo) — Free toolkits, datasets, templates & reading lists
+| Channel | Details |
+|---------|---------|
+| **Bug Reports** | [GitHub Issues](https://github.com/Varnasr/ImpactMojo/issues) |
+| **Feature Requests** | [GitHub Issues](https://github.com/Varnasr/ImpactMojo/issues) |
+| **Documentation** | [GitHub Wiki](https://github.com/Varnasr/ImpactMojo/wiki) |
+| **General Inquiries** | hello@impactmojo.in |
+| **Workshops & Coaching** | coaching@impactmojo.in |
+| **Registration** | register@impactmojo.in |
+| **Newsletter** | [Varna's Substack](https://varna.substack.com) |
+| **WhatsApp PLC** | [Professional Learning Community](https://chat.whatsapp.com/EsBjbKaQfupG1HbtajTjHM) |
+| **Discord** | [Tech tinkering & data tools](https://discord.gg/M3ZCmUe7ab) |
+| **Telegram** | [Free toolkits & resources](https://t.me/impactmojo) |
 
 ### Support the Platform
 
@@ -353,7 +451,7 @@ Educational content is available for educational and non-commercial use. Educato
 If you use ImpactMojo materials in research, teaching, or practice:
 
 ```
-Raman, V. S. (2025). ImpactMojo: Free Development Education for Social Impact. 
+Raman, V. S. (2025). ImpactMojo: Free Development Education for Social Impact.
 Retrieved from https://www.impactmojo.in
 ```
 
@@ -363,17 +461,19 @@ Retrieved from https://www.impactmojo.in
 
 **Founded by Dr. Varna Sri Raman**, a development economist with two decades of experience in development practice, research, and education across South Asia.
 
+**Co-Founded by Vandana Soni**, who leads partnerships, programmes, and social media.
+
 **Sponsored by** PinPoint Ventures
 
 **Key Contributors:**
-- Vandana Soni — Social Media & Marketing
+- Vandana Soni — Social Media, Marketing & Partnerships
 - Vignesh — Technical Support
 
 The platform is shaped by contributions from educators, practitioners, designers, and the broader development community.
 
 ---
 
-**Version:** 8.0.0
+**Version:** 9.0.0
 **Last Updated:** March 2026
-**License:** CC-BY-4.0  
+**License:** CC-BY-4.0
 **Hosting:** Netlify


### PR DESCRIPTION
## Summary
- Fix broken Netlify deploy status badge (was using wrong site ID format)
- Add Workshops, Coaching, Dojos, Premium tiers as business models
- Add podcast, blog, handouts to content inventory
- Document JWT auth-gate architecture for premium resource sites
- Add GitHub Wiki and Issues badges
- Update version to 9.0.0

https://claude.ai/code/session_012rh4tKihyPf7XjuwP14dz3