### PR TITLE
Move dot navigation inward to clear sidebar widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -4005,7 +4005,7 @@ function toggleMobileDropdown(event, element) {
 /* Floating Section Navigator - right-edge dot nav */
 .section-nav-float {
     position: fixed;
-    right: 1rem;
+    right: 4rem;
     top: 50%;
     transform: translateY(-50%);
     display: flex;


### PR DESCRIPTION
## Summary
- Moved floating section navigator dots from `right: 1rem` to `right: 4rem`
- Prevents overlap with accessibility widget, PDF button, and chatbot FAB on the right edge

## Test plan
- [ ] Verify dots no longer overlap with sidebar buttons
- [ ] Verify dot nav labels still appear on hover

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk