### PR TITLE
Add automated accessibility testing with axe-core (#78)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,73 @@
+# Dedicated accessibility testing workflow using axe-core
+# Runs on push/PR to main and can be triggered manually
+name: Accessibility Tests (axe-core)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  axe-accessibility:
+    name: axe-core WCAG 2.1 AA audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start local server
+        run: npx http-server -p 8080 -s &
+
+      - name: Wait for server
+        run: sleep 3
+
+      - name: Run axe-core accessibility tests
+        id: axe
+        run: |
+          set +e
+          npm run test:a11y 2>&1 | tee axe-results.txt
+          AXE_EXIT=$?
+          echo "exit_code=$AXE_EXIT" >> "$GITHUB_OUTPUT"
+
+          # Build a markdown report from the output
+          node -e "
+            const fs = require('fs');
+            const raw = fs.readFileSync('axe-results.txt', 'utf8');
+            let md = '## axe-core Accessibility Audit Results\n\n';
+            md += '\`\`\`\n' + raw.replace(/\x1b\[[0-9;]*m/g, '') + '\n\`\`\`\n';
+            if ($AXE_EXIT !== 0) {
+              md += '\n> **Note:** axe-core detected serious WCAG 2.1 AA violations. Please fix before merging.\n';
+            } else {
+              md += '\n> All pages passed axe-core accessibility checks.\n';
+            }
+            fs.writeFileSync('axe-report.md', md);
+          "
+
+      - name: Upload axe-core report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: axe-accessibility-report
+          path: axe-report.md
+
+      - name: Comment on PR with axe-core results
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: axe-accessibility-audit
+          path: axe-report.md
+
+      - name: Fail on violations
+        if: steps.axe.outputs.exit_code != '0'
+        run: |
+          echo "::error::axe-core accessibility audit failed with WCAG 2.1 AA violations."
+          exit 1

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "impactmojo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "ImpactMojo — Monitoring, Evaluation & Learning platform",
+  "scripts": {
+    "test:a11y": "node tests/axe-accessibility.js",
+    "serve": "npx http-server -p 8080 -s"
+  },
+  "devDependencies": {
+    "@axe-core/cli": "^4.8.0",
+    "axe-core": "^4.9.0",
+    "puppeteer": "^22.0.0",
+    "http-server": "^14.1.1"
+  }
+}

--- a/tests/axe-accessibility.js
+++ b/tests/axe-accessibility.js
@@ -1,0 +1,203 @@
+/**
+ * Automated accessibility testing with axe-core + Puppeteer
+ *
+ * Launches a local HTTP server, visits each target page, and runs
+ * axe-core to detect WCAG 2.1 AA violations.
+ *
+ * Usage:
+ *   npm run test:a11y              # assumes http-server is already running on :8080
+ *   AXE_SERVER_URL=http://localhost:3000 node tests/axe-accessibility.js
+ *
+ * The script will:
+ *  - Start an http-server if the env var AXE_START_SERVER=true (CI default)
+ *  - Test all pages listed below against WCAG 2.1 Level AA
+ *  - Print a summary and exit with code 1 if any violations are found
+ */
+
+const puppeteer = require('puppeteer');
+const { AxePuppeteer } = require('@axe-core/puppeteer') || {};
+const { execSync, spawn } = require('child_process');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const BASE_URL = process.env.AXE_SERVER_URL || 'http://localhost:8080';
+
+// Pages to audit (relative to the site root)
+const PAGES = [
+  'index.html',
+  'about.html',
+  'catalog.html',
+  'bct-repository.html',
+  'courses/mel/index.html',
+];
+
+// axe-core impact levels: minor, moderate, serious, critical
+// Only fail on serious + critical by default; override with AXE_MIN_IMPACT
+const MIN_IMPACT = process.env.AXE_MIN_IMPACT || 'serious';
+const IMPACT_ORDER = ['minor', 'moderate', 'serious', 'critical'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function impactAtLeast(impact, threshold) {
+  return IMPACT_ORDER.indexOf(impact) >= IMPACT_ORDER.indexOf(threshold);
+}
+
+function colorize(text, code) {
+  return `\x1b[${code}m${text}\x1b[0m`;
+}
+
+const red    = (t) => colorize(t, 31);
+const green  = (t) => colorize(t, 32);
+const yellow = (t) => colorize(t, 33);
+const bold   = (t) => colorize(t, 1);
+
+function printViolation(v) {
+  const impactColors = { minor: 33, moderate: 33, serious: 31, critical: 31 };
+  const color = impactColors[v.impact] || 0;
+  console.log(`  ${colorize(v.impact.toUpperCase(), color)} : ${v.id} — ${v.help}`);
+  console.log(`           ${v.helpUrl}`);
+  v.nodes.slice(0, 3).forEach((node) => {
+    console.log(`           target: ${node.target.join(', ')}`);
+  });
+  if (v.nodes.length > 3) {
+    console.log(`           ... and ${v.nodes.length - 3} more elements`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function runAxeOnPage(browser, url) {
+  const page = await browser.newPage();
+  await page.setBypassCSP(true);
+  try {
+    await page.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
+  } catch (err) {
+    console.log(yellow(`  WARNING: Could not load ${url} — ${err.message}`));
+    await page.close();
+    return { url, violations: [], skipped: true };
+  }
+
+  // Inject axe-core manually (works even if @axe-core/puppeteer is not installed)
+  const axeSource = require('axe-core').source;
+  await page.evaluate(axeSource);
+
+  const results = await page.evaluate(() => {
+    /* global axe */
+    return axe.run(document, {
+      runOnly: {
+        type: 'tag',
+        values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'],
+      },
+    });
+  });
+
+  await page.close();
+  return { url, violations: results.violations, passes: results.passes.length };
+}
+
+async function main() {
+  let serverProcess = null;
+
+  // Optionally start a local server (useful in CI)
+  if (process.env.AXE_START_SERVER === 'true') {
+    const root = path.resolve(__dirname, '..');
+    serverProcess = spawn('npx', ['http-server', root, '-p', '8080', '-s'], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    // Give the server a moment to boot
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  console.log(bold('\n=== axe-core Accessibility Audit ===\n'));
+  console.log(`Base URL : ${BASE_URL}`);
+  console.log(`Pages    : ${PAGES.length}`);
+  console.log(`Min fail : ${MIN_IMPACT} and above\n`);
+
+  let totalViolations = 0;
+  let totalFailingViolations = 0;
+  const summaries = [];
+
+  for (const pagePath of PAGES) {
+    const url = `${BASE_URL}/${pagePath}`;
+    console.log(bold(`\n--- ${pagePath} ---`));
+
+    const result = await runAxeOnPage(browser, url);
+
+    if (result.skipped) {
+      summaries.push({ page: pagePath, status: 'SKIPPED', violations: 0, failing: 0 });
+      continue;
+    }
+
+    const failing = result.violations.filter((v) => impactAtLeast(v.impact, MIN_IMPACT));
+    const warnings = result.violations.filter((v) => !impactAtLeast(v.impact, MIN_IMPACT));
+
+    totalViolations += result.violations.length;
+    totalFailingViolations += failing.length;
+
+    if (failing.length > 0) {
+      console.log(red(`  ${failing.length} failing violation(s):`));
+      failing.forEach(printViolation);
+    }
+    if (warnings.length > 0) {
+      console.log(yellow(`  ${warnings.length} warning(s) (below threshold):`));
+      warnings.forEach(printViolation);
+    }
+    if (result.violations.length === 0) {
+      console.log(green('  No violations found.'));
+    }
+
+    console.log(`  Passed rules: ${result.passes}`);
+    summaries.push({
+      page: pagePath,
+      status: failing.length > 0 ? 'FAIL' : 'PASS',
+      violations: result.violations.length,
+      failing: failing.length,
+    });
+  }
+
+  await browser.close();
+
+  if (serverProcess) {
+    process.kill(-serverProcess.pid);
+  }
+
+  // Summary table
+  console.log(bold('\n\n=== Summary ===\n'));
+  console.log('Page                          | Status  | Violations | Failing');
+  console.log('------------------------------|---------|------------|--------');
+  for (const s of summaries) {
+    const status = s.status === 'FAIL' ? red(s.status) : s.status === 'PASS' ? green(s.status) : yellow(s.status);
+    console.log(
+      `${s.page.padEnd(30)}| ${s.status === 'FAIL' ? red(s.status.padEnd(8)) : s.status === 'PASS' ? green(s.status.padEnd(8)) : yellow(s.status.padEnd(8))}| ${String(s.violations).padEnd(11)}| ${s.failing}`
+    );
+  }
+
+  console.log(`\nTotal violations : ${totalViolations}`);
+  console.log(`Failing (>= ${MIN_IMPACT}) : ${totalFailingViolations}\n`);
+
+  if (totalFailingViolations > 0) {
+    console.log(red(`FAILED — ${totalFailingViolations} accessibility violation(s) at ${MIN_IMPACT} level or above.\n`));
+    process.exit(1);
+  } else {
+    console.log(green('PASSED — No serious accessibility violations found.\n'));
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
- axe-core + Puppeteer accessibility test script for key pages (index, about, catalog, BCT repository, MEL course)
- `npm run test:a11y` script for local testing
- GitHub Actions workflow at `.github/workflows/accessibility.yml`

Closes #78

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk