### PR TITLE
Add public Transparency & Impact Data dashboard

### DIFF
--- a/admin/analytics.html
+++ b/admin/analytics.html
@@ -3,9 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Analytics Dashboard | ImpactMojo Admin</title>
-<meta name="robots" content="noindex, nofollow">
+<title>Transparency & Impact Data | ImpactMojo</title>
+<meta name="description" content="ImpactMojo's open transparency dashboard. Explore our reach, content metrics, feature adoption, and platform growth data.">
 <link rel="icon" href="/assets/images/favicon.png" type="image/png">
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -260,7 +269,7 @@ body {
         <a href="/" class="admin-logo">
             <img src="/assets/images/ImpactMojo Logo.png" alt="ImpactMojo">
             <span class="admin-logo-text">ImpactMojo</span>
-            <span class="admin-badge">Admin</span>
+            <span class="admin-badge" style="background: var(--secondary-accent);">Transparency</span>
         </a>
         <div class="admin-actions">
             <a href="/">Back to Site</a>
@@ -273,13 +282,20 @@ body {
 
 <main class="admin-main">
 
-    <!-- Data Source -->
-    <div class="data-source-bar">
+    <!-- Transparency Intro -->
+    <div style="text-align:center; padding:32px 24px 8px; max-width:720px; margin:0 auto;">
+        <h1 style="font-family:'Poppins',sans-serif; font-size:1.8rem; font-weight:700; margin-bottom:8px; background:var(--gradient-primary); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text;">Transparency & Impact Data</h1>
+        <p style="font-size:0.95rem; color:var(--text-secondary); line-height:1.7;">
+            ImpactMojo is built in the open. This page shares our platform metrics, content reach, and feature adoption data. All legacy data is reconstructed from our website; live analytics are pulled from Google Analytics 4 when connected.
+        </p>
+    </div>
+
+    <!-- Admin Controls (hidden by default, toggle with ?admin) -->
+    <div class="data-source-bar" id="adminControls" style="display:none;">
         <label>Data Source:</label>
-        <input type="text" id="webAppUrl" placeholder="Paste your Apps Script Web App URL here (or paste JSON below)">
+        <input type="text" id="webAppUrl" placeholder="Apps Script Web App URL">
         <button class="btn btn-primary" onclick="fetchFromWebApp()">Fetch Live Data</button>
-        <button class="btn btn-secondary" onclick="loadLegacyOnly()">Load Legacy Only</button>
-        <span id="dataStatus"><span class="status-dot offline"></span> No data loaded</span>
+        <span id="dataStatus"><span class="status-dot live"></span> Legacy data loaded</span>
     </div>
 
     <!-- KPI Cards -->
@@ -352,16 +368,27 @@ body {
         </table>
     </div>
 
-    <!-- JSON Paste Area -->
-    <div class="section-header">
-        <h2 class="section-title"><span class="icon">&#x1f4cb;</span> Manual Data Import</h2>
+    <!-- Admin: JSON Paste Area (hidden unless ?admin) -->
+    <div id="jsonPasteSection" style="display:none;">
+        <div class="section-header">
+            <h2 class="section-title"><span class="icon">&#x1f4cb;</span> Manual Data Import</h2>
+        </div>
+        <p style="font-size:0.85rem; color:var(--text-secondary); margin-bottom:12px;">
+            Paste the JSON export from your Google Sheet (Apps Script > Export Summary as JSON) to load live GA4 data.
+        </p>
+        <textarea class="json-paste" id="jsonPaste" placeholder='Paste JSON from Apps Script "Export Summary as JSON" here...'></textarea>
+        <div style="margin-top:8px;">
+            <button class="btn btn-primary" onclick="loadFromPaste()">Load Pasted Data</button>
+        </div>
     </div>
-    <p style="font-size:0.85rem; color:var(--text-secondary); margin-bottom:12px;">
-        Paste the JSON export from your Google Sheet (Apps Script > Export Summary as JSON) to load live GA4 data.
-    </p>
-    <textarea class="json-paste" id="jsonPaste" placeholder='Paste JSON from Apps Script "Export Summary as JSON" here...'></textarea>
-    <div style="margin-top:8px;">
-        <button class="btn btn-primary" onclick="loadFromPaste()">Load Pasted Data</button>
+
+    <!-- Footer -->
+    <div style="text-align:center; padding:48px 24px 24px; border-top:1px solid var(--border-color); margin-top:48px;">
+        <p style="font-size:0.82rem; color:var(--text-muted);">&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+        <p style="font-size:0.82rem; color:var(--text-muted); margin-top:4px;">
+            Released under MIT License. <a href="/" style="color:var(--accent-color); text-decoration:none;">Back to ImpactMojo</a>
+            &middot; <a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener" style="color:var(--accent-color); text-decoration:none;">GitHub</a>
+        </p>
     </div>
 </main>
 
@@ -679,6 +706,12 @@ document.getElementById('themeToggle').addEventListener('click', function() {
     var saved = localStorage.getItem('impactmojo-theme');
     if (saved === 'light') document.documentElement.setAttribute('data-theme', 'light');
 })();
+
+// Show admin controls if ?admin in URL
+if (window.location.search.indexOf('admin') > -1) {
+    document.getElementById('adminControls').style.display = '';
+    document.getElementById('jsonPasteSection').style.display = '';
+}
 
 // Initial render with legacy data
 render();

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -1214,6 +1214,7 @@ body.printing-technique .copy-toast { display: none !important; }
                     <li><a href="/#support-us">Support Us</a></li>
                     <li><a href="/contact">Contact</a></li>
                     <li><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener">GitHub</a></li>
+                    <li><a href="/admin/analytics">Transparency</a></li>
                 </ul>
             </div>
             <div class="footer-section">

--- a/challenges.html
+++ b/challenges.html
@@ -574,6 +574,7 @@ a:hover { color: var(--accent-hover); }
                     <li><a href="/#support-us">Support Us</a></li>
                     <li><a href="/contact">Contact</a></li>
                     <li><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener">GitHub</a></li>
+                    <li><a href="/admin/analytics">Transparency</a></li>
                 </ul>
             </div>
             <div class="footer-section">

--- a/dataverse.html
+++ b/dataverse.html
@@ -1389,6 +1389,7 @@ img { max-width: 100%; display: block; }
                     <li><a href="/#support-us">Support Us</a></li>
                     <li><a href="/contact">Contact</a></li>
                     <li><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener">GitHub</a></li>
+                    <li><a href="/admin/analytics">Transparency</a></li>
                 </ul>
             </div>
             <div class="footer-section">

--- a/handouts.html
+++ b/handouts.html
@@ -1117,6 +1117,7 @@ body.dark-mode .v3-blob-4 { background: radial-gradient(circle, rgba(245, 158, 1
                     <li><a href="/#support-us">Support Us</a></li>
                     <li><a href="/contact">Contact</a></li>
                     <li><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener">GitHub (Open Source)</a></li>
+                    <li><a href="/admin/analytics">Transparency</a></li>
                 </ul>
             </div>
             

--- a/index.html
+++ b/index.html
@@ -12737,6 +12737,7 @@ body:has(.imx-tour-overlay.active) .nav-links > li.has-dropdown.open .dropdown-m
 <li><a href="#support-us">Support Us</a></li>
 <li><a href='/contact'>Contact</a></li>
 <li><a href="https://github.com/Varnasr/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub (Open Source)</a></li>
+<li><a href="/admin/analytics">Transparency</a></li>
 </ul>
 </div>
 <div class="footer-section">

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,6 @@
 # Robots.txt for ImpactMojo
 User-agent: *
 Allow: /
-Disallow: /admin/
+Disallow: /admin/analytics-appscript.js
 
 Sitemap: https://www.impactmojo.in/sitemap.xml

--- a/testimonials.html
+++ b/testimonials.html
@@ -489,6 +489,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                 <li style="margin-bottom: 0.4rem;"><a href="/#support-us" style="color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;">Support Us</a></li>
                 <li style="margin-bottom: 0.4rem;"><a href="/contact" style="color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;">Contact</a></li>
                 <li style="margin-bottom: 0.4rem;"><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener noreferrer" style="color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;">GitHub (Open Source)</a></li>
+                <li><a href="/admin/analytics">Transparency</a></li>
             </ul>
         </div>
         <div>

--- a/updates.html
+++ b/updates.html
@@ -579,6 +579,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                 <li style="margin-bottom: 0.4rem;"><a href="/#support-us" style="color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;">Support Us</a></li>
                 <li style="margin-bottom: 0.4rem;"><a href="/contact" style="color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;">Contact</a></li>
                 <li style="margin-bottom: 0.4rem;"><a href="https://github.com/Varnasr/ImpactMojo" target="_blank" rel="noopener noreferrer" style="color: var(--text-secondary); text-decoration: none; font-size: 0.85rem;">GitHub (Open Source)</a></li>
+                <li><a href="/admin/analytics">Transparency</a></li>
             </ul>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Public transparency page at `/admin/analytics` showing platform reach, content metrics, and feature adoption
- All legacy data (100+ metrics from 41 courses, 11 games, 15 tools) baked in and visible immediately
- Admin controls (GA4 Web App connection, JSON paste) hidden behind `?admin` query param
- "Transparency" link added to footer About column on 7 pages with 4-column footer
- Apps Script (`analytics-appscript.js`) available for connecting GA4 live data via Google Sheets

## Test plan
- [ ] Visit `/admin/analytics` — verify all charts, tables, KPIs render with legacy data
- [ ] Visit `/admin/analytics?admin` — verify admin controls appear
- [ ] Check footer on index, dataverse, challenges, handouts pages for Transparency link
- [ ] Toggle light/dark theme on the dashboard

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk