### PR TITLE
Fix login persistence across page refreshes and token refresh

### DIFF
--- a/account.html
+++ b/account.html
@@ -2996,8 +2996,15 @@ document.addEventListener('DOMContentLoaded', async function() {
     const loadingOverlay = document.getElementById('loadingOverlay');
 
     // Safety timeout in case auth never resolves — must be registered BEFORE await
-    setTimeout(function() {
+    setTimeout(async function() {
         if (loadingOverlay.style.display !== 'none' && !_accountPageReady) {
+            // Before giving up, check Supabase directly for a valid session
+            var timeoutSession = null;
+            try { timeoutSession = await ImpactMojoAuth.getSession(); } catch (_) {}
+            if (timeoutSession?.user) {
+                ImpactMojoAuth.user = timeoutSession.user;
+                try { await ImpactMojoAuth.fetchProfile(); } catch (_) {}
+            }
             loadingOverlay.style.display = 'none';
             if (!ImpactMojoAuth.isLoggedIn()) {
                 window.location.href = 'login.html';
@@ -3027,6 +3034,23 @@ document.addEventListener('DOMContentLoaded', async function() {
         updatePageData();
         updateSavedItemsDisplay();
     } else {
+        // Fallback: double-check with Supabase directly before giving up.
+        // This catches cases where onAuthStateChange missed a valid session
+        // (e.g. transient SIGNED_OUT during token refresh).
+        try {
+            var fallbackSession = await ImpactMojoAuth.getSession();
+            if (fallbackSession?.user) {
+                // Session exists — re-init auth state from this session
+                ImpactMojoAuth.user = fallbackSession.user;
+                try { await ImpactMojoAuth.fetchProfile(); } catch (_) {}
+                _accountPageReady = true;
+                loadingOverlay.style.display = 'none';
+                updatePageData();
+                updateSavedItemsDisplay();
+                ImpactMojoAuth.updateUI();
+                return;
+            }
+        } catch (_) { /* proceed with redirect */ }
         // Only redirect to login if auth is ready and user is truly not logged in
         window.location.href = 'login.html';
     }

--- a/js/auth.js
+++ b/js/auth.js
@@ -54,6 +54,7 @@ const ImpactMojoAuth = {
     _authReadyResolve: null,
     isSyncing: false,
     _initialSessionHadUser: false,
+    _processingAuthEvent: false,
 
     // Initialize auth and check session
     async init() {
@@ -72,6 +73,7 @@ const ImpactMojoAuth = {
                 console.log('Auth state changed:', event);
 
                 if (event === 'INITIAL_SESSION') {
+                    this._processingAuthEvent = true;
                     // Initial session check complete - set user if session exists
                     if (session?.user) {
                         this.user = session.user;
@@ -82,6 +84,7 @@ const ImpactMojoAuth = {
                         }
                         this._initialSessionHadUser = true;
                     }
+                    this._processingAuthEvent = false;
                     // Mark auth as ready BEFORE sync — sync is non-blocking
                     this.isAuthReady = true;
                     if (this._authReadyResolve) this._authReadyResolve();
@@ -98,12 +101,14 @@ const ImpactMojoAuth = {
                     if (this._initialSessionHadUser && this.user?.id === session.user.id) {
                         return;
                     }
+                    this._processingAuthEvent = true;
                     this.user = session.user;
                     try {
                         await this.fetchProfile();
                     } catch (e) {
                         console.error('Profile fetch failed during sign-in:', e);
                     }
+                    this._processingAuthEvent = false;
                     // If auth wasn't ready yet (OAuth callback), mark it ready now
                     if (!this.isAuthReady) {
                         this.isAuthReady = true;
@@ -114,7 +119,30 @@ const ImpactMojoAuth = {
                     this.syncAll().catch(function (e) {
                         console.error('Background sync failed:', e);
                     });
+                } else if (event === 'TOKEN_REFRESHED' && session?.user) {
+                    // Token was refreshed successfully — restore state if it was
+                    // cleared by a transient SIGNED_OUT during refresh
+                    this.user = session.user;
+                    this.updateUI();
                 } else if (event === 'SIGNED_OUT') {
+                    // Guard: ignore transient SIGNED_OUT fired while we are still
+                    // processing INITIAL_SESSION or SIGNED_IN (race during token refresh)
+                    if (this._processingAuthEvent) {
+                        console.warn('Ignoring transient SIGNED_OUT during auth processing');
+                        return;
+                    }
+                    // Double-check with Supabase before clearing state — avoids
+                    // reacting to stale events when a valid session still exists
+                    try {
+                        var check = await supabaseClient.auth.getSession();
+                        if (check?.data?.session?.user) {
+                            console.warn('SIGNED_OUT fired but session still valid — ignoring');
+                            this.user = check.data.session.user;
+                            this.updateUI();
+                            return;
+                        }
+                    } catch (_) { /* proceed with sign-out */ }
+
                     this.user = null;
                     this.profile = null;
                     if (!this.isAuthReady) {
@@ -783,6 +811,16 @@ const ImpactMojoAuth = {
     // =====================================================
     // UTILITY METHODS
     // =====================================================
+
+    // Check Supabase for a valid session (bypasses in-memory state)
+    async getSession() {
+        try {
+            var result = await supabaseClient.auth.getSession();
+            return result?.data?.session || null;
+        } catch (_) {
+            return null;
+        }
+    },
 
     // Check if user is logged in
     isLoggedIn() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 // Service Worker for ImpactMojo PWA
 // v5 - Offline PWA support for flagship courses, shell caching, offline fallback
-const CACHE_NAME = 'impactmojo-v5';
+const CACHE_NAME = 'impactmojo-v6';
 const COURSE_CACHE_PREFIX = 'impactmojo-course-';
 
 // App shell: core assets cached on install


### PR DESCRIPTION
## Summary
- Guard against transient SIGNED_OUT events during token refresh
- Handle TOKEN_REFRESHED event to restore session state
- Add getSession() fallback on account.html before redirecting to login
- Bump service worker cache to v6

## Test plan
- [ ] Log in with email/password, refresh — should stay logged in
- [ ] Log in with Google OAuth, refresh — should stay logged in
- [ ] Leave tab open >1 hour, return — should stay logged in
- [ ] Open account.html directly when logged in — no redirect to login
- [ ] Sign out — properly redirects and clears state

https://claude.ai/code/session_01XfqcsMrXaMALb5hr2vVfAk