### PR TITLE
Add dual license: MIT for code, CC BY-NC-ND 4.0 for content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,35 +1,83 @@
-Creative Commons Attribution 4.0 International License (CC-BY-4.0)
+DUAL LICENSE
 
 Copyright (c) 2024-2026 ImpactMojo / Dr. Varna Sri Raman
+https://www.impactmojo.in
+
+This repository contains two types of material, each governed by a
+separate license:
+
+================================================================================
+1. SOURCE CODE — MIT License
+================================================================================
+
+Applies to: all files in js/, supabase/, netlify-resource-template/,
+and any .json configuration files, .css stylesheets, build scripts,
+and infrastructure code.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+
+================================================================================
+2. EDUCATIONAL CONTENT — CC BY-NC-ND 4.0
+   (Creative Commons Attribution-NonCommercial-NoDerivatives 4.0)
+================================================================================
+
+Applies to: all course materials in courses/, Handouts/, data/,
+all .html page content (text, curriculum, assessments, case studies,
+handout PDFs, challenge descriptions, podcast transcripts, blog posts),
+images in assets/images/, and any other written or multimedia
+educational content.
 
 You are free to:
 
-  Share - copy and redistribute the material in any medium or format for
-  any purpose, even commercially.
-
-  Adapt - remix, transform, and build upon the material for any purpose,
-  even commercially.
+  Share — copy and redistribute the material in any medium or format.
 
 Under the following terms:
 
-  Attribution - You must give appropriate credit, provide a link to the
-  license, and indicate if changes were made. You may do so in any
-  reasonable manner, but not in any way that suggests the licensor
-  endorses you or your use.
+  Attribution — You must give appropriate credit to ImpactMojo /
+  Dr. Varna Sri Raman, provide a link to the license, and indicate
+  if changes were made.
 
-  No additional restrictions - You may not apply legal terms or
-  technological measures that legally restrict others from doing
-  anything the license permits.
+  NonCommercial — You may NOT use the material for commercial purposes.
+  This includes hosting a competing platform, reselling courses, or
+  offering the content behind a paywall.
 
-Notices:
+  NoDerivatives — If you remix, transform, or build upon the material,
+  you may NOT distribute the modified material. You may adapt for
+  personal or internal organizational learning only.
 
-  You do not have to comply with the license for elements of the
-  material in the public domain or where your use is permitted by an
-  applicable exception or limitation.
+  Premium Content — Content gated behind subscription tiers
+  (Practitioner, Professional, Organization) is proprietary and
+  may NOT be redistributed, mirrored, or republished in any form
+  without explicit written permission from ImpactMojo.
 
-  No warranties are given. The license may not give you all of the
-  permissions necessary for your intended use. For example, other rights
-  such as publicity, privacy, or moral rights may limit how you use the
-  material.
+No additional restrictions — You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.
 
-Full license text: https://creativecommons.org/licenses/by/4.0/legalcode
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+
+================================================================================
+NOTICE
+================================================================================
+
+Forking this repository for the purpose of studying, learning from, or
+adapting the technical architecture (code) is encouraged.
+
+Forking this repository to redistribute, mirror, or republish the
+educational content — especially premium-gated content — is a
+violation of this license and may result in a DMCA takedown request.
+
+If in doubt, contact: hello@impactmojo.in

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ImpactMojo
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/f9e879bf-4792-42aa-96ea-c3a3b396f8b8/deploy-status)](https://app.netlify.com/sites/impactmojo/deploys)
-[![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+[![Code License: MIT](https://img.shields.io/badge/Code-MIT-green.svg)](LICENSE)
+[![Content License: CC BY-NC-ND 4.0](https://img.shields.io/badge/Content-CC_BY--NC--ND_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-nd/4.0/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![GitHub Issues](https://img.shields.io/github/issues/Varnasr/ImpactMojo)](https://github.com/Varnasr/ImpactMojo/issues)
 [![GitHub Wiki](https://img.shields.io/badge/docs-Wiki-blue)](https://github.com/Varnasr/ImpactMojo/wiki)
@@ -535,9 +536,18 @@ ImpactMojo operates on a "pay what you think is fair" model.
 
 ## License
 
-This project is released under the **Creative Commons Attribution 4.0 International (CC-BY-4.0)** license.
+This repository uses a **dual license**:
 
-Educational content is available for educational and non-commercial use. Educators are encouraged to adapt materials with appropriate attribution.
+| Component | License | What it covers |
+|-----------|---------|----------------|
+| **Source code** | MIT | All `.js`, `.css`, build scripts, Supabase functions, infrastructure code |
+| **Educational content** | CC BY-NC-ND 4.0 | Courses, handouts, assessments, case studies, blog posts, images |
+
+**You are welcome to** fork and reuse the technical architecture (code) for your own projects.
+
+**You may not** redistribute, mirror, or republish the educational content — especially premium-gated materials — without written permission. Violations may result in a DMCA takedown.
+
+See [LICENSE](LICENSE) for full terms.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace permissive CC-BY-4.0 with dual license protecting content from commercial redistribution
- Code (js/, supabase/, CSS, configs) licensed under MIT — forks can freely reuse
- Educational content (courses/, Handouts/, HTML content) under CC BY-NC-ND 4.0 — no commercial use, no derivatives
- Premium-gated content explicitly marked as proprietary
- Updated README badges and license section

## Test plan
- [ ] Verify LICENSE file renders correctly on GitHub
- [ ] Verify README badges display properly

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk