### PR TITLE
Improve page load performance: async fonts, lazy loading

### DIFF
--- a/about.html
+++ b/about.html
@@ -145,7 +145,8 @@ window.addEventListener('pageshow', function(event) {
 <!-- Google Fonts - Inter & Poppins -->
 <link href="https://fonts.googleapis.com" rel="preconnect">
 <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Poppins:wght@600;700;800&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Poppins:wght@600;700;800&amp;display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+<noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Poppins:wght@600;700;800&amp;display=swap" rel="stylesheet"></noscript>
 
 <style>
 /* ========================================
@@ -2087,7 +2088,7 @@ div[class*="acsb"],
                 </div>
                 <div class="team-card">
                     <div class="team-avatar">
-                        <img src="assets/images/team/vandana.jpeg" alt="Vandana Soni">
+                        <img src="assets/images/team/vandana.jpeg" alt="Vandana Soni" width="120" height="120" loading="lazy">
                     </div>
                     <h4>Vandana Soni</h4>
                     <div class="team-role">Co-Founder &amp; Lead of Partnerships &amp; Programmes</div>

--- a/catalog.html
+++ b/catalog.html
@@ -160,7 +160,8 @@ window.addEventListener('pageshow', function(event) {
 <!-- Google Fonts - Inter & Poppins -->
 <link href="https://fonts.googleapis.com" rel="preconnect">
 <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Poppins:wght@600;700;800&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Poppins:wght@600;700;800&amp;display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+<noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Poppins:wght@600;700;800&amp;display=swap" rel="stylesheet"></noscript>
 
 <style>
 /* ========================================


### PR DESCRIPTION
## Summary
- **about.html & catalog.html**: Convert blocking Google Fonts `<link>` to non-render-blocking using `media="print" onload="this.media='all'"` pattern (matching index.html)
- **about.html**: Add `loading="lazy"` and explicit `width`/`height` to team photo to prevent layout shift (CLS)

## Test plan
- [ ] Verify fonts still load correctly on about and catalog pages
- [ ] Verify team photo renders with correct dimensions
- [ ] Check no FOUT (flash of unstyled text) issues

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk