### PR TITLE
Fix garbled org-dashboard and mobile auth button overlap

### DIFF
--- a/mobile-index.html
+++ b/mobile-index.html
@@ -1039,13 +1039,13 @@ body.dark-mode .mobile-plane {
     justify-content: center;
     width: 36px;
     height: 36px;
+    flex-shrink: 0;
     border-radius: 50%;
     background: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
     color: white;
     text-decoration: none;
     font-weight: 600;
     font-size: 14px;
-    margin-right: 12px;
     transition: all 0.2s ease;
 }
 
@@ -1064,8 +1064,8 @@ body.dark-mode .mobile-plane {
 /* Hide auth buttons based on state */
 .auth-logged-out { display: flex; }
 .auth-logged-in { display: none; }
-body.user-logged-in .auth-logged-out { display: none; }
-body.user-logged-in .auth-logged-in { display: flex; }
+body.user-authenticated .auth-logged-out { display: none !important; }
+body.user-authenticated .auth-logged-in { display: flex !important; }
 
 /* Menu auth section */
 .menu-auth-section {
@@ -2108,7 +2108,7 @@ body.user-logged-in .auth-logged-in { display: flex; }
         
         if (user) {
             // User is logged in
-            document.body.classList.add('user-logged-in');
+            document.body.classList.add('user-authenticated');
             
             // Update user info in menu
             const avatar = document.getElementById('menuUserAvatar');
@@ -2130,7 +2130,7 @@ body.user-logged-in .auth-logged-in { display: flex; }
             }
         } else {
             // User is logged out
-            document.body.classList.remove('user-logged-in');
+            document.body.classList.remove('user-authenticated');
         }
     }
     

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -2205,8 +2205,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         });
 
         printHtml += '<div class="footer">Generated from ImpactMojo Organization Dashboard &middot; impactmojo.in &middot; ' + new Date().toLocaleDateString('en-IN', { day: 'numeric', month: 'long', year: 'numeric' }) + '</div>';
-        printHtml += '<script defer src="js/auto-refresh.js"></script>
-</body></html>';
+        printHtml += '</body></html>';
 
         var blob = new Blob([printHtml], { type: 'text/html;charset=utf-8' });
         var a = document.createElement('a');


### PR DESCRIPTION
## Summary
- **org-dashboard.html**: The auto-refresh script tag got injected inside a JS string literal (`printHtml += '</script>'`), which the browser interpreted as closing the `<script>` block. Everything after that rendered as visible garbled code on the page.
- **mobile-index.html**: CSS used `body.user-logged-in` but auth.js sets `body.user-authenticated`. Both login and logout buttons showed simultaneously, overlapping the top navigation.

## Test plan
- [ ] Verify org-dashboard loads cleanly with no visible code/text artifacts
- [ ] Verify mobile site shows only login/signup buttons when logged out
- [ ] Verify mobile site shows only account button when logged in
- [ ] Verify no button overlap with the hamburger menu icon

https://claude.ai/code/session_01Rq3z8QRYjx6p2A1dQW6UwS