### PR TITLE
Fix account page spinner and org dashboard tier check

### DIFF
--- a/account.html
+++ b/account.html
@@ -3026,8 +3026,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
     }, 10000);
 
-    // Wait for auth to fully initialize (handles OAuth callback tokens in URL)
+    // Initialize auth and wait for it to fully resolve (handles OAuth callback tokens in URL)
     try {
+        await ImpactMojoAuth.init();
         await ImpactMojoAuth.waitForAuthReady();
     } catch (e) {
         console.error('Auth ready wait failed:', e);

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -1125,7 +1125,8 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
                 return;
             }
 
-            var profile = ImpactMojoAuth.getProfile();
+            // Always fetch a fresh profile to get the latest subscription_tier from Supabase
+            var profile = await ImpactMojoAuth.fetchProfile();
             if (!profile || profile.subscription_tier !== 'organization') {
                 document.getElementById('authGate').style.display = 'block';
                 clearTimeout(safetyTimer);


### PR DESCRIPTION
## Summary
- **Account page endless spinner**: Added missing `ImpactMojoAuth.init()` call — without it, auth never initialized so the loading overlay never dismissed
- **Org dashboard not recognizing org tier**: Changed `getProfile()` to `fetchProfile()` so a fresh profile is always fetched from Supabase instead of using a stale cached version

## Test plan
- [ ] Verify account page loads without endless spinner
- [ ] Verify org dashboard recognizes organization tier from Supabase

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk