### PR TITLE
Fix auto-Hindi translation and language selector on course pages

### DIFF
--- a/js/translate.js
+++ b/js/translate.js
@@ -21,6 +21,22 @@
     var gtReady = false;
     var pendingLang = null;
 
+    // ===== COOKIE CLEANUP =====
+    // Clear stale googtrans cookies when language should be English.
+    // Without this, Google Translate auto-translates on page load based on
+    // lingering cookies even when the user hasn't chosen a language.
+    function clearGoogTransCookies() {
+        document.cookie = 'googtrans=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC';
+        document.cookie = 'googtrans=; path=/; domain=' + location.hostname + '; expires=Thu, 01 Jan 1970 00:00:00 UTC';
+        document.cookie = 'googtrans=; path=/; domain=.' + location.hostname + '; expires=Thu, 01 Jan 1970 00:00:00 UTC';
+    }
+
+    // If English is the current language, pre-emptively clear any stale cookies
+    // BEFORE Google Translate script loads, so it won't auto-translate.
+    if (currentLang === 'en') {
+        clearGoogTransCookies();
+    }
+
     // ===== UI: Language Selector =====
     function createSelector() {
         var container = document.createElement('div');
@@ -313,6 +329,18 @@
                 navContainer.insertBefore(selector, hamburger);
             } else if (navContainer) {
                 navContainer.appendChild(selector);
+            } else {
+                // Flagship course pages use .mobile-header instead of .nav-container
+                var mobileHeader = document.querySelector('.mobile-header');
+                if (mobileHeader) {
+                    // Insert before the theme toggle (last child) in the mobile header
+                    var themeToggle = mobileHeader.querySelector('#theme-toggle-mobile');
+                    if (themeToggle) {
+                        mobileHeader.insertBefore(selector, themeToggle);
+                    } else {
+                        mobileHeader.appendChild(selector);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- **Random Hindi translation**: Stale `googtrans` cookies were causing Google Translate to auto-translate pages to Hindi even when the user hadn't selected Hindi. Now we pre-emptively clear these cookies before Google Translate loads whenever the saved language is English.
- **Missing language selector on flagship course pages**: Course pages use a `.mobile-header` nav structure instead of `.nav-container`/`.nav-buttons`. Added a fallback that inserts the language selector into `.mobile-header` so it appears on all pages.

## Test plan
- [ ] Visit index.html in a fresh browser — verify it stays in English (no auto-Hindi)
- [ ] Select Hindi from language selector, navigate to another page, then switch back to English — verify it reverts and stays English on subsequent page loads
- [ ] Visit any flagship course page (e.g., /courses/mel/) — verify language selector appears in the mobile header
- [ ] Test language switching works on course pages

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk