### PR TITLE
Remove auth buttons from mobile header

### DIFF
--- a/mobile-index.html
+++ b/mobile-index.html
@@ -1203,21 +1203,6 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
             <span class="logo-text">ImpactMojo</span>
         </a>
         
-        <!-- Auth Buttons (logged out) -->
-        <div class="header-auth auth-logged-out">
-            <a href="/login" class="header-auth-btn login" title="Log In">
-                <svg viewBox="0 0 24 24"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
-            </a>
-            <a href="/signup" class="header-auth-btn signup" title="Sign Up Free">
-                <svg viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>
-            </a>
-        </div>
-        
-        <!-- Account Button (logged in) -->
-        <a href="/account" class="header-account-btn auth-logged-in" id="headerAccountBtn" title="My Account">
-            <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-        </a>
-        
         <!-- Simple Hamburger Button -->
         <button id="hamburgerBtn" type="button" aria-label="Menu">
             <span class="hamburger-bar"></span>


### PR DESCRIPTION
## Summary
- Removed login/signup and account buttons from the mobile header bar
- These were overlapping the top navigation on mobile devices
- Auth actions remain accessible via the hamburger menu (standard mobile UX)

## Test plan
- [ ] Verify mobile header shows only logo + hamburger
- [ ] Verify login/signup appears in hamburger menu when logged out
- [ ] Verify account/dashboard link appears in hamburger menu when logged in

https://claude.ai/code/session_01Rq3z8QRYjx6p2A1dQW6UwS