### PR TITLE
Replace Sarvam with Google Translate on all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1726,5 +1726,8 @@ document.addEventListener('click', function(e) {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Case Studies/case_study_template.html
+++ b/Handouts/Cross Cutting Resources/Case Studies/case_study_template.html
@@ -452,5 +452,8 @@
     <p><strong>Usage Notes:</strong> This template can be used for analyzing any South Asian case study across the three topics. Examples include: SEWA organizing model, Aadhaar implementation, Bangladesh garment sector reforms, MGNREGA employment guarantee, platform worker organizing, etc.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Case Studies/case_study_worksheets.html
+++ b/Handouts/Cross Cutting Resources/Case Studies/case_study_worksheets.html
@@ -1002,5 +1002,8 @@
     <div class="fill-line"></div>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Communications/communication_guide.html
+++ b/Handouts/Cross Cutting Resources/Communications/communication_guide.html
@@ -714,5 +714,8 @@
     <p>Your job is not just to report numbers, but to help people understand what those numbers mean for their work, their communities, and their lives. Every statistic should serve a purpose in moving your audience toward better decisions and actions.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Local Application Worksheet/local_application_worksheet.html
+++ b/Handouts/Cross Cutting Resources/Local Application Worksheet/local_application_worksheet.html
@@ -607,5 +607,8 @@
     <p><strong>Usage Notes:</strong> This worksheet helps you apply the three frameworks to your own context. Use it for field work, community projects, or personal reflection. Consider sharing findings with classmates or community members. Update periodically as conditions change.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Software Tools Guide/software_tools_guide.html
+++ b/Handouts/Cross Cutting Resources/Software Tools Guide/software_tools_guide.html
@@ -769,5 +769,8 @@ Examples:<br>
     <p>The software is just a tool to help you answer important development questions. Focus on understanding your data and research problem first, then choose the appropriate tool. Start simple and build complexity as your skills grow.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_guide.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_guide.html
@@ -605,5 +605,8 @@
 <div class="notes-block"></div>
 <div class="notes-block"></div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_1.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_1.html
@@ -856,5 +856,8 @@ All pairwise comparisons significant at p < 0.001
             <p>For statistical calculation templates, effect size guides, and interpretation frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_2.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_2.html
@@ -924,5 +924,8 @@ With FDR (q = 0.05): 34 remain significant
             <p>For survey analysis code templates, robust method tutorials, and effect size interpretation guides, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_quick_reference.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_quick_reference.html
@@ -499,5 +499,8 @@
     Part of the OpenStacks initiative for development education
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_workshop_exercises.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_workshop_exercises.html
@@ -481,5 +481,8 @@
         Licensed under CC BY-NC-SA 4.0 | For educational use with attribution<br>
         Part of the OpenStacks initiative for development education</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout.html
@@ -561,5 +561,8 @@
             <p>For the complete Data Literacy 101 course with interactive exercises, case studies, and assessment materials, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_1.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_1.html
@@ -645,5 +645,8 @@ Additional Data:
             <p>For practice datasets, calculation templates, and interactive exercises, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_2.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_2.html
@@ -681,5 +681,8 @@
             <p>For source evaluation checklists, data portal guides, and quality assessment templates, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/EDA/eda_survey_handout_1.html
+++ b/Handouts/Data and Technology Track/EDA/eda_survey_handout_1.html
@@ -800,5 +800,8 @@ outliers <- data$v447a < (Q1 - 1.5*IQR) | data$v447a > (Q3 + 1.5*IQR)
             <p>For complete code scripts, sample datasets, and EDA templates, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/EDA/eda_survey_handout_2.html
+++ b/Handouts/Data and Technology Track/EDA/eda_survey_handout_2.html
@@ -838,5 +838,8 @@ change_data <- data %>%
             <p>For advanced visualization code templates, publication-ready chart examples, and interactive dashboard tutorials, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/common_mistakes_guide.html
+++ b/Handouts/Data and Technology Track/Econometrics/common_mistakes_guide.html
@@ -917,5 +917,8 @@ stargazer(model1, model2,
             <p>Remember: Good econometrics is about being honest with the data and transparent about limitations. When in doubt, be conservative in your claims.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_formula_sheet.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_formula_sheet.html
@@ -659,5 +659,8 @@
             <strong>Licensed under CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_handout_1.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_handout_1.html
@@ -795,5 +795,8 @@ N = 8,543    R² = 0.42    F-statistic = 524.3
             <p>For regression templates, causal inference checklists, and analysis code examples, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_handout_2.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_handout_2.html
@@ -943,5 +943,8 @@
             <p>For implementation code, diagnostic tests, and advanced method tutorials, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_problem_sets.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_problem_sets.html
@@ -1190,5 +1190,8 @@ dynamic_fe <- feols(log_output ~ trained + trained_lag1 + trained_lag2 +
             <p>For complete datasets, solution guides, and additional practice problems, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_1.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_1.html
@@ -577,5 +577,8 @@ Where:
             <p>For complete multivariate analysis datasets, code templates, and diagnostic tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_2.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_2.html
@@ -747,5 +747,8 @@ model = smf.ols('test_score ~ teacher_training + infrastructure +
             <p>For complete problem set solutions, diagnostic code scripts, and additional practice datasets, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_template.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_template.html
@@ -555,5 +555,8 @@
 <div class="notes-block"></div>
 <div class="notes-block"></div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_problem_sets.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_problem_sets.html
@@ -820,5 +820,8 @@
     </ul>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_quick_reference.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_quick_reference.html
@@ -571,5 +571,8 @@
     <strong>Remember:</strong> <span class="success">Good statistics serve development goals</span> – always connect findings back to improving lives in South Asian communities.
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Education and Pedagogy/education_pedagogy_handout.html
+++ b/Handouts/Education and Pedagogy/education_pedagogy_handout.html
@@ -658,5 +658,8 @@
             <p>For the complete Education and Pedagogy 101 course with detailed case studies, curriculum samples, and assessment rubrics, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Education and Pedagogy/education_pedagogy_handout_2.html
+++ b/Handouts/Education and Pedagogy/education_pedagogy_handout_2.html
@@ -1109,5 +1109,8 @@
             <p>For complete curriculum design templates, assessment rubrics, inclusive pedagogy guides, and digital integration resources, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_1.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_1.html
@@ -535,5 +535,8 @@
             <p>For the complete Data Feminism 101 course with datasets, analysis templates, and intersectional frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_2.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_2.html
@@ -572,5 +572,8 @@ enrollment_rates <- data %>%
             <p>For complete datasets, R/Python code, and analysis templates from this workshop, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_south_asia.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_south_asia.html
@@ -467,5 +467,8 @@
 <div class="notes-block"></div>
 <div class="notes-block"></div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_handout.html
+++ b/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_handout.html
@@ -660,5 +660,8 @@
             <p>For the complete Gender Studies 101 course with detailed case studies, legal analysis, and advocacy tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_quick_reference.html
+++ b/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_quick_reference.html
@@ -577,5 +577,8 @@
             <p><strong>CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_1.html
+++ b/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_1.html
@@ -594,5 +594,8 @@
             <p>For complete constitutional analysis, intersectional assessment tools, and advocacy strategy guides, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_2.html
+++ b/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_2.html
@@ -717,5 +717,8 @@
             <p>For complete intersectional assessment tools, advocacy strategy templates, and monitoring frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_1.html
+++ b/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_1.html
@@ -652,5 +652,8 @@
             <p>For time-use analysis tools, valuation calculators, and Indian TUS datasets, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_2.html
+++ b/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_2.html
@@ -688,5 +688,8 @@
             <p>For care infrastructure calculators, budget analysis templates, and policy design frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/Assumptions Checklist/assumptions_checklist.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Assumptions Checklist/assumptions_checklist.html
@@ -756,5 +756,8 @@
     </ul>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_1.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_1.html
@@ -871,5 +871,8 @@
             <p>For complete Theory of Change templates, indicator libraries, and MEL planning tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_2.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_2.html
@@ -1125,5 +1125,8 @@
             <p>For advanced evaluation templates, adaptive management tools, and participatory evaluation guides, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/Qualitative Research/qualitative_research_handout.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Qualitative Research/qualitative_research_handout.html
@@ -911,5 +911,8 @@
             <p>For the complete Qualitative Research 101 course with detailed interview guides, analysis templates, and ethics protocols, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/Research Design Worksheet/research_design_worksheet.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Research Design Worksheet/research_design_worksheet.html
@@ -924,5 +924,8 @@
             <p>This worksheet is designed to be completed collaboratively with implementers and stakeholders. Save regularly and refer back during implementation.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_1.html
+++ b/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_1.html
@@ -699,5 +699,8 @@
             <p>For complete verification toolkits, media literacy curricula, and fact-checking guides, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_2.html
+++ b/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_2.html
@@ -847,5 +847,8 @@
             <p>For complete counter-narrative strategy templates, coalition-building guides, and policy advocacy toolkits, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Development Economics/development_economics_handout.html
+++ b/Handouts/Policy and Economics Track/Development Economics/development_economics_handout.html
@@ -780,5 +780,8 @@
             <p>For the complete Development Economics 101 course with advanced models, econometric analysis, and policy case studies, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Development Economics/development_economics_problem_sets.html
+++ b/Handouts/Policy and Economics Track/Development Economics/development_economics_problem_sets.html
@@ -671,5 +671,8 @@
             <p><strong>CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Livelihoods/livelihood_assessment_toolkit.html
+++ b/Handouts/Policy and Economics Track/Livelihoods/livelihood_assessment_toolkit.html
@@ -1409,5 +1409,8 @@
             <p><strong>CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Livelihoods/livelihoods_handout.html
+++ b/Handouts/Policy and Economics Track/Livelihoods/livelihoods_handout.html
@@ -995,5 +995,8 @@
             <p>For the complete Livelihoods 101 course with detailed case studies, value chain analysis tools, and program design templates, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Policy Tracking/policy_tracking_sheet.html
+++ b/Handouts/Policy and Economics Track/Policy Tracking/policy_tracking_sheet.html
@@ -594,5 +594,8 @@
     <p><strong>Usage Notes:</strong> Update this tracking sheet regularly (weekly/monthly) to monitor policy developments. Share with study groups, advocacy networks, or research teams. Use alongside the main topic templates to understand current policy context.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_1.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_1.html
@@ -776,5 +776,8 @@
             <p>For stakeholder mapping templates, political economy assessment frameworks, and Indian case study databases, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_2.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_2.html
@@ -935,5 +935,8 @@
             <p>For advanced political economy assessment templates, sectoral analysis guides, and comparative case study databases, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_1.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_1.html
@@ -649,5 +649,8 @@
             <p>For complete case studies, institutional analysis templates, and stakeholder mapping tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_2.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_2.html
@@ -905,5 +905,8 @@
             <p>For complete diagnostic tools, implementation templates, and monitoring frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_1.html
+++ b/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_1.html
@@ -915,5 +915,8 @@ Interpretation:
             <p>For calculation templates, datasets, and measurement tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_2.html
+++ b/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_2.html
@@ -883,5 +883,8 @@ Method C (Self-Targeting):
             <p>For decomposition analysis code, targeting evaluation templates, and policy design frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/safety_nets_south_asia.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/safety_nets_south_asia.html
@@ -560,5 +560,8 @@
 <div class="notes-block"></div>
 <div class="notes-block"></div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_1.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_1.html
@@ -662,5 +662,8 @@ Program Data:
             <p>For complete datasets, policy analysis templates, and program evaluation tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_2.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_2.html
@@ -650,5 +650,8 @@ Proposed Digital System:
             <p>For reform case studies, implementation toolkits, and cost-benefit analysis templates, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Quick Reference Cards/quick_reference_cards.html
+++ b/Handouts/Quick Reference Cards/quick_reference_cards.html
@@ -605,5 +605,8 @@
     </ul>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout.html
@@ -771,5 +771,8 @@
             <p>For the complete Climate Change 101 course with detailed climate models, vulnerability assessments, and adaptation case studies, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_1.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_1.html
@@ -569,5 +569,8 @@
             <p>For the complete Climate Change 101 course with detailed climate models, regional case studies, and advanced data analysis exercises, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_2.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_2.html
@@ -674,5 +674,8 @@
             <p>For the complete Climate Change 101 course with advanced case studies, vulnerability mapping tools, and climate finance analysis, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_dashboard_south_asia.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_dashboard_south_asia.html
@@ -742,5 +742,8 @@
             <p><strong>CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_1.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_1.html
@@ -885,5 +885,8 @@
             <p>For environmental justice assessment tools, legal advocacy templates, and community organizing guides, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_2.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_2.html
@@ -1272,5 +1272,8 @@
             <p>For complete environmental justice campaign guides, monitoring protocols, legal advocacy templates, and policy engagement frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_1.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_1.html
@@ -643,5 +643,8 @@
         <strong>Licensed under CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         <p>For constitutional analysis templates, rights-based program frameworks, and legal advocacy guides, visit the ImpactMojo platform.</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_2.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_2.html
@@ -698,5 +698,8 @@
         <strong>Licensed under CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         <p>For legal research templates, PIL strategy guides, and case law analysis tools, visit the ImpactMojo platform.</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_1.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_1.html
@@ -710,5 +710,8 @@
             <p>For the complete Indian Constitution and Law 101 course with detailed case studies, legal research methods, and advocacy tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_2.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_2.html
@@ -863,5 +863,8 @@
             <p>For the complete Indian Constitution and Law 101 course with detailed case studies, legal research methods, and advanced advocacy tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_practical_skills.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_practical_skills.html
@@ -938,5 +938,8 @@
             <p>For updated templates, current parliamentary schedules, and live policy consultation opportunities, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/AI Bias and Algorithmic Justice/handout_3_ai_bias.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/AI Bias and Algorithmic Justice/handout_3_ai_bias.html
@@ -357,5 +357,8 @@
         Licensed under CC BY-NC-SA 4.0 | For educational use with attribution<br>
         Part of the OpenStacks initiative for development education</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Digital Justice and Data Consent/handout_4_consent.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Digital Justice and Data Consent/handout_4_consent.html
@@ -416,5 +416,8 @@
         Licensed under CC BY-NC-SA 4.0 | For educational use with attribution<br>
         Part of the OpenStacks initiative for development education</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Digital Surveillance and State Power/handout_1_surveillance.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Digital Surveillance and State Power/handout_1_surveillance.html
@@ -248,5 +248,8 @@
         Licensed under CC BY-NC-SA 4.0 | For educational use with attribution<br>
         Part of the OpenStacks initiative for development education</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_1.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_1.html
@@ -628,5 +628,8 @@
             <p>For digital ethics assessment tools, algorithmic auditing templates, and implementation guides, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_2.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_2.html
@@ -867,5 +867,8 @@
             <p>For privacy impact assessment templates, AI governance checklists, and platform governance frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Platform Labour and Digital Governance/handout_2_platforms.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Platform Labour and Digital Governance/handout_2_platforms.html
@@ -323,5 +323,8 @@
         Licensed under CC BY-NC-SA 4.0 | For educational use with attribution<br>
         Part of the OpenStacks initiative for development education</p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_assessment_framework.html
+++ b/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_assessment_framework.html
@@ -986,5 +986,8 @@
             <p><strong>CC BY-NC-SA 4.0</strong> • Free to use with attribution • www.impactmojo.in</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_handout.html
+++ b/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_handout.html
@@ -862,5 +862,8 @@
             <p>For the complete Public Health 101 course with detailed health system analysis, epidemiology modules, and program planning tools, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_1.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_1.html
@@ -800,5 +800,8 @@
             <p>For complete PLA tool guides, facilitation templates, and community-led development case studies, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_2.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_2.html
@@ -1105,5 +1105,8 @@
             <p>For complete conflict resolution guides, consensus building templates, sustainability planning tools, and integration frameworks, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_1.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_1.html
@@ -697,5 +697,8 @@ MGNREGA Performance Data (2022-23):
             <p>For complete decent work indicator databases, policy analysis templates, and labor market datasets, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_2.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_2.html
@@ -705,5 +705,8 @@ e-Shram Performance Data (as of 2024):
             <p>For platform economy datasets, formalization toolkits, and wage calculation templates, visit the ImpactMojo platform.</p>
         </div>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_south_asia.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_south_asia.html
@@ -723,5 +723,8 @@
 <div class="notes-block"></div>
 <div class="notes-block"></div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/South Aisa Region/South Asia Historical - Modern Policy Timeline/historical_timeline.html
+++ b/Handouts/Thematic Areas/South Aisa Region/South Asia Historical - Modern Policy Timeline/historical_timeline.html
@@ -606,5 +606,8 @@
     <p><strong>Usage Notes:</strong> This timeline provides historical context for current debates. Use alongside topic templates to understand how issues evolved. Update regularly as new developments occur. Consider creating country-specific versions for deeper analysis.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/South Aisa Region/South Asia Regional Dashboard/regional_dashboard.html
+++ b/Handouts/Thematic Areas/South Aisa Region/South Asia Regional Dashboard/regional_dashboard.html
@@ -391,5 +391,8 @@
     <p><strong>Usage Note:</strong> This dashboard complements the three main topic templates. Update regularly with latest available data.</p>
 </div>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../../../js/translate.js"></script>
 </body>
 </html>

--- a/Handouts/index.html
+++ b/Handouts/index.html
@@ -443,5 +443,8 @@
             Use your browser's print function (Ctrl+P or Cmd+P) to save handouts as PDFs.
         </p>
     </div>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/PAGE-TEMPLATE.html
+++ b/PAGE-TEMPLATE.html
@@ -1634,5 +1634,8 @@ document.addEventListener('click', function(e) {
     if (!e.target.closest('});
 </script>
 
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
+
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Economics simulations and behavioral experiments:
 
 ### Multilingual Support
 
-Content available in 6 languages: English, Hindi, Tamil, Bengali, Telugu, Marathi
+All pages available in 5 languages via built-in translation: English, Hindi (हिन्दी), Tamil (தமிழ்), Bengali (বাংলা), Marathi (मराठी). Powered by Google Translate with a custom language selector UI.
 
 ---
 
@@ -193,7 +193,8 @@ Content available in 6 languages: English, Hindi, Tamil, Bengali, Telugu, Marath
 - **Progress Tracking** — Monitor your learning journey
 - **Reading Lists** — Curated resource collections
 - **Course Comparison** — Compare courses side-by-side
-- **Certificate Generation** — Practitioner tier and above
+- **Certificate Generation** — Auto-issued on course completion with public verification
+- **Portfolio Builder** — Premium feature: curate certificates, projects & case studies with PDF export
 
 ### Account System
 
@@ -209,8 +210,11 @@ Content available in 6 languages: English, Hindi, Tamil, Bengali, Telugu, Marath
 | Technology | Purpose |
 |------------|---------|
 | **HTML/CSS/JS** | Core frontend (no frameworks) |
+| **TypeScript/Deno** | Supabase Edge Functions (auth, certificates, tokens) |
+| **SQL (PostgreSQL)** | Database schema, triggers, RLS policies |
 | **Supabase** | Authentication, database, Edge Functions |
 | **Netlify** | Hosting, deployment, Edge Functions (auth-gate) |
+| **Google Translate** | Multilingual support (Hindi, Tamil, Bengali, Marathi) |
 | **Google Analytics** | Usage analytics |
 | **Formspree** | Contact form handling |
 | **UserWay** | Accessibility widget |
@@ -273,12 +277,15 @@ ImpactMojo/
 │   ├── router.js           # Clean URL section router
 │   ├── resource-launch.js  # JWT-based premium resource launcher
 │   ├── token-gate.js       # Client-side token verification
-│   └── premium.js          # Premium tier UI logic
+│   ├── premium.js          # Premium tier UI logic
+│   └── translate.js        # Multilingual translation (Google Translate)
 │
 ├── login.html              # User login
 ├── signup.html             # User registration
 ├── account.html            # User dashboard
 ├── premium.html            # Premium features & registration
+├── portfolio.html          # Premium portfolio builder
+├── verify-certificate.html # Public certificate verification
 │
 ├── workshops.html          # Workshop booking & info
 ├── coaching.html           # 1-on-1 coaching services
@@ -297,8 +304,10 @@ ImpactMojo/
 │   └── index.html          # ImpactLex dictionary (PWA)
 │
 ├── supabase/
-│   └── functions/
-│       └── mint-resource-token/  # JWT minting Edge Function
+│   ├── functions/
+│   │   ├── mint-resource-token/  # JWT minting Edge Function
+│   │   └── issue-certificate/    # Certificate issuance Edge Function
+│   └── migrations/               # Database migration scripts
 │
 ├── netlify-resource-template/    # Auth-gate template for resource sites
 │   ├── netlify.toml

--- a/SupportGifts/thankyou.html
+++ b/SupportGifts/thankyou.html
@@ -501,5 +501,8 @@
             });
         }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -2461,5 +2461,8 @@ document.addEventListener('click', function(e) {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/account.html
+++ b/account.html
@@ -2871,5 +2871,8 @@ style.textContent = `
 document.head.appendChild(style);
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/ai-policy.html
+++ b/ai-policy.html
@@ -1093,5 +1093,8 @@ body.dark-mode .effective-date img {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -1209,5 +1209,8 @@ function handleHash() {
 }
 window.addEventListener('hashchange', handleHash);
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -2256,5 +2256,8 @@ document.addEventListener('click', function(e) {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/blog/from-learner-to-leader.html
+++ b/blog/from-learner-to-leader.html
@@ -568,5 +568,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/blog/learning-by-doing.html
+++ b/blog/learning-by-doing.html
@@ -475,5 +475,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/blog/meal-demystified.html
+++ b/blog/meal-demystified.html
@@ -858,5 +858,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/blog/sample-size-matters.html
+++ b/blog/sample-size-matters.html
@@ -519,5 +519,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/blog/theory-of-change-pitfalls.html
+++ b/blog/theory-of-change-pitfalls.html
@@ -759,5 +759,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/blog/whats-coming-in-2026.html
+++ b/blog/whats-coming-in-2026.html
@@ -679,5 +679,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/blog/why-impactmojo-exists.html
+++ b/blog/why-impactmojo-exists.html
@@ -754,5 +754,8 @@ function updateThemeIcons() {
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/catalog.html
+++ b/catalog.html
@@ -2339,5 +2339,8 @@ document.addEventListener('click', function(e) {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/coaching.html
+++ b/coaching.html
@@ -1433,5 +1433,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/community/community.html
+++ b/community/community.html
@@ -1100,5 +1100,8 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     });
 });
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../js/translate.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1472,5 +1472,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -5840,4 +5840,7 @@
 </body>
 </html>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body></html>

--- a/courses/SEL/lexicon.html
+++ b/courses/SEL/lexicon.html
@@ -328,5 +328,8 @@
         }
         function toggleTheme() { const current = document.documentElement.getAttribute('data-theme') || 'dark'; setTheme(current === 'dark' ? 'light' : 'dark'); }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -8385,5 +8385,8 @@
         });
 
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/dataviz/lexicon.html
+++ b/courses/dataviz/lexicon.html
@@ -563,5 +563,8 @@
         // Initial render
         renderCards(LEXICON);
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -4858,5 +4858,8 @@
             button.style.opacity = '0.6';
         }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/devai/lexicon.html
+++ b/courses/devai/lexicon.html
@@ -375,5 +375,8 @@
         
         renderTerms();
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -8243,5 +8243,8 @@
         });
 
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/devecon/lexicon.html
+++ b/courses/devecon/lexicon.html
@@ -1067,5 +1067,8 @@
         document.getElementById('totalTerms').textContent = LEXICON.length;
     }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -6863,5 +6863,8 @@
         });
 
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/gandhi/lexicon.html
+++ b/courses/gandhi/lexicon.html
@@ -1905,5 +1905,8 @@
         // Initial render
         renderTerms(lexiconData);
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -6767,5 +6767,8 @@
         });
 
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/law/lexicon.html
+++ b/courses/law/lexicon.html
@@ -328,5 +328,8 @@
         }
         function toggleTheme() { const current = document.documentElement.getAttribute('data-theme') || 'dark'; setTheme(current === 'dark' ? 'light' : 'dark'); }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -7061,5 +7061,8 @@
             (d.body || d.head).appendChild(s);
         })(document);
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/media/media-lexicon.html
+++ b/courses/media/media-lexicon.html
@@ -324,5 +324,8 @@
         }
         function toggleTheme() { const current = document.documentElement.getAttribute('data-theme') || 'dark'; setTheme(current === 'dark' ? 'light' : 'dark'); }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -7940,5 +7940,8 @@
             (d.body || d.head).appendChild(s);
         })(document);
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/mel/lexicon.html
+++ b/courses/mel/lexicon.html
@@ -328,5 +328,8 @@
         }
         function toggleTheme() { const current = document.documentElement.getAttribute('data-theme') || 'dark'; setTheme(current === 'dark' ? 'light' : 'dark'); }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -7798,5 +7798,8 @@
         });
 
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/courses/poa/lexicon.html
+++ b/courses/poa/lexicon.html
@@ -614,5 +614,8 @@
         document.getElementById('total-terms').textContent = terms.length;
         renderTerms(terms);
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="../../js/translate.js"></script>
 </body>
 </html>

--- a/data-protection.html
+++ b/data-protection.html
@@ -1676,5 +1676,8 @@ function addBotMessage(text) {
 initTheme();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/dataverse.html
+++ b/dataverse.html
@@ -1861,5 +1861,8 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 })();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1131,5 +1131,8 @@ function addBotMessage(text) {
 initTheme();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/dojos.html
+++ b/dojos.html
@@ -1754,5 +1754,8 @@
         // Init
         renderSkills();
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -2096,5 +2096,8 @@ function searchFAQ() {
 
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -2257,5 +2257,8 @@ document.addEventListener('click', function(e) {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/grievance.html
+++ b/grievance.html
@@ -1532,5 +1532,8 @@ function addBotMessage(text) {
 initTheme();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/handouts.html
+++ b/handouts.html
@@ -1638,5 +1638,8 @@ searchBox.addEventListener('input', function() {
 initThemeSelector();
 loadHandouts();
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13814,9 +13814,8 @@ PASTE THIS ENTIRE BLOCK JUST BEFORE
 <!-- Premium Content Gating -->
 <script defer src="js/premium.js"></script>
 
-<!-- Sarvam AI Translation (Hindi, Tamil, Bengali, Marathi) -->
-<script>window.SARVAM_API_KEY='sk_uzv6lx8m_mmlJdug1wffHUqksVH2f6MIa';</script>
-<script defer src="js/sarvam-translate.js"></script>
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 
 <!-- Premium Card Tooltip (shows title, description & tier on hover) -->
 <script>

--- a/js/translate.js
+++ b/js/translate.js
@@ -1,0 +1,207 @@
+/**
+ * ImpactMojo Translation Widget
+ * Uses Google Translate (free, no API key) with custom UI
+ * Supports: English, Hindi, Tamil, Bengali, Marathi
+ *
+ * Replaces the previous Sarvam.ai integration.
+ * The Google Translate widget is loaded invisibly and controlled
+ * programmatically through our own language selector UI.
+ */
+(function() {
+    'use strict';
+
+    var LANGUAGES = {
+        en: { label: 'English', native: 'English', gtCode: 'en' },
+        hi: { label: 'Hindi',   native: '\u0939\u093F\u0928\u094D\u0926\u0940', gtCode: 'hi' },
+        ta: { label: 'Tamil',   native: '\u0BA4\u0BAE\u0BBF\u0BB4\u0BCD', gtCode: 'ta' },
+        bn: { label: 'Bengali', native: '\u09AC\u09BE\u0982\u09B2\u09BE', gtCode: 'bn' },
+        mr: { label: 'Marathi', native: '\u092E\u0930\u093E\u0920\u0940', gtCode: 'mr' }
+    };
+
+    var currentLang = localStorage.getItem('impactmojo_lang') || 'en';
+
+    // ===== UI: Language Selector =====
+    function createSelector() {
+        var container = document.createElement('div');
+        container.className = 'imx-lang-selector';
+        container.setAttribute('role', 'navigation');
+        container.setAttribute('aria-label', 'Language selection');
+
+        var btn = document.createElement('button');
+        btn.className = 'imx-lang-btn';
+        btn.setAttribute('aria-expanded', 'false');
+        btn.setAttribute('aria-haspopup', 'true');
+        btn.setAttribute('type', 'button');
+        btn.innerHTML = '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg> <span class="imx-lang-label">' + (LANGUAGES[currentLang] ? LANGUAGES[currentLang].native : 'English') + '</span>';
+
+        var dropdown = document.createElement('div');
+        dropdown.className = 'imx-lang-dropdown';
+        dropdown.style.display = 'none';
+
+        Object.keys(LANGUAGES).forEach(function(key) {
+            var lang = LANGUAGES[key];
+            var item = document.createElement('button');
+            item.className = 'imx-lang-option' + (key === currentLang ? ' active' : '');
+            item.setAttribute('data-lang', key);
+            item.setAttribute('type', 'button');
+            item.innerHTML = '<span class="imx-lang-native">' + lang.native + '</span> <span class="imx-lang-english">' + lang.label + '</span>';
+            item.addEventListener('click', function(e) {
+                e.stopPropagation();
+                selectLanguage(key);
+                dropdown.style.display = 'none';
+                btn.setAttribute('aria-expanded', 'false');
+            });
+            dropdown.appendChild(item);
+        });
+
+        btn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            var open = dropdown.style.display === 'none';
+            dropdown.style.display = open ? 'block' : 'none';
+            btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        });
+
+        document.addEventListener('click', function() {
+            dropdown.style.display = 'none';
+            btn.setAttribute('aria-expanded', 'false');
+        });
+
+        container.appendChild(btn);
+        container.appendChild(dropdown);
+        return container;
+    }
+
+    function injectStyles() {
+        var css = document.createElement('style');
+        css.textContent = [
+            '/* Language Selector */',
+            '.imx-lang-selector { position: relative; display: inline-flex; margin-left: 0.5rem; }',
+            '.imx-lang-btn { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.75rem; border: 1px solid var(--border-color, #334155); border-radius: 8px; background: var(--card-bg, #1E293B); color: var(--text-primary, #F1F5F9); font-size: 0.8rem; font-weight: 500; cursor: pointer; transition: all 0.2s; white-space: nowrap; }',
+            '.imx-lang-btn:hover { border-color: #0EA5E9; color: #0EA5E9; }',
+            '.imx-lang-btn svg { flex-shrink: 0; }',
+            '.imx-lang-dropdown { position: absolute; top: calc(100% + 4px); right: 0; background: var(--card-bg, #1E293B); border: 1px solid var(--border-color, #334155); border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.2); z-index: 1000; min-width: 180px; padding: 0.35rem; overflow: hidden; }',
+            '.imx-lang-option { display: flex; align-items: center; gap: 0.5rem; width: 100%; padding: 0.5rem 0.75rem; border: none; background: none; color: var(--text-primary, #F1F5F9); font-size: 0.85rem; cursor: pointer; border-radius: 6px; transition: background 0.15s; text-align: left; }',
+            '.imx-lang-option:hover { background: var(--hover-bg, #334155); }',
+            '.imx-lang-option.active { background: rgba(14, 165, 233, 0.15); color: #0EA5E9; font-weight: 600; }',
+            '.imx-lang-native { font-weight: 500; }',
+            '.imx-lang-english { color: var(--text-muted, #64748B); font-size: 0.75rem; }',
+            '/* Hide Google Translate widget elements */',
+            '.goog-te-banner-frame, .skiptranslate, #google_translate_element { display: none !important; }',
+            'body { top: 0 !important; }',
+            '/* Fix Google Translate font overrides */',
+            '.goog-text-highlight { background: none !important; box-shadow: none !important; }',
+            '@media (max-width: 768px) { .imx-lang-label { display: none; } .imx-lang-btn { padding: 0.4rem; } .imx-lang-dropdown { right: -1rem; } }'
+        ].join('\n');
+        document.head.appendChild(css);
+    }
+
+    // ===== GOOGLE TRANSLATE ENGINE =====
+
+    function loadGoogleTranslate() {
+        // Create hidden container for Google Translate widget
+        var gtDiv = document.createElement('div');
+        gtDiv.id = 'google_translate_element';
+        gtDiv.style.display = 'none';
+        document.body.appendChild(gtDiv);
+
+        // Define the callback Google Translate expects
+        window.googleTranslateElementInit = function() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en',
+                includedLanguages: 'en,hi,ta,bn,mr',
+                autoDisplay: false
+            }, 'google_translate_element');
+
+            // If user had a language selected, apply it after widget loads
+            if (currentLang !== 'en') {
+                setTimeout(function() { triggerGoogleTranslate(LANGUAGES[currentLang].gtCode); }, 1000);
+            }
+        };
+
+        // Load Google Translate script
+        var script = document.createElement('script');
+        script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+        script.async = true;
+        document.body.appendChild(script);
+    }
+
+    function triggerGoogleTranslate(langCode) {
+        // Google Translate uses a cookie to track language selection
+        // Set the cookie and reload the translate frame
+        var gtCombo = document.querySelector('.goog-te-combo');
+        if (gtCombo) {
+            gtCombo.value = langCode;
+            gtCombo.dispatchEvent(new Event('change'));
+            return;
+        }
+
+        // Fallback: set the cookie directly
+        document.cookie = 'googtrans=/en/' + langCode + '; path=/; domain=' + window.location.hostname;
+        document.cookie = 'googtrans=/en/' + langCode + '; path=/';
+
+        // Retry after a delay (widget may still be loading)
+        setTimeout(function() {
+            var combo = document.querySelector('.goog-te-combo');
+            if (combo) {
+                combo.value = langCode;
+                combo.dispatchEvent(new Event('change'));
+            }
+        }, 500);
+    }
+
+    function selectLanguage(langKey) {
+        if (langKey === currentLang) return;
+
+        currentLang = langKey;
+        localStorage.setItem('impactmojo_lang', langKey);
+
+        // Update active state in dropdown
+        document.querySelectorAll('.imx-lang-option').forEach(function(opt) {
+            opt.classList.toggle('active', opt.getAttribute('data-lang') === langKey);
+        });
+
+        // Update button label
+        var label = document.querySelector('.imx-lang-label');
+        if (label) label.textContent = LANGUAGES[langKey].native;
+
+        if (langKey === 'en') {
+            // Restore to English
+            triggerGoogleTranslate('en');
+            // Also clear the cookie
+            document.cookie = 'googtrans=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC';
+            document.cookie = 'googtrans=; path=/; domain=' + window.location.hostname + '; expires=Thu, 01 Jan 1970 00:00:00 UTC';
+        } else {
+            triggerGoogleTranslate(LANGUAGES[langKey].gtCode);
+        }
+    }
+
+    // ===== INIT =====
+    function init() {
+        injectStyles();
+
+        // Insert language selector into the nav
+        var selector = createSelector();
+        var navButtons = document.querySelector('.nav-buttons');
+        if (navButtons) {
+            navButtons.insertBefore(selector, navButtons.firstChild);
+        } else {
+            // Fallback: insert into nav-container before mobile menu button
+            var navContainer = document.querySelector('.nav-container');
+            var hamburger = document.querySelector('.mobile-menu-toggle');
+            if (navContainer && hamburger) {
+                navContainer.insertBefore(selector, hamburger);
+            } else if (navContainer) {
+                navContainer.appendChild(selector);
+            }
+        }
+
+        // Load Google Translate
+        loadGoogleTranslate();
+    }
+
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+        setTimeout(init, 0);
+    } else {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+})();

--- a/login.html
+++ b/login.html
@@ -1699,5 +1699,8 @@ document.addEventListener('click', function(e) {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/mobile-index.html
+++ b/mobile-index.html
@@ -2092,9 +2092,8 @@ body.user-logged-in .auth-logged-in { display: flex; }
 })(document);
 </script>
 
-<!-- Sarvam AI Translation (Hindi, Tamil, Bengali, Marathi) -->
-<script>window.SARVAM_API_KEY='sk_uzv6lx8m_mmlJdug1wffHUqksVH2f6MIa';</script>
-<script defer src="js/sarvam-translate.js"></script>
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 
 </body>
 </html>

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -902,5 +902,8 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
     }
 })();
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/podcast.html
+++ b/podcast.html
@@ -1728,5 +1728,8 @@ function addBotMessage(text) {
 document.addEventListener('DOMContentLoaded', initTheme);
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -1099,5 +1099,8 @@ document.getElementById('headlineInput').addEventListener('input', function() {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/premium.html
+++ b/premium.html
@@ -1821,5 +1821,8 @@ function toggleTierDetail(id) {
     }
 }
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1067,5 +1067,8 @@ function addBotMessage(text) {
 initTheme();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1218,5 +1218,8 @@ function addBotMessage(text) {
 initTheme();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -2107,5 +2107,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -1035,5 +1035,8 @@
             document.querySelector('.nav-links').classList.toggle('active');
         }
     </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1167,5 +1167,8 @@ function addBotMessage(text) {
 initTheme();
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -543,5 +543,8 @@ function filterLang(lang) {
     });
 }
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/updates.html
+++ b/updates.html
@@ -627,5 +627,8 @@ function toggleCard(card) {
     card.classList.toggle('expanded');
 }
 </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/verify-certificate.html
+++ b/verify-certificate.html
@@ -679,5 +679,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>

--- a/workshops.html
+++ b/workshops.html
@@ -1513,5 +1513,8 @@ function addBotMessage(text) {
 document.addEventListener('DOMContentLoaded', initTheme);
 </script>
 
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **New** : Custom language selector UI (globe icon) powered by Google Translate
- **Languages**: English, Hindi, Tamil, Bengali, Marathi
- **Coverage**: All 145 HTML pages (courses, handouts, blog, account, legal, etc.)
- **Removed**: Sarvam.ai API key and integration (was only on homepage)
- **Updated**: README.md (tech stack, multilingual section, project structure)
- **Closed**: Issue #39 (Hindi/Tamil support)
- **Created**: Announcement discussion #65

## Technical approach
Google Translate widget loaded invisibly, branding hidden with CSS, controlled programmatically via custom dropdown UI. Zero API cost. Language preference persisted in localStorage.

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk