### PR TITLE
Improve challenges page: theme selector, Formspree, consistent layout

### DIFF
--- a/challenges.html
+++ b/challenges.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -56,40 +56,115 @@ body {
     color: var(--text-primary);
     line-height: 1.6;
     min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
+a { color: var(--accent-color); text-decoration: none; transition: color 0.25s; }
+a:hover { color: var(--accent-hover); }
 
 /* ---- Header ---- */
-.ch-header {
-    position: sticky; top: 0; z-index: 100;
-    background: rgba(15, 23, 42, 0.95);
-    backdrop-filter: blur(12px);
+.site-header {
+    position: sticky; top: 0; z-index: 1000;
+    background: var(--primary-bg);
     border-bottom: 1px solid var(--border-color);
-    padding: 0.75rem 2rem;
-    display: flex; align-items: center; gap: 1rem;
+    backdrop-filter: blur(12px);
 }
-[data-theme="light"] .ch-header { background: rgba(255,255,255,0.95); }
+.nav-container {
+    max-width: 1280px; margin: 0 auto; padding: 0 24px;
+    height: 64px; display: flex; align-items: center;
+    justify-content: space-between; gap: 24px;
+}
+.logo {
+    display: flex; align-items: center; gap: 10px;
+    text-decoration: none; color: var(--text-primary); flex-shrink: 0;
+}
+.logo-icon { height: 36px; width: auto; }
+.logo-text-wrap { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-text { font-family: 'Poppins', sans-serif; font-weight: 700; font-size: 1.15rem; color: var(--text-primary); }
+.logo-tagline { font-size: 0.7rem; color: var(--text-muted); font-weight: 400; }
 
-.ch-header-logo {
-    display: flex; align-items: center; gap: 0.5rem;
-    text-decoration: none; color: var(--text-primary);
-    font-family: 'Poppins', sans-serif; font-weight: 700; font-size: 1.1rem;
+.nav-links { display: flex; align-items: center; gap: 8px; }
+.nav-link {
+    padding: 6px 14px; font-size: 0.9rem; font-weight: 500;
+    color: var(--text-secondary); border-radius: 8px;
+    transition: all 0.25s; white-space: nowrap; text-decoration: none;
 }
-.ch-header-logo img { width: 32px; height: 32px; border-radius: 6px; }
+.nav-link:hover { color: var(--text-primary); background: var(--hover-bg); }
+.nav-link.active { color: var(--accent-color); background: rgba(14, 165, 233, 0.1); }
 
-.ch-header-nav { display: flex; align-items: center; gap: 1rem; margin-left: auto; }
-.ch-header-nav a {
-    color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;
-    font-weight: 500; transition: color 0.2s;
-}
-.ch-header-nav a:hover { color: var(--accent-color); }
+.nav-actions { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
 
-.ch-back-btn {
-    display: inline-flex; align-items: center; gap: 0.4rem;
-    color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;
-    padding: 0.4rem 0.75rem; border-radius: 8px; border: 1px solid var(--border-color);
-    transition: all 0.2s;
+.theme-selector {
+    display: flex; gap: 4px; background: var(--hover-bg);
+    border: 1px solid var(--border-color); border-radius: 10px; padding: 4px;
 }
-.ch-back-btn:hover { border-color: var(--accent-color); color: var(--accent-color); }
+.theme-btn {
+    background: transparent; border: none; color: var(--text-secondary);
+    padding: 8px; border-radius: 6px; cursor: pointer;
+    transition: all 0.2s ease; display: flex; align-items: center;
+    justify-content: center; width: 36px; height: 36px;
+}
+.theme-btn:hover { background: var(--hover-bg); color: var(--text-primary); }
+.theme-btn.active { background: var(--accent-color); color: white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.theme-btn svg { width: 18px; height: 18px; }
+
+.mobile-menu-toggle {
+    display: none; background: none; border: none;
+    color: var(--text-primary); cursor: pointer; padding: 4px;
+}
+
+/* Mobile nav overlay */
+.mobile-nav-overlay {
+    display: none; position: fixed; inset: 0;
+    background: rgba(0,0,0,0.5); z-index: 999;
+}
+.mobile-nav-overlay.active { display: block; }
+.mobile-nav-panel {
+    display: none; position: fixed; top: 0; right: 0; bottom: 0;
+    width: 280px; background: var(--primary-bg);
+    border-left: 1px solid var(--border-color); z-index: 1001;
+    padding: 24px; flex-direction: column; gap: 8px; overflow-y: auto;
+}
+.mobile-nav-panel.active { display: flex; }
+.mobile-nav-panel .nav-link { display: block; padding: 12px 16px; font-size: 1rem; }
+.mobile-nav-close {
+    align-self: flex-end; background: none; border: none;
+    color: var(--text-primary); cursor: pointer; padding: 4px; margin-bottom: 16px;
+}
+
+@media (max-width: 900px) {
+    .nav-links, .nav-actions { display: none; }
+    .mobile-menu-toggle { display: flex; }
+}
+
+/* ---- Footer ---- */
+.footer {
+    margin-top: auto; background: var(--secondary-bg);
+    border-top: 1px solid var(--border-color); padding: 48px 24px 24px;
+}
+.footer-content { max-width: 1280px; margin: 0 auto; }
+.footer-grid {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 32px; margin-bottom: 32px;
+}
+.footer-section h4 {
+    font-family: 'Poppins', sans-serif; font-size: 0.95rem;
+    font-weight: 700; color: var(--text-primary); margin-bottom: 12px;
+}
+.footer-section ul { list-style: none; }
+.footer-section li { margin-bottom: 8px; }
+.footer-section a { font-size: 0.88rem; color: var(--text-secondary); transition: color 0.25s; text-decoration: none; }
+.footer-section a:hover { color: var(--accent-color); }
+.footer-bottom { border-top: 1px solid var(--border-color); padding-top: 24px; text-align: center; }
+.footer-bottom p { font-size: 0.82rem; color: var(--text-muted); margin-bottom: 4px; }
+.footer-bottom a { color: var(--accent-color); text-decoration: none; }
+
+@media (max-width: 768px) {
+    .footer-grid { grid-template-columns: repeat(2, 1fr); gap: 24px; }
+}
+@media (max-width: 480px) {
+    .footer-grid { grid-template-columns: 1fr; }
+}
 
 /* ---- Hero ---- */
 .ch-hero {
@@ -353,13 +428,6 @@ body {
 .ch-empty-icon { font-size: 3rem; margin-bottom: 1rem; opacity: 0.5; }
 .ch-empty-text { font-size: 1rem; }
 
-/* ---- Footer ---- */
-.ch-footer {
-    text-align: center; padding: 2rem; border-top: 1px solid var(--border-color);
-    color: var(--text-muted); font-size: 0.8rem;
-}
-.ch-footer a { color: var(--accent-color); text-decoration: none; }
-
 /* ---- Responsive ---- */
 @media (max-width: 768px) {
     .ch-hero h1 { font-size: 1.6rem; }
@@ -367,25 +435,72 @@ body {
     .ch-detail { margin-top: 0; border-radius: 16px 16px 0 0; }
     .ch-detail-overlay { padding: 0; align-items: flex-end; }
     .ch-filters { padding: 0.75rem 1rem; }
-    .ch-header { padding: 0.75rem 1rem; }
 }
 </style>
 </head>
 <body>
 
 <!-- Header -->
-<header class="ch-header">
-    <a href="index.html" class="ch-header-logo">
-        <img src="assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="32" height="32">
-        <span>ImpactMojo</span>
-    </a>
-    <nav class="ch-header-nav">
-        <a href="index.html" class="ch-back-btn">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M19 12H5m7-7l-7 7 7 7"/></svg>
-            Back to Home
+<header class="site-header">
+    <nav class="nav-container">
+        <a href="/" class="logo">
+            <img src="/assets/images/ImpactMojo Logo.png" alt="ImpactMojo" class="logo-icon">
+            <div class="logo-text-wrap">
+                <span class="logo-text">ImpactMojo</span>
+                <span class="logo-tagline">Learn for Impact</span>
+            </div>
         </a>
+        <div class="nav-links">
+            <a href="/" class="nav-link">Home</a>
+            <a href="/catalog" class="nav-link">Catalog</a>
+            <a href="/handouts" class="nav-link">Handouts</a>
+            <a href="/dataverse" class="nav-link">Dataverse</a>
+            <a href="/challenges" class="nav-link active">Challenges</a>
+            <a href="/blog" class="nav-link">Blog</a>
+        </div>
+        <div class="nav-actions">
+            <div class="theme-selector" aria-label="Theme selection">
+                <button class="theme-btn" data-theme="system" title="System theme" aria-label="Use system theme">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+                </button>
+                <button class="theme-btn" data-theme="light" title="Light theme" aria-label="Use light theme">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+                </button>
+                <button class="theme-btn" data-theme="dark" title="Dark theme" aria-label="Use dark theme">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+                </button>
+            </div>
+        </div>
+        <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Menu">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+        </button>
     </nav>
 </header>
+
+<!-- Mobile Nav -->
+<div class="mobile-nav-overlay" id="mobileOverlay"></div>
+<div class="mobile-nav-panel" id="mobilePanel">
+    <button class="mobile-nav-close" id="mobileNavClose" aria-label="Close menu">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+    </button>
+    <a href="/" class="nav-link">Home</a>
+    <a href="/catalog" class="nav-link">Catalog</a>
+    <a href="/handouts" class="nav-link">Handouts</a>
+    <a href="/dataverse" class="nav-link">Dataverse</a>
+    <a href="/challenges" class="nav-link active">Challenges</a>
+    <a href="/blog" class="nav-link">Blog</a>
+    <div class="theme-selector" aria-label="Theme selection" style="margin-top:16px;">
+        <button class="theme-btn" data-theme="system" title="System theme" aria-label="Use system theme">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+        </button>
+        <button class="theme-btn" data-theme="light" title="Light theme" aria-label="Use light theme">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        </button>
+        <button class="theme-btn" data-theme="dark" title="Dark theme" aria-label="Use dark theme">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+    </div>
+</div>
 
 <!-- Hero -->
 <section class="ch-hero">
@@ -439,14 +554,101 @@ body {
 </div>
 
 <!-- Footer -->
-<footer class="ch-footer">
-    <p>Have a real case problem your organization wants learners to solve? <a href="mailto:hello@impactmojo.in">Submit a challenge</a></p>
-    <p style="margin-top: 0.5rem;">© ImpactMojo. All rights reserved. <a href="index.html">Back to Home</a></p>
+<footer class="footer">
+    <div class="footer-content">
+        <div class="footer-grid">
+            <div class="footer-section">
+                <h4>About ImpactMojo</h4>
+                <ul>
+                    <li><a href="/about">About Us</a></li>
+                    <li><a href="/community/community">Community</a></li>
+                    <li><a href="/#support-us">Support Us</a></li>
+                    <li><a href="/contact">Contact</a></li>
+                    <li><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener">GitHub</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Legal</h4>
+                <ul>
+                    <li><a href="/privacy-policy">Privacy Policy</a></li>
+                    <li><a href="/terms-of-service">Terms of Service</a></li>
+                    <li><a href="/disclaimer">Disclaimer</a></li>
+                    <li><a href="/grievance">Grievance Redressal</a></li>
+                    <li><a href="/refund-policy">Refund Policy</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Learn</h4>
+                <ul>
+                    <li><a href="/catalog">All Courses</a></li>
+                    <li><a href="/#labs">Labs</a></li>
+                    <li><a href="/#games">Games</a></li>
+                    <li><a href="/premium">Premium</a></li>
+                    <li><a href="/workshops">Workshops</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Resources</h4>
+                <ul>
+                    <li><a href="/handouts">Handouts</a></li>
+                    <li><a href="/bct-repository">NudgeKit</a></li>
+                    <li><a href="/dataverse">Dataverse</a></li>
+                    <li><a href="/challenges">Challenges</a></li>
+                    <li><a href="/blog">Blog</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+            <p>Released under MIT License. Supported by <a href="https://www.pinpointventures.in" target="_blank" rel="noopener">PinPoint Ventures</a></p>
+        </div>
+    </div>
 </footer>
 
-<!-- Supabase (optional — for cloud submissions) -->
+<!-- Supabase (for cloud submissions) -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
 <script src="js/challenges.js" defer></script>
 <script defer src="js/translate.js"></script>
+
+<!-- Theme & Mobile Menu -->
+<script>
+/* Theme */
+function getPreferredTheme() {
+    return localStorage.getItem('impactmojo-theme') || 'system';
+}
+function applyTheme(theme) {
+    var resolved = theme;
+    if (theme === 'system') {
+        resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+    }
+    document.documentElement.setAttribute('data-theme', resolved);
+    localStorage.setItem('impactmojo-theme', theme);
+    document.querySelectorAll('.theme-btn').forEach(function(btn) {
+        btn.classList.toggle('active', btn.getAttribute('data-theme') === theme);
+    });
+}
+applyTheme(getPreferredTheme());
+document.querySelectorAll('.theme-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        applyTheme(btn.getAttribute('data-theme'));
+    });
+});
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+    if (getPreferredTheme() === 'system') applyTheme('system');
+});
+
+/* Mobile Menu */
+(function() {
+    var toggle = document.getElementById('mobileMenuToggle');
+    var overlay = document.getElementById('mobileOverlay');
+    var panel = document.getElementById('mobilePanel');
+    var closeBtn = document.getElementById('mobileNavClose');
+    function openMenu() { overlay.classList.add('active'); panel.classList.add('active'); }
+    function closeMenu() { overlay.classList.remove('active'); panel.classList.remove('active'); }
+    if (toggle) toggle.addEventListener('click', openMenu);
+    if (closeBtn) closeBtn.addEventListener('click', closeMenu);
+    if (overlay) overlay.addEventListener('click', closeMenu);
+})();
+</script>
 </body>
 </html>

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -301,6 +301,8 @@
     }
 
     // ---- Submit ----
+    var FORMSPREE_URL = 'https://formspree.io/f/xpwdvgzp';
+
     function submitChallenge(challengeId) {
         var textarea = document.getElementById('challengeResponse');
         if (!textarea) return;
@@ -311,6 +313,7 @@
             return;
         }
 
+        var ch = challenges.find(function (c) { return c.id === challengeId; });
         var btn = document.getElementById('submitChallengeBtn');
         if (btn) {
             btn.disabled = true;
@@ -329,7 +332,23 @@
         delete drafts[challengeId];
         saveDrafts();
 
-        // Try Supabase sync
+        // Submit to Formspree (email notification)
+        var formData = new FormData();
+        formData.append('_subject', 'Challenge Submission: ' + (ch ? ch.title : challengeId));
+        formData.append('challenge_id', challengeId);
+        formData.append('challenge_title', ch ? ch.title : '');
+        formData.append('challenge_track', ch ? ch.trackLabel : '');
+        formData.append('challenge_difficulty', ch ? ch.difficulty : '');
+        formData.append('submission_text', text);
+        formData.append('submitted_at', new Date().toISOString());
+
+        fetch(FORMSPREE_URL, {
+            method: 'POST',
+            body: formData,
+            headers: { 'Accept': 'application/json' }
+        }).catch(function () { /* silent — localStorage is primary fallback */ });
+
+        // Sync to Supabase (DB record)
         syncSubmission(challengeId, text);
 
         // Show success


### PR DESCRIPTION
## Summary
- Add 3-button theme selector (system/light/dark) matching dataverse and other resource pages
- Switch challenge submissions to Formspree (`xpwdvgzp`) for email notifications, keep Supabase sync for DB records
- Replace minimal header with full site navigation (logo + tagline, nav links, mobile hamburger menu)
- Replace minimal footer with full 4-column footer matching dataverse

## Test plan
- [ ] Verify theme toggle works (system/light/dark) and persists across page reload
- [ ] Submit a challenge and confirm it arrives in Formspree
- [ ] Check mobile nav hamburger menu opens/closes correctly
- [ ] Compare header/footer with dataverse page for visual consistency

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk