### PR TITLE
Add BCT Repository card to homepage Free Resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -8707,6 +8707,20 @@ body:has(.imx-tour-overlay.active) .dropdown-menu li {
         <span class="imx-resource-cta">Explore PolicyDhara <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><use href="#si_Arrow_right"/></svg></span>
     </a>
 
+    <a href="/bct-repository" class="imx-resource-card" id="bct-repository">
+        <div class="imx-resource-icon" style="background: rgba(236, 72, 153, 0.1); color: #EC4899;">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Fact_check"/></svg>
+        </div>
+        <h3 class="imx-resource-title">BCT Repository</h3>
+        <p class="imx-resource-desc">Searchable catalog of 203 behavior change techniques from the BCT Taxonomy v1. Definitions, examples, and evidence ratings for intervention design.</p>
+        <div class="imx-resource-stats">
+            <span><strong>203</strong> Techniques</span>
+            <span><strong>16</strong> Categories</span>
+            <span><strong>Evidence</strong> Rated</span>
+        </div>
+        <span class="imx-resource-cta">Explore BCT Repository <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><use href="#si_Arrow_right"/></svg></span>
+    </a>
+
 </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Adds BCT Repository card to the Free Resources grid on the homepage
- Links to `/bct-repository` with pink accent, showing 203 techniques across 16 categories

https://claude.ai/code/session_01KKoDc93MeAeaXKFKDSM9ek