### PR TITLE
Add GA4 credentials to transparency page

### DIFF
--- a/admin/analytics.html
+++ b/admin/analytics.html
@@ -702,8 +702,8 @@ var ga4Data = null;
 // CONFIG — Update these after Google Cloud setup
 // ============================================================
 var GA4_CONFIG = {
-    CLIENT_ID: '',  // Your OAuth Client ID (e.g., '123456789.apps.googleusercontent.com')
-    PROPERTY_ID: '',  // Your GA4 numeric Property ID (e.g., '123456789')
+    CLIENT_ID: '904414464711-crf45sfa1neo3hf16ekbn5jv2qdjlhtr.apps.googleusercontent.com',
+    PROPERTY_ID: '514001382',
     CACHE_KEY: 'impactmojo_ga4_cache',
     CACHE_HOURS: 24  // Auto-refresh after this many hours
 };


### PR DESCRIPTION
## Summary
- Configure GA4 OAuth Client ID and Property ID in the transparency page
- Enables live GA4 analytics data loading when admins sign in with Google

## Test plan
- [ ] Visit /admin/analytics and click "Sign in with Google"
- [ ] Verify GA4 data loads after OAuth consent

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk