### PR TITLE
Fix malformed img tags in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8347,7 +8347,7 @@ body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-m
 <nav class="nav-container">
 <a class="logo-container" href="#">
 <div class="logo-svg">
-<img alt="ImpactMojo logo" src="assets/images/ImpactMojo%20Logo.png" style="width:48px;height:48px;border-radius:8px;object-fit:contain;display:block;"/ width="48" height="48" fetchpriority="high">
+<img alt="ImpactMojo logo" src="assets/images/ImpactMojo%20Logo.png" style="width:48px;height:48px;border-radius:8px;object-fit:contain;display:block;" width="48" height="48" fetchpriority="high">
 </div>
 <div class="logo-text">
 <div class="logo-main">ImpactMojo</div>
@@ -10283,7 +10283,7 @@ body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-m
 <!-- Vandana Soni -->
 <div class="creator-box" style="margin: 0;">
 <div class="creator-photo">
-<img alt="Varna Sri Raman" src="assets/images/varna-photo.jpg" style="width:120px;height:120px;border-radius:50%;object-fit:cover;display:block;"/ width="120" height="120" loading="lazy">
+<img alt="Varna Sri Raman" src="assets/images/varna-photo.jpg" style="width:120px;height:120px;border-radius:50%;object-fit:cover;display:block;" width="120" height="120" loading="lazy">
 </div>
 <h3>Varna Sri Raman</h3>
 <p class="title">Founder and Lead of Learning Design &amp; Impact</p>
@@ -10319,7 +10319,7 @@ body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-m
 </div>
 </div><div class="creator-box" style="margin: 0;">
 <div class="creator-photo">
-<img alt="Vandana Soni" src="assets/images/vandana-photo.jpeg" style="width:120px;height:120px;border-radius:50%;object-fit:cover;display:block;"/ width="120" height="120" loading="lazy">
+<img alt="Vandana Soni" src="assets/images/vandana-photo.jpeg" style="width:120px;height:120px;border-radius:50%;object-fit:cover;display:block;" width="120" height="120" loading="lazy">
 </div>
 <h3>Vandana Soni</h3>
 <p class="title">Co-Founder and Lead of Partnerships &amp; Programmes</p>


### PR DESCRIPTION
## Summary
- Fixed 3 `<img>` tags where `width`, `height`, and `loading`/`fetchpriority` attributes were placed after a misplaced self-closing slash (`"/`), making them invalid HTML
- Affected: logo image (line 8350), Varna photo (line 10286), Vandana photo (line 10322)

## Test plan
- [ ] Verify images render correctly with proper dimensions
- [ ] Run HTML validator — no more attribute-after-slash warnings

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk