### PR TITLE
Fix Google OAuth login loop caused by redirect race condition

### DIFF
--- a/account.html
+++ b/account.html
@@ -2756,10 +2756,13 @@ async function signOut() {
     }
 }
 
-// Auth State Listener
+// Auth State Listener - only act on auth changes AFTER initial auth is ready
 window.addEventListener('authStateChanged', (e) => {
+    // Ignore early events before auth is fully ready (prevents OAuth redirect race)
+    if (!ImpactMojoAuth.isAuthReady) return;
+
     const loadingOverlay = document.getElementById('loadingOverlay');
-    
+
     if (e.detail.isLoggedIn) {
         loadingOverlay.style.display = 'none';
         updatePageData();
@@ -2770,25 +2773,38 @@ window.addEventListener('authStateChanged', (e) => {
 });
 
 // Initialization
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
     initTheme();
     updateSavedItemsDisplay();
-    
-    // Auth is initialized via auth.js automatically
-    // The authStateChanged event will trigger updatePageData when ready
-    // Show loading state until auth is confirmed
+
     const loadingOverlay = document.getElementById('loadingOverlay');
-    
-    // Set a timeout to hide loading if auth takes too long
+
+    // Wait for auth to fully initialize (handles OAuth callback tokens in URL)
+    try {
+        await ImpactMojoAuth.waitForAuthReady();
+    } catch (e) {
+        console.error('Auth ready wait failed:', e);
+    }
+
+    // Now we know the true auth state
+    if (ImpactMojoAuth.isLoggedIn()) {
+        loadingOverlay.style.display = 'none';
+        updatePageData();
+        updateSavedItemsDisplay();
+    } else {
+        // Only redirect to login if auth is ready and user is truly not logged in
+        window.location.href = 'login.html';
+    }
+
+    // Safety timeout in case auth never resolves
     setTimeout(function() {
         if (loadingOverlay.style.display !== 'none') {
             loadingOverlay.style.display = 'none';
-            // Check if user is logged in after timeout
             if (!ImpactMojoAuth.isLoggedIn()) {
                 window.location.href = 'login.html';
             }
         }
-    }, 5000);
+    }, 10000);
 });
 
 // Close dropdowns when clicking outside

--- a/js/auth.js
+++ b/js/auth.js
@@ -49,51 +49,74 @@ const ImpactMojoAuth = {
     user: null,
     profile: null,
     isInitialized: false,
+    isAuthReady: false,
+    _authReadyPromise: null,
+    _authReadyResolve: null,
     isSyncing: false,
 
     // Initialize auth and check session
     async init() {
         if (this.isInitialized) return;
-        
+
+        // Create a promise that resolves when auth state is fully determined
+        // This is critical for OAuth redirects where tokens are in the URL hash
+        this._authReadyPromise = new Promise(resolve => {
+            this._authReadyResolve = resolve;
+        });
+
         try {
-            // Get current session
-            const { data: { session }, error } = await supabaseClient.auth.getSession();
-            
-            if (error) {
-                console.error('Auth init error:', error);
-                return;
-            }
-
-            if (session?.user) {
-                this.user = session.user;
-                await this.fetchProfile();
-                // Auto-sync on init if logged in
-                await this.syncFromCloud();
-            }
-
-            // Listen for auth changes
+            // Listen for auth changes FIRST - this is what processes OAuth callbacks
+            // Supabase fires INITIAL_SESSION first, then SIGNED_IN if OAuth tokens are in URL
             supabaseClient.auth.onAuthStateChange(async (event, session) => {
                 console.log('Auth state changed:', event);
-                
-                if (event === 'SIGNED_IN' && session?.user) {
+
+                if (event === 'INITIAL_SESSION') {
+                    // Initial session check complete - set user if session exists
+                    if (session?.user) {
+                        this.user = session.user;
+                        await this.fetchProfile();
+                        await this.syncFromCloud();
+                    }
+                    // Mark auth as ready - we now know the true auth state
+                    this.isAuthReady = true;
+                    if (this._authReadyResolve) this._authReadyResolve();
+                    this.updateUI();
+                } else if (event === 'SIGNED_IN' && session?.user) {
                     this.user = session.user;
                     await this.fetchProfile();
                     // Sync data when user signs in
                     await this.syncAll();
+                    // If auth wasn't ready yet (OAuth callback), mark it ready now
+                    if (!this.isAuthReady) {
+                        this.isAuthReady = true;
+                        if (this._authReadyResolve) this._authReadyResolve();
+                    }
                     this.updateUI();
                 } else if (event === 'SIGNED_OUT') {
                     this.user = null;
                     this.profile = null;
+                    if (!this.isAuthReady) {
+                        this.isAuthReady = true;
+                        if (this._authReadyResolve) this._authReadyResolve();
+                    }
                     this.updateUI();
                 }
             });
 
             this.isInitialized = true;
-            this.updateUI();
-            
+
         } catch (err) {
             console.error('Auth initialization failed:', err);
+            // Ensure auth ready resolves even on error
+            this.isAuthReady = true;
+            if (this._authReadyResolve) this._authReadyResolve();
         }
+    },
+
+    // Wait for auth to be fully ready (use this before redirecting based on auth state)
+    waitForAuthReady() {
+        if (this.isAuthReady) return Promise.resolve();
+        return this._authReadyPromise || Promise.resolve();
     },
 
     // Fetch user profile from database

--- a/login.html
+++ b/login.html
@@ -674,9 +674,9 @@
             }
         });
 
-        // Check if already logged in
+        // Check if already logged in (wait for auth to be fully ready first)
         window.addEventListener('authStateChanged', (e) => {
-            if (e.detail.isLoggedIn) {
+            if (ImpactMojoAuth.isAuthReady && e.detail.isLoggedIn) {
                 ImpactMojoAuth.redirectAfterLogin();
             }
         });


### PR DESCRIPTION
The login loop occurred because account.html redirected to login.html before Supabase could process the OAuth callback tokens in the URL hash. Added isAuthReady flag and waitForAuthReady() promise to auth.js so pages wait for the INITIAL_SESSION event before making redirect decisions.

https://claude.ai/code/session_012rh4tKihyPf7XjuwP14dz3

## What does this PR do?

Brief description of the change.

## Type of change

- [ ] Bug fix (broken link, layout, JS error)
- [ ] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

- [ ] Tested on desktop browser
- [ ] Tested on mobile browser
- [ ] No console errors
- [ ] Links are working
