### PR TITLE
Fix tour welcome popup dropdown menu bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -7617,47 +7617,26 @@ body.dark-mode .v3-dot {
     pointer-events: auto;
 }
 
-/* Keep dropdown menus FULLY visible during tour - highest priority */
+/* HIDE all dropdown menus during tour to prevent random menu popups */
 body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown .dropdown-menu,
 body:has(.imx-tour-overlay.active) .dropdown-menu,
 .imx-tour-overlay.active ~ * .dropdown-menu {
-    opacity: 1 !important;
-    visibility: visible !important;
-    max-height: none !important;
-    pointer-events: auto !important;
-    z-index: 10005 !important;
-    background: var(--card-bg, #fff) !important;
-    box-shadow: 0 10px 40px rgba(0,0,0,0.3) !important;
+    display: none !important;
+    opacity: 0 !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
 }
 
+/* Suppress hover-triggered dropdowns during tour */
+body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown:hover .dropdown-menu {
+    display: none !important;
+    opacity: 0 !important;
+    visibility: hidden !important;
+}
+
+/* Suppress open class dropdowns during tour */
 body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-menu {
-    display: block !important;
-}
-
-/* Ensure entire navigation and dropdowns stay above overlay during tour */
-body:has(.imx-tour-overlay.active) header,
-body:has(.imx-tour-overlay.active) nav,
-body:has(.imx-tour-overlay.active) .nav-links,
-body:has(.imx-tour-overlay.active) .nav-links > li,
-body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown,
-body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown > a {
-    position: relative;
-    z-index: 10004 !important;
-}
-
-/* Make dropdown content fully visible and readable */
-body:has(.imx-tour-overlay.active) .dropdown-menu {
-    z-index: 10006 !important;
-    position: absolute !important;
-    background: var(--card-bg, #ffffff) !important;
-    border: 1px solid var(--border-color, #e5e7eb) !important;
-    box-shadow: 0 15px 50px rgba(0,0,0,0.25) !important;
-}
-
-body:has(.imx-tour-overlay.active) .dropdown-menu a,
-body:has(.imx-tour-overlay.active) .dropdown-menu li {
-    background: var(--card-bg, #ffffff) !important;
-    color: var(--text-color, #1f2937) !important;
+    display: none !important;
 }
 
 .imx-tour-spotlight {

--- a/js/bookmarks-compare.js
+++ b/js/bookmarks-compare.js
@@ -1835,30 +1835,57 @@ IMX.Tour = {
     },
     
     showWelcome: function() {
+        var self = this;
+
+        // Close any open dropdown menus immediately
+        document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(item) {
+            item.classList.remove('open');
+        });
+
         // Create overlay
         this.overlay = document.createElement('div');
         this.overlay.className = 'imx-tour-overlay active';
-        
+
+        // Clicking overlay background dismisses the welcome
+        this.overlay.addEventListener('click', function(e) {
+            if (e.target === self.overlay) {
+                self.skip();
+            }
+        });
+
         // Create welcome modal
         var welcome = document.createElement('div');
         welcome.className = 'imx-tour-welcome';
-        welcome.innerHTML = 
+        welcome.innerHTML =
             '<div class="imx-tour-welcome-icon">' + this.icons.welcome + '</div>' +
             '<h2>Welcome to ImpactMojo</h2>' +
             '<p>Your free platform for development education. Take a quick tour to discover powerful features that enhance your learning experience.</p>' +
             '<div class="imx-tour-welcome-buttons">' +
-                '<button class="imx-tour-btn-secondary" type="button" onclick="IMX.Tour.skip()">Skip Tour</button>' +
-                '<button class="imx-tour-btn-primary" type="button" onclick="IMX.Tour.start()">Start Tour <svg viewBox="0 0 24 24" width="16" height="16"><polyline points="9 18 15 12 9 6" fill="none" stroke="currentColor" stroke-width="2"></polyline></svg></button>' +
+                '<button class="imx-tour-btn-secondary" type="button" onclick="IMX.Tour.skip()">No Thanks</button>' +
+                '<button class="imx-tour-btn-primary" type="button" onclick="IMX.Tour.start()">Take the Tour <svg viewBox="0 0 24 24" width="16" height="16"><polyline points="9 18 15 12 9 6" fill="none" stroke="currentColor" stroke-width="2"></polyline></svg></button>' +
             '</div>';
-        
+
         this.overlay.appendChild(welcome);
         document.body.appendChild(this.overlay);
+
+        // Escape key dismisses welcome
+        this._escHandler = function(e) {
+            if (e.key === 'Escape') {
+                self.skip();
+            }
+        };
+        document.addEventListener('keydown', this._escHandler);
     },
     
     start: function() {
         this.isActive = true;
         this.currentStep = 0;
-        
+
+        // Close any open dropdowns before starting
+        document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(item) {
+            item.classList.remove('open');
+        });
+
         // Clear welcome content
         this.overlay.innerHTML = '';
         
@@ -2060,11 +2087,17 @@ IMX.Tour = {
     skip: function() {
         this.end();
     },
-    
+
     end: function() {
         this.isActive = false;
         localStorage.setItem(this.STORAGE_KEY, 'true');
-        
+
+        // Remove escape key handler
+        if (this._escHandler) {
+            document.removeEventListener('keydown', this._escHandler);
+            this._escHandler = null;
+        }
+
         // Close any open dropdowns
         document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(item) {
             item.classList.remove('open');


### PR DESCRIPTION
## Summary
- **Fixed**: Tour overlay CSS was forcing ALL dropdown menus visible when active, causing menus to randomly drop down with half-loaded icons on first visit
- **Changed**: Dropdown menus are now hidden/suppressed during tour instead of forced visible
- **Improved**: Welcome popup is quietly dismissable — click outside or press Escape to dismiss. Clearer button labels ("No Thanks" / "Take the Tour")

## Test plan
- [ ] Hard refresh as new user (clear impactmojo_tour_completed from localStorage)
- [ ] Verify welcome popup appears without dropdown menus opening
- [ ] Verify clicking outside, pressing Escape, or clicking No Thanks dismisses it
- [ ] Verify Take the Tour starts guided tour without dropdown interference

https://claude.ai/code/session_01KKoDc93MeAeaXKFKDSM9ek