### PR TITLE
Add axe-core CI job and fix print cleanup (#78, #37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,29 @@ jobs:
           echo "::error::Accessibility audit failed with critical WCAG 2.1 AA violations."
           exit 1
 
+  axe-core:
+    name: Accessibility audit (axe-core)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start local server
+        run: npx http-server -p 8080 -s &
+
+      - name: Wait for server
+        run: sleep 3
+
+      - name: Run axe-core accessibility tests
+        run: npm run test:a11y
+
   html-validate:
     name: Validate HTML
     runs-on: ubuntu-latest

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -1786,8 +1786,12 @@ function shareTechnique() {
 
 function printTechnique() {
     document.body.classList.add('printing-technique');
+    var cleanup = function() {
+        document.body.classList.remove('printing-technique');
+        window.removeEventListener('afterprint', cleanup);
+    };
+    window.addEventListener('afterprint', cleanup);
     window.print();
-    document.body.classList.remove('printing-technique');
 }
 
 document.getElementById('modalOverlay').addEventListener('click', function(e) { if (e.target === this) closeModal(); });


### PR DESCRIPTION
## Summary
- Add axe-core accessibility audit job to CI workflow
- Fix printTechnique() to use `afterprint` event instead of synchronous cleanup

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk