### PR TITLE
Sync package-lock.json to fix CI failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@axe-core/cli": "^4.8.0",
+        "@axe-core/puppeteer": "^4.9.0",
         "axe-core": "^4.9.0",
         "http-server": "^14.1.1",
         "puppeteer": "^24.15.0"
@@ -34,6 +35,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@axe-core/puppeteer": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.11.1.tgz",
+      "integrity": "sha512-xXnHGmVtPxGGf9FCtUetY9sptsR/bbQypMODuBenYyufhX2XNgsEbmx8u0WyL75Ft1IGUuBaLB4u2m7CrM63jQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=1.10.0"
       }
     },
     "node_modules/@axe-core/webdriverjs": {


### PR DESCRIPTION
## Summary
- `@axe-core/puppeteer` was added to `package.json` but `package-lock.json` was never regenerated
- This caused `npm ci` to fail in both the **CI** (axe-core job) and **Accessibility Tests** workflows on every push
- Fix: ran `npm install` to sync the lock file

## Test plan
- [ ] Verify CI axe-core job passes
- [ ] Verify Accessibility Tests (axe-core) workflow passes

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk