### PR TITLE
Add Dataverse to index.html navigation and resource cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -8701,6 +8701,20 @@ body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-m
         <span class="imx-resource-cta">Explore BCT Repository <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><use href="#si_Arrow_right"/></svg></span>
     </a>
 
+    <a href="dataverse.html" class="imx-resource-card" id="dataverse">
+        <div class="imx-resource-icon" style="background: rgba(99, 102, 241, 0.1); color: #6366F1;">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Database"/></svg>
+        </div>
+        <h3 class="imx-resource-title">Dataverse</h3>
+        <p class="imx-resource-desc">Curated catalog of 215 tools, datasets, APIs, and platforms for social impact, development economics, and policy research.</p>
+        <div class="imx-resource-stats">
+            <span><strong>215</strong> Resources</span>
+            <span><strong>Tools</strong> & APIs</span>
+            <span><strong>Open</strong> Access</span>
+        </div>
+        <span class="imx-resource-cta">Explore Dataverse <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><use href="#si_Arrow_right"/></svg></span>
+    </a>
+
 </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Adds Dataverse link to the Learn dropdown navigation menu with a NEW badge
- Adds Dataverse card to the Free Resources grid alongside ImpactLex, FieldCases, DevDiscourses, PolicyDhara, and BCT Repository
- Card highlights 215 curated resources (tools, datasets, APIs) for social impact research

## Test plan
- [ ] Verify Dataverse appears in the Learn dropdown nav menu
- [ ] Verify Dataverse card renders correctly in the Free Resources grid
- [ ] Verify card link navigates to dataverse.html
- [ ] Check responsive layout with 6 cards in the grid

https://claude.ai/code/session_01KKoDc93MeAeaXKFKDSM9ek