### PR TITLE
Add offline PWA support for flagship courses (#76)

### DIFF
--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <title>Social-Emotional Learning for Development Practice | ImpactMojo</title>
     <meta name="description" content="How social-emotional competencies shape effective development practice. A rigorous course connecting SEL research from CASEL, WHO life skills, and Indian educational frameworks with the daily realities of practitioners working in high-stress, resource-constrained environments across South Asia.">
     <meta name="keywords" content="social emotional learning, SEL, practitioner wellbeing, facilitation skills, conflict resolution, burnout, trauma-informed, NEP 2020, CASEL, development practice, ImpactMojo">
@@ -5848,4 +5850,6 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body></html>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <title>Seeing Data: Visualization for Impact | ImpactMojo</title>
     <meta name="description" content="A flagship course on data visualization for development professionals. Learn principles, design, and tools to communicate data effectively for social impact.">
     <meta property="og:title" content="Seeing Data: Visualization for Impact | ImpactMojo">
@@ -8392,5 +8396,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <title>AI for Impact: Data Monitoring & Evaluation in Development | ImpactMojo</title>
     <meta name="description" content="Learn when and how to use AI tools in development M&E—from data collection and computer vision to algorithmic targeting and ethical frameworks. A rigorous, evidence-based course with South Asian and African case studies.">
     <meta name="keywords" content="AI, machine learning, M&E, monitoring and evaluation, development, NLP, computer vision, GiveDirectly, J-PAL, satellite imagery, poverty targeting, algorithmic bias, Ghana, India, development economics">
@@ -4865,5 +4869,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
@@ -8250,5 +8252,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <title>Gandhi's Political Thought: Philosophy for Praxis | ImpactMojo</title>
     <meta name="description" content="A comprehensive journey through Gandhi's political thought—from Swaraj and Satyagraha to Gram Swaraj and Trusteeship. Includes an interactive lexicon with 55+ annotated terms.">
     <meta name="keywords" content="Gandhi, Gandhian philosophy, Satyagraha, Swaraj, Ahimsa, non-violence, political philosophy, Indian independence, civil disobedience, ImpactMojo, free course">
@@ -6870,5 +6874,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
@@ -6774,5 +6776,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
@@ -7068,5 +7070,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
@@ -7947,5 +7949,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="/manifest.json">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
@@ -7805,5 +7807,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -252,7 +252,9 @@ function toggleMobileDropdown(event, element) {
 <link href="assets/images/apple-touch-icon.png" rel="apple-touch-icon"/>
 <!-- Web App Manifest for PWA -->
 <link href="manifest.json" rel="manifest"/>
-<meta content="#0066CC" name="theme-color"/>
+<meta content="#0F172A" name="theme-color"/>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <!-- Google Fonts - Inter & Poppins -->
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
@@ -14262,5 +14264,7 @@ document.addEventListener('click', function(e) {
 });
 </script>
 <script src="/js/search.js" defer></script>
+<script src="/js/pwa.js" defer></script>
+<script src="/js/offline.js" defer></script>
 </body>
 </html>

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,35 @@
+// ImpactMojo PWA - Service Worker Registration
+// Registers the service worker and handles update notifications
+(function () {
+  'use strict';
+
+  if (!('serviceWorker' in navigator)) return;
+
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
+      .then(function (registration) {
+        console.log('ImpactMojo SW registered, scope:', registration.scope);
+
+        // Check for updates every 30 minutes
+        setInterval(function () {
+          registration.update();
+        }, 30 * 60 * 1000);
+
+        // Notify user when a new version is available
+        registration.addEventListener('updatefound', function () {
+          var newWorker = registration.installing;
+          if (!newWorker) return;
+
+          newWorker.addEventListener('statechange', function () {
+            if (newWorker.state === 'activated' && navigator.serviceWorker.controller) {
+              // New SW activated - optionally show a refresh prompt
+              console.log('ImpactMojo SW updated. Refresh for latest version.');
+            }
+          });
+        });
+      })
+      .catch(function (err) {
+        console.log('ImpactMojo SW registration failed:', err);
+      });
+  });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,10 @@
   "short_name": "ImpactMojo",
   "description": "101 Knowledge Series for Social Impact - Development education for justice, equity, and development in South Asia",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
-  "background_color": "#0a0e27",
-  "theme_color": "#00D9FF",
+  "background_color": "#0F172A",
+  "theme_color": "#0EA5E9",
   "orientation": "portrait-primary",
   "icons": [
     {
@@ -19,14 +20,22 @@
       "type": "image/png"
     },
     {
+      "src": "/assets/images/favicon.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
       "src": "/assets/images/android-chrome-192x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/assets/images/android-chrome-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ],
   "categories": ["education", "development", "social"],

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0F172A">
+    <title>Offline - ImpactMojo</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: #0F172A;
+            color: #E2E8F0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 2rem;
+        }
+        .offline-container {
+            max-width: 480px;
+        }
+        .offline-icon {
+            font-size: 4rem;
+            margin-bottom: 1.5rem;
+            opacity: 0.7;
+        }
+        h1 {
+            font-family: 'Poppins', 'Inter', sans-serif;
+            font-size: 1.75rem;
+            font-weight: 700;
+            color: #F8FAFC;
+            margin-bottom: 0.75rem;
+        }
+        p {
+            font-size: 1rem;
+            line-height: 1.6;
+            color: #94A3B8;
+            margin-bottom: 1.5rem;
+        }
+        .offline-actions {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            align-items: center;
+        }
+        .btn {
+            display: inline-block;
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            font-size: 0.95rem;
+            font-weight: 600;
+            text-decoration: none;
+            cursor: pointer;
+            border: none;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+        .btn:hover {
+            transform: translateY(-1px);
+        }
+        .btn-primary {
+            background: #0EA5E9;
+            color: #FFF;
+        }
+        .btn-primary:hover {
+            box-shadow: 0 4px 14px rgba(14, 165, 233, 0.4);
+        }
+        .btn-secondary {
+            background: transparent;
+            color: #0EA5E9;
+            border: 1px solid #1E293B;
+        }
+        .btn-secondary:hover {
+            border-color: #0EA5E9;
+        }
+        .hint {
+            margin-top: 2rem;
+            font-size: 0.85rem;
+            color: #64748B;
+        }
+    </style>
+</head>
+<body>
+    <div class="offline-container">
+        <div class="offline-icon">&#x1F4F6;</div>
+        <h1>You are offline</h1>
+        <p>It looks like you have lost your internet connection. Any courses you have previously downloaded are still available.</p>
+        <div class="offline-actions">
+            <button class="btn btn-primary" onclick="window.location.reload()">Try again</button>
+            <a class="btn btn-secondary" href="/">Go to homepage</a>
+        </div>
+        <p class="hint">Tip: Use the "Download for Offline" button on any course page to make it available without internet.</p>
+    </div>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,14 +1,35 @@
 // Service Worker for ImpactMojo PWA
-// v4 - Offline course support, background sync, offline indicator
-const CACHE_NAME = 'impactmojo-v4';
+// v5 - Offline PWA support for flagship courses, shell caching, offline fallback
+const CACHE_NAME = 'impactmojo-v5';
 const COURSE_CACHE_PREFIX = 'impactmojo-course-';
-const STATIC_ASSETS = [
+
+// App shell: core assets cached on install
+const SHELL_ASSETS = [
+  '/',
+  '/index.html',
+  '/offline.html',
   '/manifest.json',
+  '/js/pwa.js',
+  '/js/offline.js',
+  '/js/auth.js',
+  '/js/router.js',
+  '/js/search.js',
+  '/js/cookie-ui.js',
+  '/js/learning-tracks.js',
+  '/js/faq-bank.js',
+  '/js/bookmarks-compare.js',
+  '/js/premium.js',
+  '/js/translate.js',
+  '/js/resource-launch.js',
+  '/js/mobile-ui.js',
+  '/js/course-progress.js',
   '/assets/images/favicon.ico',
+  '/assets/images/favicon.png',
   '/assets/images/favicon-16x16.png',
   '/assets/images/favicon-32x32.png',
   '/assets/images/apple-touch-icon.png',
-  '/assets/images/varna-photo.jpg'
+  '/assets/images/android-chrome-192x192.png',
+  '/assets/images/android-chrome-512x512.png'
 ];
 
 // Flagship course definitions
@@ -17,7 +38,10 @@ const FLAGSHIP_COURSES = [
   'mel', 'poa', 'media', 'law', 'SEL'
 ];
 
-// Get all URLs that need caching for a given course
+// Course page URLs to pre-cache
+const COURSE_PAGES = FLAGSHIP_COURSES.map(id => `/courses/${id}/index.html`);
+
+// Get all URLs that need caching for a given course (on-demand download)
 function getCourseURLs(courseId) {
   const base = `/courses/${courseId}/`;
   return [
@@ -32,17 +56,27 @@ function getCourseCacheName(courseId) {
   return `${COURSE_CACHE_PREFIX}${courseId}`;
 }
 
-// Install - cache only static assets (fonts, icons)
+// Install - cache app shell + flagship course pages
 self.addEventListener('install', event => {
-  self.skipWaiting(); // Activate immediately on update
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(STATIC_ASSETS))
-      .catch(err => console.log('SW: cache error', err))
+    caches.open(CACHE_NAME).then(cache => {
+      // Cache shell assets first, then course pages (non-blocking failures)
+      return cache.addAll(SHELL_ASSETS).then(() => {
+        // Cache course pages individually so one failure doesn't break install
+        return Promise.allSettled(
+          COURSE_PAGES.map(url =>
+            fetch(url).then(resp => {
+              if (resp.ok) return cache.put(url, resp);
+            }).catch(() => {})
+          )
+        );
+      });
+    }).catch(err => console.log('SW: install cache error', err))
   );
 });
 
-// Activate - clean up old caches (preserve course caches)
+// Activate - clean up old caches (preserve individual course download caches)
 self.addEventListener('activate', event => {
   event.waitUntil(
     caches.keys().then(names =>
@@ -51,13 +85,14 @@ self.addEventListener('activate', event => {
           .filter(n => n !== CACHE_NAME && !n.startsWith(COURSE_CACHE_PREFIX))
           .map(n => caches.delete(n))
       )
-    ).then(() => self.clients.claim()) // Take control of all pages
+    ).then(() => self.clients.claim())
   );
 });
 
 // Fetch strategy:
-// - HTML pages: network-first (fall back to cache only when offline)
-// - JS/CSS/images: stale-while-revalidate (fast + stays fresh)
+// - Cached shell/course assets: cache-first (fast offline)
+// - Other HTML pages: network-first (fresh content, fallback to cache/offline.html)
+// - Other JS/CSS/images: stale-while-revalidate
 // - API/Supabase calls: network-only (never cache)
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
@@ -67,11 +102,44 @@ self.addEventListener('fetch', event => {
     return;
   }
 
+  const pathname = url.pathname;
   const isHTML = event.request.headers.get('accept')?.includes('text/html') ||
-                 url.pathname.endsWith('.html') || url.pathname === '/';
+                 pathname.endsWith('.html') || pathname === '/';
 
-  if (isHTML) {
-    // Network-first for HTML — always get fresh content, fall back to course cache
+  // Check if this URL is part of the pre-cached shell or course pages
+  const isShellAsset = SHELL_ASSETS.includes(pathname);
+  const isCoursePage = COURSE_PAGES.includes(pathname) ||
+                       FLAGSHIP_COURSES.some(id => pathname === `/courses/${id}/`);
+
+  if (isShellAsset || isCoursePage) {
+    // Cache-first for shell assets and pre-cached course pages
+    event.respondWith(
+      caches.match(event.request).then(cached => {
+        if (cached) {
+          // Return cache immediately, update in background
+          const fetchPromise = fetch(event.request).then(response => {
+            if (response.ok) {
+              caches.open(CACHE_NAME).then(cache => cache.put(event.request, response));
+            }
+          }).catch(() => {});
+          fetchPromise; // fire-and-forget
+          return cached;
+        }
+        // Not in cache yet - fetch and cache
+        return fetch(event.request).then(response => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
+          return response;
+        }).catch(() => {
+          if (isHTML) return caches.match('/offline.html');
+          return new Response('', { status: 503 });
+        });
+      })
+    );
+  } else if (isHTML) {
+    // Network-first for other HTML pages
     event.respondWith(
       fetch(event.request)
         .then(response => {
@@ -86,20 +154,19 @@ self.addEventListener('fetch', event => {
           return caches.match(event.request)
             .then(cached => {
               if (cached) return cached;
-              // Check course caches as fallback
+              // Check course download caches as fallback
               return caches.keys().then(names => {
                 const courseCaches = names.filter(n => n.startsWith(COURSE_CACHE_PREFIX));
                 return courseCaches.reduce((promise, cacheName) =>
                   promise.then(result => result || caches.open(cacheName).then(c => c.match(event.request))),
                   Promise.resolve(null)
                 );
-              }).then(result => result || caches.match('/index.html'));
+              }).then(result => result || caches.match('/offline.html'));
             });
         })
     );
   } else {
-    // Stale-while-revalidate for assets (JS, CSS, images, fonts)
-    // Also check course caches for offline asset serving
+    // Stale-while-revalidate for other assets (JS, CSS, images, fonts)
     event.respondWith(
       caches.match(event.request).then(cached => {
         const fetchPromise = fetch(event.request).then(response => {
@@ -147,7 +214,7 @@ self.addEventListener('message', event => {
   }
 });
 
-// Cache all assets for a course
+// Cache all assets for a course (on-demand download)
 async function cacheCourse(courseId) {
   const cacheName = getCourseCacheName(courseId);
   const urls = getCourseURLs(courseId);
@@ -192,7 +259,6 @@ self.addEventListener('sync', event => {
 
 async function syncProgress() {
   try {
-    // Open IndexedDB to check for queued progress data
     const db = await openDB();
     const tx = db.transaction('pendingSync', 'readwrite');
     const store = tx.objectStore('pendingSync');
@@ -215,10 +281,9 @@ async function syncProgress() {
         }
         resolve();
       };
-      request.onerror = () => resolve(); // Don't block on DB errors
+      request.onerror = () => resolve();
     });
   } catch (err) {
-    // IndexedDB not available or no pending data — that's fine
     console.log('SW: No pending sync data');
   }
 }
@@ -237,13 +302,9 @@ function openDB() {
   });
 }
 
-// ─── Offline indicator: notify clients of connectivity changes ───
+// ─── Notify all clients ───
 function notifyClients(message) {
   self.clients.matchAll({ type: 'window', includeUncontrolled: false }).then(clients => {
     clients.forEach(client => client.postMessage(message));
   });
 }
-
-// Periodic offline check — notify clients when a navigation fetch fails
-// (Integrated into the main fetch handler's .catch paths above rather than
-//  duplicating requests. Client-side navigator.onLine events handle the rest.)


### PR DESCRIPTION
## Summary
- Service worker with cache-first strategy for shell assets and course pages
- Pre-caches all 9 flagship course pages for offline access
- Network-first for other HTML, stale-while-revalidate for assets
- `offline.html` fallback page matching dark theme
- `js/pwa.js` registration with 30-minute update checks
- Manifest and meta tags added to index.html and all course pages

Closes #76

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk