### PR TITLE
Add structured Learning Pathways with milestones (#28)

### DIFF
--- a/account.html
+++ b/account.html
@@ -3065,6 +3065,7 @@ document.head.appendChild(style);
 
 
 <script src="js/open-badges.js"></script>
+<script src="js/learning-pathways.js"></script>
 <style>
 .imx-badge-wallet { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1rem; }
 .imx-badge-card { display: flex; gap: 1rem; padding: 1rem; background: var(--hover-bg); border-radius: 12px; border: 1px solid var(--border-color); }

--- a/index.html
+++ b/index.html
@@ -9593,6 +9593,53 @@ body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-m
 </section>
 
 <!-- END imx: Tracks section -->
+
+<!-- BEGIN imx: Learning Pathways section -->
+<section id="pathways" class="imx-pathways-section">
+  <div class="imx-pathways-wrap">
+    <div class="imx-pathways-header">
+      <div class="imx-kicker">Learning Pathways</div>
+      <h2 class="imx-h2">Structured credential journeys</h2>
+      <p class="imx-pathways-sub">Follow curated pathways combining courses, labs, and games. Earn milestone badges and pathway credentials as you progress.</p>
+    </div>
+    <div id="pathwaysContainer"></div>
+  </div>
+  <style>
+  .imx-pathways-section { padding: 3rem 0; }
+  .imx-pathways-wrap { max-width: 1200px; margin: 0 auto; padding: 0 1.5rem; }
+  .imx-pathways-header { margin-bottom: 2rem; }
+  .imx-pathways-sub { color: var(--text-secondary); font-size: 0.9rem; max-width: 600px; margin-top: 0.5rem; line-height: 1.5; }
+  #pathwaysContainer { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1.25rem; }
+  @media (max-width: 550px) { #pathwaysContainer { grid-template-columns: 1fr; } }
+  .imx-pw-card { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 14px; padding: 1.25rem 1.5rem; border-top: 3px solid var(--pw-color); }
+  .imx-pw-card-header { cursor: pointer; }
+  .imx-pw-card-title { font-size: 1.05rem; font-weight: 700; color: var(--pw-color); }
+  .imx-pw-card-track { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.1rem; }
+  .imx-pw-card-desc { font-size: 0.85rem; color: var(--text-secondary); margin: 0.5rem 0; line-height: 1.5; }
+  .imx-pw-card-audience { font-size: 0.78rem; color: var(--text-muted); margin-bottom: 0.75rem; }
+  .imx-pw-progress-bar { height: 4px; background: var(--border-color); border-radius: 2px; overflow: hidden; }
+  .imx-pw-progress-fill { height: 100%; border-radius: 2px; transition: width 0.4s ease; }
+  .imx-pw-progress-label { font-size: 0.7rem; color: var(--text-muted); margin-top: 0.3rem; font-weight: 500; }
+  .imx-pw-steps { margin-top: 0.75rem; }
+  .imx-pw-step { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0; font-size: 0.82rem; border-bottom: 1px solid var(--border-color); }
+  .imx-pw-step:last-child { border-bottom: none; }
+  .imx-pw-step-num { width: 20px; height: 20px; border-radius: 50%; background: var(--border-color); display: flex; align-items: center; justify-content: center; font-size: 0.65rem; font-weight: 700; color: var(--text-muted); flex-shrink: 0; }
+  .imx-pw-step-done .imx-pw-step-num { background: #10B981; color: white; }
+  .imx-pw-step-icon { font-size: 0.9rem; }
+  .imx-pw-step-title { flex: 1; }
+  .imx-pw-step-done .imx-pw-step-title { text-decoration: line-through; color: var(--text-muted); }
+  .imx-pw-check { flex-shrink: 0; }
+  .imx-pw-milestones { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.6rem; }
+  .imx-pw-milestone { font-size: 0.7rem; padding: 0.2rem 0.5rem; border-radius: 12px; font-weight: 600; }
+  .imx-pw-milestone-earned { background: rgba(16,185,129,0.12); color: #10B981; }
+  .imx-pw-milestone-locked { background: var(--hover-bg); color: var(--text-muted); }
+  .imx-pw-next { font-size: 0.8rem; margin-top: 0.75rem; padding: 0.5rem 0.75rem; background: var(--hover-bg); border-radius: 8px; color: var(--text-secondary); }
+  .imx-pw-complete-badge { font-size: 0.85rem; font-weight: 700; margin-top: 0.75rem; text-align: center; }
+  .imx-pw-card-mini { margin-top: 0.5rem; padding-top: 0.4rem; border-top: 1px solid var(--border-color); }
+  </style>
+</section>
+<!-- END imx: Learning Pathways section -->
+
 <!-- Track Quiz CTA -->
 <section class="track-quiz-cta" id="quiz">
   <div class="track-quiz-inner">
@@ -13017,6 +13064,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 <!-- BEGIN imx: scripts -->
 <script defer src="js/learning-tracks.js"></script>
+<script defer src="js/learning-pathways.js"></script>
 <!-- END imx: scripts -->
 
 

--- a/js/learning-pathways.js
+++ b/js/learning-pathways.js
@@ -1,0 +1,358 @@
+/**
+ * ImpactMojo Learning Pathways
+ * Structured credential tracks with prerequisites, milestones, and visual progress.
+ *
+ * Builds on:
+ *  - learning-tracks.js (TRACKS data, track modal)
+ *  - course-progress.js (localStorage per-course progress)
+ *  - open-badges.js (badge definitions, track badges)
+ */
+
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'impactmojo_pathway_state';
+
+  // ── Pathway Definitions ─────────────────────────────────────────────
+  // Each pathway is a structured journey through a track with ordered
+  // steps, prerequisites, and milestone markers.
+  var PATHWAYS = {
+    'mel-practitioner': {
+      name: 'MEL Practitioner',
+      track: 'Monitoring, Evaluation & Learning',
+      description: 'Master MEL frameworks, qualitative methods, and research design through courses, labs, and hands-on practice.',
+      audience: 'M&E officers, program managers, researchers',
+      color: '#10B981',
+      steps: [
+        { id: 'mel-course', type: 'course', courseId: 'mel', title: 'MEL Flagship Course', description: 'Complete all modules in Monitoring, Evaluation & Learning.' },
+        { id: 'toc-lab', type: 'lab', title: 'TOC Lab', description: 'Build a Theory of Change for a real program.' },
+        { id: 'mle-lab', type: 'lab', title: 'MLE Lab', description: 'Design monitoring indicators and a learning agenda.' },
+        { id: 'mel-planning-lab', type: 'lab', title: 'MEL Planning Lab', description: 'Develop a complete MEL plan with data collection tools.' },
+        { id: 'survey-lab', type: 'lab', title: 'Survey Design Lab', description: 'Design and pilot a household survey instrument.' }
+      ],
+      milestones: [
+        { afterStep: 'mel-course', label: 'MEL Foundations', badge: true },
+        { afterStep: 'mel-planning-lab', label: 'MEL Practitioner', badge: true, credential: true }
+      ]
+    },
+    'data-analyst': {
+      name: 'Development Data Analyst',
+      track: 'Data & Technology',
+      description: 'Build comprehensive data skills from visualization and AI to advanced statistical analysis for development work.',
+      audience: 'Data analysts, researchers, M&E specialists',
+      color: '#0EA5E9',
+      steps: [
+        { id: 'dataviz-course', type: 'course', courseId: 'dataviz', title: 'Data Visualization for Impact', description: 'Master visual encoding, chart selection, and M&E dashboards.' },
+        { id: 'devai-course', type: 'course', courseId: 'devai', title: 'AI for Impact', description: 'Apply ML, NLP, and computer vision to development monitoring.' },
+        { id: 'viz-lab', type: 'lab', title: 'Visualization Lab', description: 'Create publication-quality visualizations from real datasets.' },
+        { id: 'lorenz-game', type: 'game', title: 'Lorenz Curve Game', description: 'Practice inequality measurement interactively.' },
+        { id: 'sampling-game', type: 'game', title: 'Sampling Strategy Game', description: 'Design sampling strategies for field surveys.' }
+      ],
+      milestones: [
+        { afterStep: 'dataviz-course', label: 'Data Viz Certified', badge: true },
+        { afterStep: 'devai-course', label: 'AI Certified', badge: true },
+        { afterStep: 'sampling-game', label: 'Data Analyst', badge: true, credential: true }
+      ]
+    },
+    'dev-economist': {
+      name: 'Development Economist',
+      track: 'Policy & Economics',
+      description: 'From foundational economics through policy analysis, impact evaluation, and cost-effectiveness.',
+      audience: 'Economists, policy analysts, program designers',
+      color: '#6366F1',
+      steps: [
+        { id: 'devecon-course', type: 'course', courseId: 'devecon', title: 'Development Economics', description: 'Master development economics theory and empirical methods.' },
+        { id: 'poa-course', type: 'course', courseId: 'poa', title: 'Politics of Aspiration', description: 'Understand political economy and aspiration theory.' },
+        { id: 'cea-lab', type: 'lab', title: 'CEA Lab', description: 'Conduct a cost-effectiveness analysis.' },
+        { id: 'ie-lab', type: 'lab', title: 'Impact Evaluation Lab', description: 'Design a randomized or quasi-experimental evaluation.' },
+        { id: 'budget-game', type: 'game', title: 'Budget Trade-offs Game', description: 'Allocate scarce resources across competing programs.' },
+        { id: 'targeting-game', type: 'game', title: 'Targeting Game', description: 'Design targeting criteria for social programs.' }
+      ],
+      milestones: [
+        { afterStep: 'devecon-course', label: 'Economics Foundations', badge: true },
+        { afterStep: 'targeting-game', label: 'Development Economist', badge: true, credential: true }
+      ]
+    },
+    'governance-scholar': {
+      name: 'Governance & Rights Scholar',
+      track: 'Philosophy, Law & Governance',
+      description: 'Gandhian political thought, constitutional law, and rights-based approaches to development.',
+      audience: 'Governance professionals, advocates, academics',
+      color: '#8B5CF6',
+      steps: [
+        { id: 'gandhi-course', type: 'course', courseId: 'gandhi', title: "Gandhi's Political Thought", description: "Engage with Gandhi's philosophy and contemporary relevance." },
+        { id: 'law-course', type: 'course', courseId: 'law', title: 'Law & Development', description: 'Constitutional law, rights, and legal frameworks.' },
+        { id: 'advocacy-lab', type: 'lab', title: 'Policy and Advocacy Lab', description: 'Design an evidence-based advocacy campaign.' }
+      ],
+      milestones: [
+        { afterStep: 'gandhi-course', label: 'Gandhian Scholar', badge: true },
+        { afterStep: 'advocacy-lab', label: 'Governance Scholar', badge: true, credential: true }
+      ]
+    },
+    'health-comms': {
+      name: 'Health & Communication Specialist',
+      track: 'Health, Communication & Wellbeing',
+      description: 'SEL facilitation, media for development, and public health communication skills.',
+      audience: 'Health communicators, BCC designers, wellbeing practitioners',
+      color: '#F59E0B',
+      steps: [
+        { id: 'sel-course', type: 'course', courseId: 'SEL', title: 'Social & Emotional Learning', description: 'Master SEL facilitation for development contexts.' },
+        { id: 'media-course', type: 'course', courseId: 'media', title: 'Media, Communication & Development', description: 'BCC strategy, storytelling, and campaign design.' },
+        { id: 'epi-lab', type: 'lab', title: 'Epidemiology Lab', description: 'Analyze disease surveillance data.' },
+        { id: 'outbreak-game', type: 'game', title: 'Outbreak Simulation Game', description: 'Respond to a public health emergency scenario.' }
+      ],
+      milestones: [
+        { afterStep: 'sel-course', label: 'SEL Certified', badge: true },
+        { afterStep: 'outbreak-game', label: 'Health & Comms Specialist', badge: true, credential: true }
+      ]
+    }
+  };
+
+  // ── Progress Reading ────────────────────────────────────────────────
+  // Read completion state from localStorage (course-progress.js format)
+  function getCourseProgress(courseId) {
+    try {
+      var raw = localStorage.getItem('impactmojo_course_progress_' + courseId);
+      if (!raw) return 0;
+      var data = JSON.parse(raw);
+      return data.percentage || 0;
+    } catch (e) { return 0; }
+  }
+
+  // Lab/game completion tracked separately
+  function getStepCompletion(stepId) {
+    try {
+      var state = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      return state[stepId] === true;
+    } catch (e) { return false; }
+  }
+
+  function markStepComplete(stepId) {
+    try {
+      var state = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      state[stepId] = true;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (e) {}
+  }
+
+  // ── Pathway Progress Calculator ─────────────────────────────────────
+  function getPathwayProgress(pathwayId) {
+    var pw = PATHWAYS[pathwayId];
+    if (!pw) return { completed: 0, total: 0, percentage: 0, steps: [], currentStep: null, milestones: [] };
+
+    var total = pw.steps.length;
+    var completed = 0;
+    var stepStates = [];
+    var currentStep = null;
+
+    pw.steps.forEach(function (step) {
+      var done = false;
+      if (step.courseId) {
+        done = getCourseProgress(step.courseId) >= 100;
+      } else {
+        done = getStepCompletion(step.id);
+      }
+      if (done) completed++;
+      else if (!currentStep) currentStep = step;
+      stepStates.push({ id: step.id, title: step.title, type: step.type, done: done });
+    });
+
+    // Calculate milestone states
+    var milestoneStates = [];
+    pw.milestones.forEach(function (m) {
+      var stepIdx = pw.steps.findIndex(function (s) { return s.id === m.afterStep; });
+      var allDone = stepIdx >= 0 && stepStates.slice(0, stepIdx + 1).every(function (s) { return s.done; });
+      milestoneStates.push({ label: m.label, earned: allDone, credential: m.credential || false, afterStep: m.afterStep });
+    });
+
+    return {
+      completed: completed,
+      total: total,
+      percentage: total ? Math.round((completed / total) * 100) : 0,
+      steps: stepStates,
+      currentStep: currentStep,
+      milestones: milestoneStates
+    };
+  }
+
+  // ── Pathway Card Renderer ───────────────────────────────────────────
+  function renderPathwayCard(pathwayId) {
+    var pw = PATHWAYS[pathwayId];
+    if (!pw) return '';
+
+    var progress = getPathwayProgress(pathwayId);
+    var pct = progress.percentage;
+    var earnedMilestones = progress.milestones.filter(function (m) { return m.earned; }).length;
+
+    var stepIcons = { course: '&#x1F4D6;', lab: '&#x1F52C;', game: '&#x1F3AE;' };
+
+    var stepsHtml = progress.steps.map(function (s, i) {
+      var icon = stepIcons[s.type] || '&#x2022;';
+      var cls = s.done ? 'imx-pw-step-done' : 'imx-pw-step-pending';
+      return '<div class="imx-pw-step ' + cls + '">' +
+        '<span class="imx-pw-step-num">' + (i + 1) + '</span>' +
+        '<span class="imx-pw-step-icon">' + icon + '</span>' +
+        '<span class="imx-pw-step-title">' + s.title + '</span>' +
+        (s.done ? '<svg class="imx-pw-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#10B981" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>' : '') +
+      '</div>';
+    }).join('');
+
+    var milestonesHtml = progress.milestones.map(function (m) {
+      var cls = m.earned ? 'imx-pw-milestone-earned' : 'imx-pw-milestone-locked';
+      return '<span class="imx-pw-milestone ' + cls + '">' +
+        (m.earned ? '&#x2605; ' : '&#x2606; ') + m.label +
+        (m.credential ? ' (Credential)' : '') +
+      '</span>';
+    }).join('');
+
+    return '<div class="imx-pw-card" data-pathway="' + pathwayId + '" style="--pw-color:' + pw.color + ';">' +
+      '<div class="imx-pw-card-header">' +
+        '<div class="imx-pw-card-title">' + pw.name + '</div>' +
+        '<div class="imx-pw-card-track">' + pw.track + '</div>' +
+      '</div>' +
+      '<p class="imx-pw-card-desc">' + pw.description + '</p>' +
+      '<div class="imx-pw-card-audience"><strong>For:</strong> ' + pw.audience + '</div>' +
+      '<div class="imx-pw-progress-bar"><div class="imx-pw-progress-fill" style="width:' + pct + '%;background:' + pw.color + ';"></div></div>' +
+      '<div class="imx-pw-progress-label">' + pct + '% complete &middot; ' + progress.completed + '/' + progress.total + ' steps &middot; ' + earnedMilestones + ' milestones</div>' +
+      '<div class="imx-pw-steps">' + stepsHtml + '</div>' +
+      '<div class="imx-pw-milestones">' + milestonesHtml + '</div>' +
+      (progress.currentStep ? '<div class="imx-pw-next"><strong>Next:</strong> ' + progress.currentStep.title + '</div>' : '<div class="imx-pw-complete-badge" style="color:' + pw.color + ';">&#x2714; Pathway Complete!</div>') +
+    '</div>';
+  }
+
+  // ── Render All Pathways ─────────────────────────────────────────────
+  function renderPathways(containerId) {
+    var container = document.getElementById(containerId);
+    if (!container) return;
+
+    var html = '';
+    Object.keys(PATHWAYS).forEach(function (id) {
+      html += renderPathwayCard(id);
+    });
+    container.innerHTML = html;
+
+    // Add click-to-expand for step details
+    container.querySelectorAll('.imx-pw-card').forEach(function (card) {
+      var steps = card.querySelector('.imx-pw-steps');
+      if (steps) {
+        steps.style.display = 'none';
+        card.querySelector('.imx-pw-card-header').style.cursor = 'pointer';
+        card.querySelector('.imx-pw-card-header').addEventListener('click', function () {
+          steps.style.display = steps.style.display === 'none' ? 'block' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Pathway Recommendation ──────────────────────────────────────────
+  // Returns sorted pathways based on existing progress (most started first)
+  function recommendPathways() {
+    var scored = Object.keys(PATHWAYS).map(function (id) {
+      var p = getPathwayProgress(id);
+      return { id: id, pathway: PATHWAYS[id], progress: p, score: p.percentage > 0 && p.percentage < 100 ? 100 + p.percentage : p.percentage };
+    });
+    scored.sort(function (a, b) { return b.score - a.score; });
+    return scored;
+  }
+
+  // ── Inject Pathway Progress into Track Modal ────────────────────────
+  function enhanceTrackModal() {
+    var origOpen = window.IMPACTMOJO && window.IMPACTMOJO.openTrack;
+    if (!origOpen) return;
+
+    window.IMPACTMOJO.openTrack = function (trackName) {
+      origOpen(trackName);
+
+      // Find pathways for this track
+      var trackPathways = Object.keys(PATHWAYS).filter(function (id) {
+        return PATHWAYS[id].track === trackName;
+      });
+      if (!trackPathways.length) return;
+
+      // Inject pathway progress into modal
+      var modal = document.getElementById('imxTrackModal');
+      if (!modal) return;
+      var body = modal.querySelector('.modal-body');
+      if (!body) return;
+
+      // Remove old pathway section if exists
+      var old = body.querySelector('.imx-pw-modal-section');
+      if (old) old.remove();
+
+      var section = document.createElement('div');
+      section.className = 'imx-pw-modal-section';
+      section.innerHTML = '<div style="margin-top:1.5rem;padding-top:1rem;border-top:1px solid var(--border-color);">' +
+        '<div style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-muted);font-weight:600;margin-bottom:0.75rem;">Learning Pathways</div>' +
+        '<div id="imxModalPathways"></div>' +
+      '</div>';
+      body.appendChild(section);
+
+      var html = '';
+      trackPathways.forEach(function (id) {
+        var pw = PATHWAYS[id];
+        var p = getPathwayProgress(id);
+        html += '<div style="padding:0.75rem;background:var(--hover-bg);border-radius:8px;margin-bottom:0.5rem;">' +
+          '<div style="display:flex;justify-content:space-between;align-items:center;">' +
+            '<div><strong style="font-size:0.9rem;">' + pw.name + '</strong>' +
+            '<div style="font-size:0.75rem;color:var(--text-muted);">' + pw.audience + '</div></div>' +
+            '<span style="font-size:0.8rem;font-weight:600;color:' + pw.color + ';">' + p.percentage + '%</span>' +
+          '</div>' +
+          '<div style="height:3px;background:var(--border-color);border-radius:2px;margin-top:0.5rem;"><div style="height:100%;border-radius:2px;background:' + pw.color + ';width:' + p.percentage + '%;transition:width 0.3s;"></div></div>' +
+          '<div style="display:flex;gap:0.3rem;flex-wrap:wrap;margin-top:0.5rem;">' +
+            p.milestones.map(function (m) {
+              return '<span style="font-size:0.65rem;padding:0.15rem 0.4rem;border-radius:10px;background:' + (m.earned ? pw.color + '20' : 'var(--hover-bg)') + ';color:' + (m.earned ? pw.color : 'var(--text-muted)') + ';font-weight:600;">' + (m.earned ? '&#x2605; ' : '&#x2606; ') + m.label + '</span>';
+            }).join('') +
+          '</div>' +
+        '</div>';
+      });
+      section.querySelector('#imxModalPathways').innerHTML = html;
+    };
+  }
+
+  // ── Init ────────────────────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', function () {
+    // Enhance track modal with pathway progress
+    enhanceTrackModal();
+
+    // Render pathways section if container exists (for dedicated page)
+    renderPathways('pathwaysContainer');
+
+    // Inject pathway progress summary into homepage track cards
+    document.querySelectorAll('.imx-track-card[data-track]').forEach(function (card) {
+      var trackName = card.getAttribute('data-track');
+      var trackPathways = Object.keys(PATHWAYS).filter(function (id) {
+        return PATHWAYS[id].track === trackName;
+      });
+      if (!trackPathways.length) return;
+
+      // Show first pathway progress on card
+      var pw = PATHWAYS[trackPathways[0]];
+      var p = getPathwayProgress(trackPathways[0]);
+      if (p.percentage === 0) return;
+
+      var existing = card.querySelector('.imx-pw-card-mini');
+      if (existing) return;
+
+      var mini = document.createElement('div');
+      mini.className = 'imx-pw-card-mini';
+      mini.innerHTML = '<div style="font-size:0.7rem;font-weight:600;color:' + pw.color + ';">' + pw.name + '</div>' +
+        '<div style="display:flex;gap:0.3rem;margin-top:0.25rem;">' +
+        p.milestones.map(function (m) {
+          return '<span style="font-size:0.6rem;color:' + (m.earned ? pw.color : 'var(--text-muted)') + ';">' + (m.earned ? '&#x2605;' : '&#x2606;') + '</span>';
+        }).join('') +
+        '</div>';
+      card.appendChild(mini);
+    });
+  });
+
+  // ── Public API ──────────────────────────────────────────────────────
+  window.IMPACTMOJO = window.IMPACTMOJO || {};
+  window.IMPACTMOJO.pathways = {
+    PATHWAYS: PATHWAYS,
+    getPathwayProgress: getPathwayProgress,
+    renderPathways: renderPathways,
+    renderPathwayCard: renderPathwayCard,
+    recommendPathways: recommendPathways,
+    markStepComplete: markStepComplete
+  };
+})();


### PR DESCRIPTION
## Summary
- **5 curated pathways**: MEL Practitioner, Data Analyst, Dev Economist, Governance Scholar, Health & Comms Specialist
- Each pathway has ordered steps (courses → labs → games), milestone badges, and a final pathway credential
- Reads existing course-progress.js localStorage data for automatic progress tracking
- Visual pathway cards with progress bars, step checklists, earned/locked milestones
- Pathway recommendation engine (prioritizes in-progress pathways)
- Enhances track modal with pathway progress section
- New homepage section between tracks and quiz

Closes #28

## Test plan
- [ ] Verify pathways section renders on homepage with all 5 pathways
- [ ] Verify click-to-expand shows step details
- [ ] Verify course progress from localStorage reflects in pathway progress
- [ ] Verify track modal shows pathway progress when opened
- [ ] Verify milestone badges show earned/locked states correctly

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk