### PR TITLE
Update Dojos to canonical 56-session, 6-series structure

### DIFF
--- a/dojos.html
+++ b/dojos.html
@@ -556,10 +556,13 @@
             height: 18px;
         }
 
-        .skill-icon.thinking { background: var(--indigo-light); }
-        .skill-icon.evidence { background: var(--teal-light); }
-        .skill-icon.action { background: var(--green-light); }
-        .skill-icon.communication { background: var(--orange-light); }
+        .skill-icon.pre { background: #F1F5F9; }
+        .skill-icon.s01 { background: var(--indigo-light); }
+        .skill-icon.s02 { background: var(--teal-light); }
+        .skill-icon.s03 { background: var(--green-light); }
+        .skill-icon.s04 { background: var(--orange-light); }
+        .skill-icon.s05 { background: #FEF3C7; }
+        .skill-icon.s06 { background: #FCE7F3; }
 
         body.dark-mode .skill-icon img {
             filter: invert(1);
@@ -1197,13 +1200,17 @@
         </a>
 
         <h1>Dojos</h1>
-        <p class="intro">Practice-based skill sessions for development practitioners. Not lectures—90-minute cohort workshops where you actually use the techniques. Pre-mortems, stakeholder mapping, cost-effectiveness analysis, and 32 more skills.</p>
+        <p class="intro">Practice-based skill sessions for development practitioners. Not lectures—90-minute cohort workshops where you actually use the techniques. 56 sessions across 6 structured series covering thinking, evidence, methods, implementation, epistemic hygiene, and gender & power.</p>
 
         <!-- Stats -->
         <div class="stats-bar">
             <div class="stat">
-                <div class="stat-value">35+</div>
-                <div class="stat-label">Skills</div>
+                <div class="stat-value">56</div>
+                <div class="stat-label">Sessions</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value">6</div>
+                <div class="stat-label">Series</div>
             </div>
             <div class="stat">
                 <div class="stat-value">90</div>
@@ -1245,21 +1252,33 @@
                     <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Grid.svg" alt="">
                     All
                 </button>
-                <button class="filter-btn" data-category="thinking">
+                <button class="filter-btn" data-category="pre">
+                    <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Book.svg" alt="">
+                    PRE
+                </button>
+                <button class="filter-btn" data-category="s01">
                     <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="">
-                    Thinking
+                    S01 Thinking
                 </button>
-                <button class="filter-btn" data-category="evidence">
+                <button class="filter-btn" data-category="s02">
                     <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="">
-                    Evidence
+                    S02 Evidence
                 </button>
-                <button class="filter-btn" data-category="action">
+                <button class="filter-btn" data-category="s03">
                     <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Activity.svg" alt="">
-                    Action
+                    S03 Implementation
                 </button>
-                <button class="filter-btn" data-category="communication">
-                    <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Chat.svg" alt="">
-                    Communication
+                <button class="filter-btn" data-category="s04">
+                    <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Tool.svg" alt="">
+                    S04 Methods
+                </button>
+                <button class="filter-btn" data-category="s05">
+                    <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Alert_triangle.svg" alt="">
+                    S05 Epistemic
+                </button>
+                <button class="filter-btn" data-category="s06">
+                    <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Users.svg" alt="">
+                    S06 Gender
                 </button>
             </div>
 
@@ -1288,44 +1307,112 @@
 
         <!-- Series -->
         <h2>Dojo Series</h2>
-        <p>Structured cohorts. Join one or build your own path from individual skills.</p>
+        <p>6 structured series, 56 sessions. Join one or build your own path from individual skills.</p>
 
         <div class="series-grid">
             <div class="series-card">
+                <div class="series-badge">PRE</div>
+                <h3 class="series-title">Orientation and Starters</h3>
+                <div class="series-meta">Placed in all 6 series • Delhi • Bangalore • Online</div>
+                <p class="series-desc">Entry point for every series. Sets the ground rules, introduces the dojo format, and gets participants calibrated before diving into specific skills.</p>
+                <div class="series-tags">
+                    <span class="series-tag">Orientation</span>
+                </div>
+            </div>
+            <div class="series-card">
                 <div class="series-badge">Series 01</div>
                 <h3 class="series-title">Thinking Clearly in Development</h3>
-                <div class="series-meta">8 weeks • Delhi • Bangalore • Online</div>
-                <p class="series-desc">Foundation skills for practitioners. Notice confusion, anticipate failure, resolve disagreements productively, and debug your own avoidance patterns.</p>
+                <div class="series-meta">8 sessions • Delhi • Bangalore • Online</div>
+                <p class="series-desc">Foundation skills for practitioners. Counterfactual reasoning, cognitive bias awareness, problem framing, theory of change thinking, and calibrating your uncertainty.</p>
                 <div class="series-tags">
-                    <span class="series-tag">Pre-mortems</span>
-                    <span class="series-tag">Crux-Finding</span>
+                    <span class="series-tag">Counterfactual Thinking</span>
+                    <span class="series-tag">Cognitive Biases</span>
                     <span class="series-tag">TAPs</span>
-                    <span class="series-tag">Goal Factoring</span>
-                    <span class="series-tag">Calibrating Intuition</span>
+                    <span class="series-tag">Problem Framing</span>
+                    <span class="series-tag">Theory of Change</span>
+                    <span class="series-tag">Asking Better Questions</span>
+                    <span class="series-tag">Uncertainty</span>
+                    <span class="series-tag">Critical Thinking</span>
                 </div>
             </div>
             <div class="series-card">
                 <div class="series-badge">Series 02</div>
                 <h3 class="series-title">Evidence Reasoning</h3>
-                <div class="series-meta">6 weeks • Delhi • Bangalore • Online</div>
-                <p class="series-desc">Critical thinking for consuming research. Read RCTs without getting fooled, spot publication bias, develop cost-effectiveness intuition, and update gracefully.</p>
+                <div class="series-meta">9 sessions • Delhi • Bangalore • Online</div>
+                <p class="series-desc">Critical thinking for consuming and producing research. Design indicators, review evidence rapidly, synthesize qualitative data, tell stories with data, and build cost-effectiveness intuition.</p>
                 <div class="series-tags">
-                    <span class="series-tag">Reading RCTs</span>
-                    <span class="series-tag">Publication Bias</span>
-                    <span class="series-tag">Cost-Effectiveness</span>
+                    <span class="series-tag">Indicator Design</span>
+                    <span class="series-tag">Research Design</span>
+                    <span class="series-tag">Rapid Evidence Review</span>
+                    <span class="series-tag">Qualitative Synthesis</span>
+                    <span class="series-tag">Data Storytelling</span>
+                    <span class="series-tag">Evidence Hierarchies</span>
                     <span class="series-tag">Updating on Evidence</span>
+                    <span class="series-tag">Cost-Effectiveness</span>
                 </div>
             </div>
             <div class="series-card">
                 <div class="series-badge">Series 03</div>
                 <h3 class="series-title">Political Economy & Implementation</h3>
-                <div class="series-meta">6 weeks • Delhi • Bangalore • Online</div>
-                <p class="series-desc">The messy reality of making things work. Map stakeholder power, diagnose implementation failure, navigate funder psychology, and decide when to scale.</p>
+                <div class="series-meta">16 sessions • Delhi • Bangalore • Online</div>
+                <p class="series-desc">The messy reality of making things work. Map stakeholder power, diagnose implementation failure, navigate funder psychology, design services, plan exits, and decide when to scale.</p>
                 <div class="series-tags">
                     <span class="series-tag">Stakeholder Mapping</span>
                     <span class="series-tag">Implementation Diagnosis</span>
                     <span class="series-tag">Funder Psychology</span>
                     <span class="series-tag">Scaling Decisions</span>
+                    <span class="series-tag">Adaptive Management</span>
+                    <span class="series-tag">Risk Registers</span>
+                    <span class="series-tag">Budget Defence</span>
+                    <span class="series-tag">Service Design</span>
+                    <span class="series-tag">Exit Strategy</span>
+                    <span class="series-tag">Negotiation</span>
+                    <span class="series-tag">+6 more</span>
+                </div>
+            </div>
+            <div class="series-card">
+                <div class="series-badge">Series 04</div>
+                <h3 class="series-title">Methods That Actually Work</h3>
+                <div class="series-meta">9 sessions • Delhi • Bangalore • Online</div>
+                <p class="series-desc">Advanced evaluation methods for practitioners. Process tracing, realist evaluation, contribution analysis, mixed methods integration, and statistical reasoning for real-world programmes.</p>
+                <div class="series-tags">
+                    <span class="series-tag">Process Tracing</span>
+                    <span class="series-tag">Realist Evaluation</span>
+                    <span class="series-tag">Mixed Methods</span>
+                    <span class="series-tag">Contribution Analysis</span>
+                    <span class="series-tag">Effect Sizes & Power</span>
+                    <span class="series-tag">ITT, LATE & Compliance</span>
+                    <span class="series-tag">Qualitative Rigor</span>
+                </div>
+            </div>
+            <div class="series-card">
+                <div class="series-badge">Series 05</div>
+                <h3 class="series-title">Epistemic Hygiene</h3>
+                <div class="series-meta">8 sessions • Delhi • Bangalore • Online</div>
+                <p class="series-desc">Intellectual honesty as a practice. Catch the lies you tell yourself, calibrate magnitude, sit with discomfort, know when to trust intuition vs data, and write honestly.</p>
+                <div class="series-tags">
+                    <span class="series-tag">Common Lies</span>
+                    <span class="series-tag">Magnitude Matters</span>
+                    <span class="series-tag">Sitting with Discomfort</span>
+                    <span class="series-tag">Scope Sensitivity</span>
+                    <span class="series-tag">Intuition vs Data</span>
+                    <span class="series-tag">Writing Honestly</span>
+                    <span class="series-tag">Fermi Estimation</span>
+                    <span class="series-tag">Quoting Data</span>
+                </div>
+            </div>
+            <div class="series-card">
+                <div class="series-badge">Series 06</div>
+                <h3 class="series-title">Gender, Power & Data</h3>
+                <div class="series-meta">6 sessions • Delhi • Bangalore • Online</div>
+                <p class="series-desc">Gender as an analytical lens, not a checkbox. Data feminism, disaggregated data, third gender in South Asian fieldwork, intersectionality, feminist participatory action research, and power analysis beyond the 2x2.</p>
+                <div class="series-tags">
+                    <span class="series-tag">Data Feminism</span>
+                    <span class="series-tag">Gender-Disaggregated Data</span>
+                    <span class="series-tag">Third Gender</span>
+                    <span class="series-tag">Intersectionality</span>
+                    <span class="series-tag">Feminist PAR</span>
+                    <span class="series-tag">Power Analysis</span>
                 </div>
             </div>
         </div>
@@ -1372,7 +1459,7 @@
         <!-- CTA -->
         <div class="cta-box">
             <h2>Join a Cohort</h2>
-            <p>Next cohorts begin February 2026 in Delhi, Bangalore, and Online.</p>
+            <p>Cohorts running now in Delhi, Bangalore, and Online.</p>
             <button class="cta-btn" onclick="openModal()">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                 Register Interest
@@ -1477,43 +1564,78 @@
     </div>
 
     <script>
-        // Skills Data
+        // Skills Data — 56 sessions across 6 series + PRE
         const skills = [
-            { name: "Pre-mortems", category: "thinking", icon: "si_Crosshair_detailed" },
-            { name: "Counterfactual Thinking", category: "thinking", icon: "si_Direction_alt" },
-            { name: "Crux-Finding", category: "thinking", icon: "si_Flare" },
-            { name: "Goal Factoring", category: "thinking", icon: "si_Globe_detailed" },
-            { name: "Calibrating Intuition", category: "thinking", icon: "si_Search" },
-            { name: "Fermi Estimation", category: "thinking", icon: "si_Calculator" },
-            { name: "Systems Mapping", category: "thinking", icon: "si_Refresh_outlined" },
-            { name: "Red Teaming", category: "thinking", icon: "si_Alert_triangle" },
-            { name: "Scenario Planning", category: "thinking", icon: "si_Layers" },
-            { name: "Reading RCTs", category: "evidence", icon: "si_Bar_chart" },
-            { name: "Updating on Evidence", category: "evidence", icon: "si_Refresh_outlined" },
-            { name: "Cost-Effectiveness", category: "evidence", icon: "si_Activity" },
-            { name: "Spotting Publication Bias", category: "evidence", icon: "si_Alert_triangle" },
-            { name: "Indicator Design", category: "evidence", icon: "si_Crosshair_detailed" },
-            { name: "Rapid Evidence Review", category: "evidence", icon: "si_Search" },
-            { name: "Qualitative Synthesis", category: "evidence", icon: "si_Article" },
-            { name: "Sampling Shortcuts", category: "evidence", icon: "si_Grid" },
-            { name: "Trigger-Action Plans", category: "action", icon: "si_Flare" },
-            { name: "Implementation Diagnosis", category: "action", icon: "si_Tool" },
-            { name: "Stakeholder Mapping", category: "action", icon: "si_Users" },
-            { name: "Scaling Decisions", category: "action", icon: "si_Trending_up" },
-            { name: "Results Chain Architecture", category: "action", icon: "si_Direction_alt" },
-            { name: "Value Pricing", category: "action", icon: "si_Tag" },
-            { name: "Service Design", category: "action", icon: "si_Layout" },
-            { name: "Exit Strategy Design", category: "action", icon: "si_Log_out" },
-            { name: "Adaptive Management", category: "action", icon: "si_Refresh_outlined" },
-            { name: "Risk Registers", category: "action", icon: "si_Shield" },
-            { name: "Productive Disagreements", category: "communication", icon: "si_Chat" },
-            { name: "Communicating Failure", category: "communication", icon: "si_Article" },
-            { name: "Funder Psychology", category: "communication", icon: "si_Heart" },
-            { name: "Live Facilitation Tools", category: "communication", icon: "si_Users" },
-            { name: "Budget Defense", category: "communication", icon: "si_Shield" },
-            { name: "Data Storytelling", category: "communication", icon: "si_Bar_chart" },
-            { name: "Negotiation Tactics", category: "communication", icon: "si_Handshake" },
-            { name: "Participatory Facilitation", category: "communication", icon: "si_Users" }
+            // PRE — Orientation and Starters
+            { name: "Orientation and Starters", category: "pre", code: "PRE", icon: "si_Book" },
+
+            // S01 — Thinking Clearly in Development (8 sessions)
+            { name: "Counterfactual Thinking", category: "s01", code: "S01-01", icon: "si_Direction_alt" },
+            { name: "Cognitive Biases in Development Practice", category: "s01", code: "S01-02", icon: "si_Alert_triangle" },
+            { name: "Trigger Action Plans", category: "s01", code: "S01-03", icon: "si_Flare" },
+            { name: "Problem Framing", category: "s01", code: "S01-04", icon: "si_Crosshair_detailed" },
+            { name: "Theory of Change Thinking", category: "s01", code: "S01-05", icon: "si_Direction_alt" },
+            { name: "Asking Better Questions", category: "s01", code: "S01-06", icon: "si_Search" },
+            { name: "Uncertainty and Probabilistic Thinking", category: "s01", code: "S01-07", icon: "si_Globe_detailed" },
+            { name: "Critical Thinking", category: "s01", code: "S01-08", icon: "si_Crosshair_detailed" },
+
+            // S02 — Evidence Reasoning (9 sessions)
+            { name: "Indicator Design", category: "s02", code: "S02-01", icon: "si_Crosshair_detailed" },
+            { name: "Research Design Basics", category: "s02", code: "S02-02", icon: "si_Layout" },
+            { name: "Rapid Evidence Review", category: "s02", code: "S02-03", icon: "si_Search" },
+            { name: "Qualitative Synthesis", category: "s02", code: "S02-04", icon: "si_Article" },
+            { name: "Data Storytelling", category: "s02", code: "S02-05", icon: "si_Bar_chart" },
+            { name: "Using Evidence Well", category: "s02", code: "S02-06", icon: "si_Activity" },
+            { name: "Evidence Hierarchies and Their Limits", category: "s02", code: "S02-07", icon: "si_Layers" },
+            { name: "Updating on Evidence", category: "s02", code: "S02-08", icon: "si_Refresh_outlined" },
+            { name: "Cost-Effectiveness Analysis", category: "s02", code: "S02-09", icon: "si_Calculator" },
+
+            // S03 — Political Economy & Implementation (16 sessions)
+            { name: "Stakeholder Mapping", category: "s03", code: "S03-01", icon: "si_Users" },
+            { name: "Implementation Diagnosis", category: "s03", code: "S03-02", icon: "si_Tool" },
+            { name: "Funder Psychology", category: "s03", code: "S03-03", icon: "si_Heart" },
+            { name: "Scaling Decisions", category: "s03", code: "S03-04", icon: "si_Trending_up" },
+            { name: "Adaptive Management", category: "s03", code: "S03-05", icon: "si_Refresh_outlined" },
+            { name: "Risk Registers", category: "s03", code: "S03-06", icon: "si_Shield" },
+            { name: "Budget Defence", category: "s03", code: "S03-07", icon: "si_Shield" },
+            { name: "Communicating Failure", category: "s03", code: "S03-08", icon: "si_Article" },
+            { name: "Live Facilitation Tools", category: "s03", code: "S03-09", icon: "si_Users" },
+            { name: "Systems Mapping", category: "s03", code: "S03-10", icon: "si_Refresh_outlined" },
+            { name: "Scenario Planning", category: "s03", code: "S03-11", icon: "si_Layers" },
+            { name: "Service Design", category: "s03", code: "S03-12", icon: "si_Layout" },
+            { name: "Exit Strategy Design", category: "s03", code: "S03-13", icon: "si_Log_out" },
+            { name: "Value and Pricing", category: "s03", code: "S03-14", icon: "si_Tag" },
+            { name: "Negotiation Tactics", category: "s03", code: "S03-15", icon: "si_Handshake" },
+            { name: "Participatory Facilitation", category: "s03", code: "S03-16", icon: "si_Users" },
+
+            // S04 — Methods That Actually Work (9 sessions)
+            { name: "Process Tracing", category: "s04", code: "S04-01", icon: "si_Direction_alt" },
+            { name: "Pilots vs Testing at Scale", category: "s04", code: "S04-02", icon: "si_Trending_up" },
+            { name: "Realist Evaluation", category: "s04", code: "S04-03", icon: "si_Search" },
+            { name: "Mixed Methods Integration", category: "s04", code: "S04-04", icon: "si_Grid" },
+            { name: "Contribution Analysis", category: "s04", code: "S04-05", icon: "si_Activity" },
+            { name: "Effect Sizes, MDE and Statistical Power", category: "s04", code: "S04-06", icon: "si_Bar_chart" },
+            { name: "ITT, LATE and Compliance", category: "s04", code: "S04-07", icon: "si_Crosshair_detailed" },
+            { name: "Qualitative Rigor", category: "s04", code: "S04-08", icon: "si_Article" },
+            { name: "Performance Disaggregation", category: "s04", code: "S04-09", icon: "si_Grid" },
+
+            // S05 — Epistemic Hygiene (8 sessions)
+            { name: "Common Lies We Tell Ourselves", category: "s05", code: "S05-01", icon: "si_Alert_triangle" },
+            { name: "Magnitude Matters", category: "s05", code: "S05-02", icon: "si_Trending_up" },
+            { name: "Sitting with Discomfort", category: "s05", code: "S05-03", icon: "si_Heart" },
+            { name: "Scope Sensitivity and Scale Thinking", category: "s05", code: "S05-04", icon: "si_Globe_detailed" },
+            { name: "When to Trust Intuition vs Data", category: "s05", code: "S05-05", icon: "si_Search" },
+            { name: "Writing Honestly", category: "s05", code: "S05-06", icon: "si_Article" },
+            { name: "Fermi Estimation", category: "s05", code: "S05-07", icon: "si_Calculator" },
+            { name: "Quoting Data Honestly", category: "s05", code: "S05-08", icon: "si_Bar_chart" },
+
+            // S06 — Gender, Power & Data (6 sessions)
+            { name: "Data Feminism", category: "s06", code: "S06-01", icon: "si_Globe_detailed" },
+            { name: "Gender-Disaggregated Data", category: "s06", code: "S06-02", icon: "si_Grid" },
+            { name: "Third Gender in South Asian Fieldwork", category: "s06", code: "S06-03", icon: "si_Users" },
+            { name: "Intersectionality as an Analytic Tool", category: "s06", code: "S06-04", icon: "si_Layers" },
+            { name: "Feminist Participatory Action Research", category: "s06", code: "S06-05", icon: "si_Activity" },
+            { name: "Power Analysis Beyond the 2x2", category: "s06", code: "S06-06", icon: "si_Crosshair_detailed" }
         ];
 
         let selectedSkills = new Set();
@@ -1523,15 +1645,16 @@
             const grid = document.getElementById('skillsGrid');
             const filtered = currentFilter === 'all' ? skills : skills.filter(s => s.category === currentFilter);
             
+            const seriesLabels = { pre: 'PRE', s01: 'S01', s02: 'S02', s03: 'S03', s04: 'S04', s05: 'S05', s06: 'S06' };
             grid.innerHTML = filtered.map(skill => `
-                <div class="skill-card ${selectedSkills.has(skill.name) ? 'selected' : ''}" 
-                     onclick="toggleSkill('${skill.name}')" data-category="${skill.category}">
+                <div class="skill-card ${selectedSkills.has(skill.name) ? 'selected' : ''}"
+                     onclick="toggleSkill('${skill.name.replace(/'/g, "\\'")}')" data-category="${skill.category}">
                     <div class="skill-icon ${skill.category}">
                         <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/${skill.icon}.svg" alt="">
                     </div>
                     <div class="skill-info">
                         <div class="skill-name">${skill.name}</div>
-                        <div class="skill-category-label">${skill.category}</div>
+                        <div class="skill-category-label">${skill.code} · ${seriesLabels[skill.category]}</div>
                     </div>
                     <div class="skill-check">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
@@ -1617,8 +1740,8 @@
 
         const mojiniAnswers = {
             pricing: "Each Dojo session is ₹1,500 per person for 90 minutes. Pay per session with no long-term commitments. Sessions run in Delhi, Bangalore, or Online.",
-            skills: "We offer 35+ practitioner skills across 4 categories: Thinking (pre-mortems, crux-finding, scenario planning), Evidence (reading RCTs, cost-effectiveness), Action (stakeholder mapping, scaling decisions), and Communication (funder psychology, data storytelling).",
-            series: "We have 3 structured series: (1) Thinking Clearly in Development (8 weeks), (2) Evidence Reasoning (6 weeks), and (3) Political Economy & Implementation (6 weeks). Or pick individual skills à la carte!",
+            skills: "We offer 56 sessions across 6 series: S01 Thinking Clearly (8 sessions), S02 Evidence Reasoning (9), S03 Political Economy & Implementation (16), S04 Methods That Actually Work (9), S05 Epistemic Hygiene (8), and S06 Gender, Power & Data (6). Plus an Orientation session placed in every series.",
+            series: "We have 6 structured series: (1) Thinking Clearly in Development, (2) Evidence Reasoning, (3) Political Economy & Implementation, (4) Methods That Actually Work, (5) Epistemic Hygiene, and (6) Gender, Power & Data. Or pick individual sessions à la carte!",
             sliding: "Financial constraints shouldn't prevent learning. Contact hello@impactmojo.in if you need a reduced rate. Community organizations and grassroots groups are especially encouraged to reach out."
         };
 


### PR DESCRIPTION
## Summary
- Replaces the old 35-skill / 4-category Dojos layout with the full canonical listing: **56 sessions across 6 series** (PRE + S01–S06)
- Updates filter buttons from Thinking/Evidence/Action/Communication to series-based filters (PRE, S01–S06)
- Expands series cards from 3 to 7, each with correct session counts, descriptions, and tags matching the canonical deck listing
- Updates stats bar (56 Sessions · 6 Series), Mojini chatbot answers, and CSS color scheme for new series categories

## Test plan
- [ ] Verify all 56 session cards render in the skills grid
- [ ] Confirm each series filter button shows only that series’ sessions
- [ ] Check all 7 series cards display correct session counts and tags
- [ ] Test Mojini chatbot answers reflect the updated 6-series structure
- [ ] Verify dark mode styling for new series icon colors

https://claude.ai/code/session_011pB5eqKT4VpTjoDUtwBK7R