### PR TITLE
Expand path builder, fix status labels, redesign admin panel

### DIFF
--- a/admin/analytics.html
+++ b/admin/analytics.html
@@ -288,20 +288,36 @@ body {
     text-align: right; flex-shrink: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .bar-track {
-    flex: 1; height: 28px; background: var(--secondary-bg);
-    border-radius: 6px; overflow: hidden; position: relative;
+    flex: 1; height: 32px; background: var(--secondary-bg);
+    border-radius: 8px; overflow: hidden; position: relative;
+    border: 1px solid var(--border-color);
 }
 .bar-fill {
-    height: 100%; border-radius: 6px; transition: width 0.8s ease;
-    display: flex; align-items: center; padding-left: 8px;
+    height: 100%; border-radius: 7px; transition: width 0.8s ease;
+    display: flex; align-items: center; padding-left: 10px;
     font-size: 0.75rem; font-weight: 600; color: white;
     font-family: 'JetBrains Mono', monospace;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
 }
-.bar-fill.blue { background: var(--accent-color); }
-.bar-fill.purple { background: var(--secondary-accent); }
-.bar-fill.green { background: var(--success-color); }
-.bar-fill.amber { background: var(--warning-color); }
-.bar-fill.red { background: var(--danger-color); }
+.bar-fill.blue { background: linear-gradient(90deg, var(--accent-color), #38BDF8); }
+.bar-fill.purple { background: linear-gradient(90deg, var(--secondary-accent), #A78BFA); }
+.bar-fill.green { background: linear-gradient(90deg, var(--success-color), #34D399); }
+.bar-fill.amber { background: linear-gradient(90deg, var(--warning-color), #FBBF24); }
+.bar-fill.red { background: linear-gradient(90deg, var(--danger-color), #F87171); }
+
+/* Paper plane */
+.paper-plane {
+    position: fixed; top: 12%; right: 6%; width: 140px; height: 140px;
+    opacity: 0.08; pointer-events: none; z-index: 0;
+    animation: float 12s ease-in-out infinite;
+}
+[data-theme="light"] .paper-plane { opacity: 0.06; }
+@keyframes float {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    25% { transform: translate(-15px, -20px) rotate(3deg); }
+    50% { transform: translate(10px, -10px) rotate(-2deg); }
+    75% { transform: translate(-20px, 15px) rotate(4deg); }
+}
 
 /* Two-column layout */
 .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
@@ -351,6 +367,15 @@ body {
 </style>
 </head>
 <body>
+
+<!-- Paper Plane -->
+<svg class="paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="140" r="1.5" fill="#10B981" opacity="0.4"/>
+</svg>
 
 <!-- Header -->
 <header class="site-header">
@@ -418,7 +443,7 @@ body {
 <main class="admin-main">
 
     <!-- Transparency Intro -->
-    <div style="text-align:center; padding:32px 24px 8px; max-width:720px; margin:0 auto;">
+    <div style="text-align:center; padding:20px 24px 8px; max-width:720px; margin:0 auto;">
         <h1 style="font-family:'Poppins',sans-serif; font-size:1.8rem; font-weight:700; margin-bottom:8px; background:var(--gradient-primary); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text;">Transparency & Impact Data</h1>
         <p style="font-size:0.95rem; color:var(--text-secondary); line-height:1.7;">
             ImpactMojo is built in the open. This page shares our platform metrics, content reach, and feature adoption data. All legacy data is reconstructed from our website; live analytics are pulled from Google Analytics 4 when connected.

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,9 +11,6 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
 <style>
-/* ========================================
-   DESIGN SYSTEM (matches ImpactMojo V3)
-   ======================================== */
 :root {
     --primary-bg: #0F172A;
     --secondary-bg: #1E293B;
@@ -61,9 +58,7 @@ body {
     min-height: 100vh;
 }
 
-/* ========================================
-   LOADING OVERLAY
-   ======================================== */
+/* Loading & Access Denied */
 .loading-overlay {
     position: fixed; inset: 0; z-index: 9999;
     background: var(--primary-bg);
@@ -79,206 +74,279 @@ body {
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* ========================================
-   ACCESS DENIED
-   ======================================== */
 .access-denied {
-    display: none;
-    min-height: 100vh;
+    display: none; min-height: 100vh;
     align-items: center; justify-content: center;
     flex-direction: column; gap: 16px;
     text-align: center; padding: 24px;
 }
-.access-denied h1 {
-    font-family: 'Poppins', sans-serif;
-    font-size: 1.5rem;
-    color: var(--danger-color);
-}
-.access-denied p {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    max-width: 400px;
-}
+.access-denied h1 { font-family: 'Poppins', sans-serif; font-size: 1.5rem; color: var(--danger-color); }
+.access-denied p { color: var(--text-secondary); font-size: 0.9rem; max-width: 400px; }
 .access-denied .btn {
     display: inline-flex; align-items: center; gap: 8px;
-    padding: 10px 20px;
-    background: var(--accent-color);
+    padding: 10px 20px; background: var(--accent-color);
     color: white; border: none; border-radius: var(--radius-sm);
-    font-size: 0.85rem; font-weight: 600;
-    cursor: pointer; text-decoration: none;
-    transition: background var(--transition);
+    font-size: 0.85rem; font-weight: 600; cursor: pointer; text-decoration: none;
 }
-.access-denied .btn:hover { background: var(--accent-hover); }
 
-/* ========================================
-   ADMIN HEADER
-   ======================================== */
-.admin-header {
+/* Header */
+.site-header {
     position: sticky; top: 0; z-index: 100;
     background: var(--primary-bg);
     border-bottom: 1px solid var(--border-color);
+    backdrop-filter: blur(12px);
     padding: 0 24px;
 }
-.admin-header-inner {
-    max-width: 1200px; margin: 0 auto; height: 64px;
+.nav-container {
+    max-width: 1400px; margin: 0 auto; height: 64px;
     display: flex; align-items: center; justify-content: space-between; gap: 16px;
 }
-.admin-logo {
+.logo {
     display: flex; align-items: center; gap: 10px;
-    text-decoration: none; color: var(--text-primary);
+    text-decoration: none; color: var(--text-primary); flex-shrink: 0;
 }
-.admin-logo img { height: 32px; }
-.admin-logo-text {
-    font-family: 'Poppins', sans-serif;
-    font-weight: 700; font-size: 1rem;
+.logo-icon { height: 32px; }
+.logo-text-wrap { display: flex; flex-direction: column; line-height: 1.2; }
+.logo-text { font-family: 'Poppins', sans-serif; font-weight: 700; font-size: 1.1rem; }
+.logo-tagline { font-size: 0.65rem; color: var(--text-muted); letter-spacing: 0.05em; }
+.admin-badge {
+    padding: 2px 8px; background: var(--gradient-primary); color: white;
+    font-size: 0.65rem; font-weight: 700; border-radius: 100px;
+    text-transform: uppercase; letter-spacing: 0.05em;
 }
-.admin-logo-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    background: var(--gradient-primary);
-    color: white;
-    font-size: 0.65rem;
-    font-weight: 700;
-    border-radius: 100px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+.nav-links { display: flex; gap: 4px; align-items: center; }
+.nav-link {
+    color: var(--text-secondary); text-decoration: none; font-size: 0.85rem; font-weight: 500;
+    padding: 6px 12px; border-radius: 8px; transition: all var(--transition);
 }
-.admin-header-actions {
-    display: flex; align-items: center; gap: 12px;
+.nav-link:hover { color: var(--text-primary); background: var(--hover-bg); }
+.nav-link.active { color: var(--accent-color); }
+.nav-actions { display: flex; align-items: center; gap: 12px; }
+
+/* 3-button theme selector */
+.theme-selector {
+    display: flex; gap: 4px; background: var(--hover-bg);
+    border: 1px solid var(--border-color); border-radius: 10px; padding: 4px;
 }
-.admin-user {
-    display: flex; align-items: center; gap: 8px;
-    font-size: 0.85rem; color: var(--text-secondary);
+.theme-btn {
+    background: transparent; border: none; color: var(--text-secondary);
+    padding: 8px; border-radius: 6px; cursor: pointer; transition: all 0.2s ease;
+    display: flex; align-items: center; justify-content: center; width: 36px; height: 36px;
 }
-.admin-user-avatar {
-    width: 32px; height: 32px; border-radius: 50%;
-    object-fit: cover;
-}
-.theme-toggle {
-    background: none; border: 1px solid var(--border-color);
-    color: var(--text-secondary); cursor: pointer;
-    width: 36px; height: 36px; border-radius: 8px;
-    display: flex; align-items: center; justify-content: center;
-    transition: all var(--transition);
-}
-.theme-toggle:hover { color: var(--text-primary); background: var(--hover-bg); }
+.theme-btn:hover { background: var(--hover-bg); color: var(--text-primary); }
+.theme-btn.active { background: var(--accent-color); color: white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.theme-btn svg { width: 18px; height: 18px; }
+
 .btn-sign-out {
-    padding: 6px 14px;
-    background: transparent; border: 1px solid var(--border-color);
+    padding: 6px 14px; background: transparent; border: 1px solid var(--border-color);
     color: var(--text-secondary); border-radius: var(--radius-sm);
-    font-size: 0.8rem; font-weight: 500;
-    cursor: pointer; transition: all var(--transition);
+    font-size: 0.8rem; font-weight: 500; cursor: pointer; transition: all var(--transition);
 }
 .btn-sign-out:hover { color: var(--danger-color); border-color: var(--danger-color); }
 
-/* ========================================
-   ADMIN CONTENT
-   ======================================== */
-.admin-content {
-    max-width: 1200px; margin: 0 auto;
-    padding: 32px 24px 64px;
+/* Paper plane */
+.paper-plane {
+    position: fixed; top: 12%; right: 6%; width: 140px; height: 140px;
+    opacity: 0.08; pointer-events: none; z-index: 0;
+    animation: float 12s ease-in-out infinite;
 }
-.admin-title {
-    font-family: 'Poppins', sans-serif;
-    font-size: 1.6rem; font-weight: 700;
-    margin-bottom: 8px;
-    background: var(--gradient-primary);
-    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-    background-clip: text;
-}
-.admin-subtitle {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    margin-bottom: 32px;
+[data-theme="light"] .paper-plane { opacity: 0.06; }
+@keyframes float {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    25% { transform: translate(-15px, -20px) rotate(3deg); }
+    50% { transform: translate(10px, -10px) rotate(-2deg); }
+    75% { transform: translate(-20px, 15px) rotate(4deg); }
 }
 
-/* ========================================
-   DASHBOARD GRID
-   ======================================== */
+/* Content */
+.admin-main {
+    max-width: 1200px; margin: 0 auto; padding: 24px 24px 48px;
+    position: relative; z-index: 1;
+}
+
+/* Dashboard grid */
 .dash-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 20px;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 16px; margin-bottom: 32px;
 }
 .dash-card {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    padding: 24px;
-    transition: all var(--transition);
-    text-decoration: none;
-    color: inherit;
-    display: flex; flex-direction: column; gap: 12px;
+    background: var(--card-bg); border: 1px solid var(--border-color);
+    border-radius: var(--radius-md); padding: 20px;
+    transition: all var(--transition); text-decoration: none; color: inherit;
+    display: flex; flex-direction: column; gap: 8px;
 }
 .dash-card:hover {
-    border-color: var(--accent-color);
-    box-shadow: var(--shadow-md);
+    border-color: var(--accent-color); box-shadow: var(--shadow-md);
     transform: translateY(-2px);
 }
 .dash-card-icon {
-    width: 48px; height: 48px;
-    border-radius: var(--radius-sm);
+    width: 40px; height: 40px; border-radius: var(--radius-sm);
     display: flex; align-items: center; justify-content: center;
-    font-size: 1.4rem;
 }
-.dash-card-icon.blue { background: rgba(14, 165, 233, 0.15); }
-.dash-card-icon.purple { background: rgba(99, 102, 241, 0.15); }
-.dash-card-icon.green { background: rgba(16, 185, 129, 0.15); }
-.dash-card-icon.amber { background: rgba(245, 158, 11, 0.15); }
-.dash-card-title {
-    font-family: 'Poppins', sans-serif;
-    font-weight: 700; font-size: 1rem;
-}
-.dash-card-desc {
-    font-size: 0.85rem; color: var(--text-secondary);
-    line-height: 1.6;
-}
+.dash-card-icon svg { width: 20px; height: 20px; }
+.dash-card-icon.blue { background: rgba(14,165,233,0.15); color: var(--accent-color); }
+.dash-card-icon.purple { background: rgba(99,102,241,0.15); color: var(--secondary-accent); }
+.dash-card-icon.green { background: rgba(16,185,129,0.15); color: var(--success-color); }
+.dash-card-icon.amber { background: rgba(245,158,11,0.15); color: var(--warning-color); }
+.dash-card-icon.red { background: rgba(239,68,68,0.15); color: var(--danger-color); }
+.dash-card-title { font-family: 'Poppins', sans-serif; font-weight: 700; font-size: 0.95rem; }
+.dash-card-desc { font-size: 0.82rem; color: var(--text-secondary); line-height: 1.5; }
 .dash-card-badge {
     display: inline-flex; align-items: center; gap: 4px;
-    padding: 3px 10px;
-    border-radius: 100px;
-    font-size: 0.7rem; font-weight: 600;
-    width: fit-content;
+    padding: 2px 8px; border-radius: 100px; font-size: 0.65rem; font-weight: 600; width: fit-content;
 }
-.dash-card-badge.live {
-    background: rgba(16, 185, 129, 0.15);
-    color: var(--success-color);
-}
-.dash-card-badge.new {
-    background: rgba(14, 165, 233, 0.15);
-    color: var(--accent-color);
+.badge-live { background: rgba(16,185,129,0.15); color: var(--success-color); }
+.badge-cms { background: rgba(14,165,233,0.15); color: var(--accent-color); }
+.badge-soon { background: var(--hover-bg); color: var(--text-muted); }
+
+/* Section headers */
+.section-header {
+    font-family: 'Poppins', sans-serif; font-size: 0.85rem; font-weight: 700;
+    color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;
+    margin-bottom: 12px; display: flex; align-items: center; gap: 8px;
 }
 
-/* ========================================
-   FEATURE LIST INSIDE CARDS
-   ======================================== */
-.dash-card-features {
-    list-style: none; padding: 0; margin: 0;
-    display: flex; flex-direction: column; gap: 6px;
+/* Quick links grid */
+.quick-links {
+    display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 32px;
 }
-.dash-card-features li {
-    font-size: 0.82rem; color: var(--text-secondary);
-    display: flex; align-items: flex-start; gap: 8px;
-    line-height: 1.5;
+.quick-link {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 8px 14px; border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color); background: var(--card-bg);
+    color: var(--text-secondary); text-decoration: none; font-size: 0.82rem; font-weight: 500;
+    transition: all var(--transition);
 }
-.dash-card-features li::before {
-    content: '';
-    display: inline-block;
-    width: 5px; height: 5px;
-    background: var(--accent-color);
-    border-radius: 50%;
-    flex-shrink: 0;
-    margin-top: 7px;
+.quick-link:hover { color: var(--accent-color); border-color: var(--accent-color); }
+.quick-link svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+/* Ideas Tracker */
+.ideas-section {
+    background: var(--card-bg); border: 1px solid var(--border-color);
+    border-radius: var(--radius-md); padding: 20px; margin-bottom: 32px;
+}
+.ideas-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 12px;
+}
+.ideas-header h3 {
+    font-family: 'Poppins', sans-serif; font-size: 1rem; font-weight: 700;
+    display: flex; align-items: center; gap: 8px;
+}
+.ideas-count {
+    font-size: 0.7rem; background: rgba(14,165,233,0.15); color: var(--accent-color);
+    padding: 2px 8px; border-radius: 100px; font-weight: 600;
+}
+.ideas-input-row { display: flex; gap: 8px; margin-bottom: 12px; }
+.ideas-input {
+    flex: 1; padding: 10px 14px; border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color); background: var(--primary-bg);
+    color: var(--text-primary); font-family: inherit; font-size: 0.85rem;
+}
+.ideas-input:focus { outline: none; border-color: var(--accent-color); }
+.ideas-input::placeholder { color: var(--text-muted); }
+.btn-add-idea {
+    padding: 10px 16px; border-radius: var(--radius-sm); border: none;
+    background: var(--accent-color); color: white; font-weight: 600;
+    font-size: 0.85rem; cursor: pointer; font-family: inherit;
+    transition: background var(--transition); white-space: nowrap;
+}
+.btn-add-idea:hover { background: var(--accent-hover); }
+.ideas-list { list-style: none; }
+.idea-item {
+    display: flex; align-items: flex-start; gap: 10px;
+    padding: 10px 0; border-bottom: 1px solid var(--border-color);
+    font-size: 0.85rem;
+}
+.idea-item:last-child { border-bottom: none; }
+.idea-check {
+    width: 20px; height: 20px; border-radius: 6px; border: 2px solid var(--border-color);
+    cursor: pointer; flex-shrink: 0; margin-top: 1px;
+    display: flex; align-items: center; justify-content: center;
+    transition: all 0.15s ease; color: transparent; background: transparent;
+}
+.idea-check:hover { border-color: var(--accent-color); }
+.idea-item.done .idea-check {
+    background: var(--success-color); border-color: var(--success-color); color: white;
+}
+.idea-item.done .idea-text { text-decoration: line-through; color: var(--text-muted); }
+.idea-text { flex: 1; color: var(--text-secondary); line-height: 1.5; }
+.idea-meta {
+    font-size: 0.7rem; color: var(--text-muted); white-space: nowrap; margin-top: 2px;
+}
+.idea-delete {
+    background: none; border: none; color: var(--text-muted); cursor: pointer;
+    padding: 2px; opacity: 0; transition: opacity 0.15s ease;
+}
+.idea-item:hover .idea-delete { opacity: 1; }
+.idea-delete:hover { color: var(--danger-color); }
+.ideas-empty {
+    text-align: center; padding: 24px; color: var(--text-muted); font-size: 0.85rem;
 }
 
-/* ========================================
-   RESPONSIVE
-   ======================================== */
+/* Setup card (collapsible) */
+.setup-card {
+    background: var(--card-bg); border: 1px solid var(--border-color);
+    border-radius: var(--radius-md); margin-bottom: 32px; overflow: hidden;
+}
+.setup-toggle {
+    width: 100%; padding: 16px 20px; background: none; border: none;
+    color: var(--text-primary); font-family: 'Poppins', sans-serif;
+    font-size: 0.9rem; font-weight: 700; cursor: pointer;
+    display: flex; align-items: center; gap: 8px; text-align: left;
+}
+.setup-toggle:hover { background: var(--hover-bg); }
+.setup-toggle svg { transition: transform 0.2s ease; }
+.setup-toggle.open svg { transform: rotate(90deg); }
+.setup-body { display: none; padding: 0 20px 20px; }
+.setup-body.open { display: block; }
+.setup-body pre {
+    background: var(--primary-bg); border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm); padding: 16px;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.78rem;
+    color: var(--text-secondary); overflow-x: auto; line-height: 1.8; white-space: pre-wrap;
+}
+.setup-body pre .kw { color: var(--accent-color); }
+.setup-body pre .str { color: var(--success-color); }
+.setup-body pre .cm { color: var(--text-muted); }
+
+/* Footer */
+.footer {
+    border-top: 1px solid var(--border-color);
+    padding: 32px 24px 20px; background: var(--secondary-bg);
+}
+.footer-content { max-width: 1400px; margin: 0 auto; }
+.footer-bottom { text-align: center; }
+.footer-bottom p { font-size: 0.82rem; color: var(--text-muted); margin-bottom: 4px; }
+.footer-bottom a { color: var(--accent-color); text-decoration: none; }
+
+/* Mobile menu */
+.mobile-menu-toggle {
+    display: none; background: none; border: none; color: var(--text-primary);
+    cursor: pointer; padding: 8px;
+}
+.mobile-nav-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 999; }
+.mobile-nav-overlay.active { display: block; }
+.mobile-nav-panel {
+    display: none; position: fixed; top: 0; right: 0; bottom: 0; width: 280px;
+    background: var(--primary-bg); border-left: 1px solid var(--border-color);
+    z-index: 1001; padding: 24px; flex-direction: column; gap: 8px; overflow-y: auto;
+}
+.mobile-nav-panel.active { display: flex; }
+.mobile-nav-panel .nav-link { display: block; padding: 12px 16px; font-size: 1rem; }
+.mobile-nav-close {
+    align-self: flex-end; background: none; border: none; color: var(--text-primary);
+    cursor: pointer; padding: 4px; margin-bottom: 16px;
+}
+
+@media (max-width: 900px) {
+    .nav-links, .nav-actions { display: none; }
+    .mobile-menu-toggle { display: flex; }
+}
 @media (max-width: 640px) {
-    .admin-content { padding: 20px 16px 48px; }
-    .admin-title { font-size: 1.3rem; }
+    .admin-main { padding: 16px 16px 32px; }
     .dash-grid { grid-template-columns: 1fr; }
-    .admin-user span { display: none; }
 }
 </style>
 </head>
@@ -299,108 +367,245 @@ body {
     </svg>
     <h1>Access Denied</h1>
     <p>This page is restricted to ImpactMojo administrators. If you believe you should have access, contact the site admin.</p>
-    <a href="/" class="btn">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-        Back to Home
-    </a>
+    <a href="/" class="btn">Back to Home</a>
 </div>
 
-<!-- Admin Dashboard (hidden until auth passes) -->
+<!-- Admin Dashboard -->
 <div id="adminApp" style="display:none;">
 
+    <!-- Paper Plane -->
+    <svg class="paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+        <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+        <circle cx="35" cy="140" r="1.5" fill="#10B981" opacity="0.4"/>
+    </svg>
+
     <!-- Header -->
-    <header class="admin-header">
-        <div class="admin-header-inner">
-            <a href="/admin/" class="admin-logo">
-                <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
-                <span class="admin-logo-text">ImpactMojo</span>
-                <span class="admin-logo-badge">Admin</span>
-            </a>
-            <div class="admin-header-actions">
-                <div class="admin-user">
-                    <img class="admin-user-avatar auth-user-avatar" src="" alt="">
-                    <span class="auth-user-name"></span>
+    <header class="site-header">
+        <nav class="nav-container">
+            <a href="/" class="logo">
+                <img src="/assets/images/ImpactMojo Logo.png" alt="ImpactMojo" class="logo-icon">
+                <div class="logo-text-wrap">
+                    <span class="logo-text">ImpactMojo</span>
+                    <span class="logo-tagline">Learn for Impact</span>
                 </div>
-                <button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-                </button>
+                <span class="admin-badge">Admin</span>
+            </a>
+            <div class="nav-links">
+                <a href="/" class="nav-link">Home</a>
+                <a href="/admin/analytics" class="nav-link">Transparency</a>
+                <a href="/updates" class="nav-link">Updates</a>
+                <a href="/org-dashboard" class="nav-link">Org Dashboard</a>
+                <a href="/challenges" class="nav-link">Challenges</a>
+            </div>
+            <div class="nav-actions">
+                <div class="theme-selector" aria-label="Theme selection">
+                    <button class="theme-btn" data-theme="system" title="System theme" aria-label="Use system theme">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+                    </button>
+                    <button class="theme-btn" data-theme="light" title="Light theme" aria-label="Use light theme">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+                    </button>
+                    <button class="theme-btn" data-theme="dark" title="Dark theme" aria-label="Use dark theme">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                    </button>
+                </div>
                 <button class="btn-sign-out" onclick="handleSignOut()">Sign Out</button>
             </div>
-        </div>
+            <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Menu">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+            </button>
+        </nav>
     </header>
 
+    <!-- Mobile Nav -->
+    <div class="mobile-nav-overlay" id="mobileOverlay"></div>
+    <div class="mobile-nav-panel" id="mobilePanel">
+        <button class="mobile-nav-close" id="mobileNavClose" aria-label="Close menu">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+        <a href="/" class="nav-link">Home</a>
+        <a href="/admin/analytics" class="nav-link">Transparency</a>
+        <a href="/updates" class="nav-link">Updates</a>
+        <a href="/org-dashboard" class="nav-link">Org Dashboard</a>
+        <a href="/challenges" class="nav-link">Challenges</a>
+        <div class="theme-selector" style="margin-top:16px;">
+            <button class="theme-btn" data-theme="system" title="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="theme-btn" data-theme="light" title="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/></svg></button>
+            <button class="theme-btn" data-theme="dark" title="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
+    </div>
+
     <!-- Content -->
-    <main class="admin-content">
-        <h1 class="admin-title">Admin Dashboard</h1>
-        <p class="admin-subtitle">Manage your site content, view analytics, and configure settings.</p>
+    <main class="admin-main">
+        <div style="margin-bottom:24px;">
+            <h1 style="font-family:'Poppins',sans-serif; font-size:1.5rem; font-weight:700; margin-bottom:4px; background:var(--gradient-primary); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text;">Admin Dashboard</h1>
+            <p style="font-size:0.88rem; color:var(--text-secondary);">Manage content, view analytics, and track ideas.</p>
+        </div>
 
-        <div class="dash-grid">
-            <!-- CMS -->
-            <a href="/admin/cms.html" class="dash-card">
-                <div class="dash-card-icon blue">&#x1f4dd;</div>
-                <div class="dash-card-title">Content Manager</div>
-                <ul class="dash-card-features">
-                    <li>Homepage hero — headline, subtext, CTA buttons</li>
-                    <li>Course catalog — add, edit, remove courses with type, track, level</li>
-                    <li>Games &amp; simulations — manage interactive content listings</li>
-                    <li>Tools &amp; labs — free and premium tool directory</li>
-                    <li>Testimonials — quotes, ratings, user details</li>
-                    <li>Team members — bios, roles, photos, LinkedIn links</li>
-                    <li>Footer links — site-wide navigation sections</li>
-                    <li>Announcements — site-wide banners with active/inactive toggle</li>
-                    <li>Form view and raw JSON editor with toggle</li>
-                    <li>All changes saved to Supabase with admin-only write access</li>
-                </ul>
-                <span class="dash-card-badge new">CMS</span>
+        <!-- Quick Links -->
+        <div class="section-header">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+            Quick Links
+        </div>
+        <div class="quick-links">
+            <a href="/admin/analytics" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                Transparency
             </a>
-
-            <!-- Analytics -->
-            <a href="/admin/analytics" class="dash-card">
-                <div class="dash-card-icon purple">&#x1f4ca;</div>
-                <div class="dash-card-title">Analytics &amp; Transparency</div>
-                <ul class="dash-card-features">
-                    <li>Reconciled overview — legacy data merged with GA4 live metrics</li>
-                    <li>GA4 real-time data — users, sessions, pageviews, engagement rate</li>
-                    <li>Course user breakdown — enrolment numbers per course</li>
-                    <li>Game &amp; tool usage — interaction counts with bar charts</li>
-                    <li>Feature adoption table — type, user count, active/sunset status</li>
-                    <li>Geographic distribution — country-level user and session data</li>
-                    <li>Key metrics definitions — how each GA4 metric is calculated</li>
-                    <li>Data methodology &amp; model documentation</li>
-                    <li>24-hour client-side cache with manual refresh</li>
-                </ul>
-                <span class="dash-card-badge live">Live</span>
+            <a href="/updates" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                Updates & Roadmap
             </a>
-
-            <!-- User Management -->
-            <a href="/admin/users.html" class="dash-card">
-                <div class="dash-card-icon green">&#x1f465;</div>
-                <div class="dash-card-title">User Management</div>
-                <ul class="dash-card-features">
-                    <li>View all registered users with profile details</li>
-                    <li>Assign and revoke admin roles</li>
-                    <li>Review subscription tiers — explorer, practitioner, professional, organization</li>
-                    <li>Organization memberships and team structures</li>
-                    <li>Certificate issuance history per user</li>
-                    <li>Learning progress and streak data</li>
-                </ul>
+            <a href="/org-dashboard" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                Org Dashboard
             </a>
-
-            <!-- Site Settings -->
-            <a href="/admin/settings.html" class="dash-card">
-                <div class="dash-card-icon amber">&#x2699;&#xFE0F;</div>
-                <div class="dash-card-title">Site Settings</div>
-                <ul class="dash-card-features">
-                    <li>Site metadata — title, description, OG tags</li>
-                    <li>Feature flags — enable/disable platform features</li>
-                    <li>Maintenance mode — take site offline with custom message</li>
-                    <li>Integration keys — GA4 property, Supabase project, Stripe</li>
-                    <li>Email templates — welcome, password reset, certificate notifications</li>
-                    <li>Audit log — track admin actions and content changes</li>
-                </ul>
+            <a href="/challenges" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+                Challenges
+            </a>
+            <a href="/account" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                Account
+            </a>
+            <a href="/privacy-policy" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                Privacy Policy
+            </a>
+            <a href="https://github.com/Varnasr/ImpactMojo" target="_blank" class="quick-link">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22"/></svg>
+                GitHub
             </a>
         </div>
+
+        <!-- Admin Tools Grid -->
+        <div class="section-header">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+            Admin Tools
+        </div>
+        <div class="dash-grid">
+            <a href="/admin/cms.html" class="dash-card">
+                <div class="dash-card-icon blue">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4z"/></svg>
+                </div>
+                <div class="dash-card-title">Content Manager</div>
+                <div class="dash-card-desc">Edit hero, courses, games, tools, testimonials, announcements via visual JSON editor.</div>
+                <span class="dash-card-badge badge-cms">CMS</span>
+            </a>
+
+            <a href="/admin/analytics" class="dash-card">
+                <div class="dash-card-icon purple">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                </div>
+                <div class="dash-card-title">Analytics & Transparency</div>
+                <div class="dash-card-desc">Platform metrics, GA4 live data, course usage, feature adoption, and geographic reach.</div>
+                <span class="dash-card-badge badge-live">Live</span>
+            </a>
+
+            <a href="/org-dashboard" class="dash-card">
+                <div class="dash-card-icon green">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                </div>
+                <div class="dash-card-title">Organization Dashboard</div>
+                <div class="dash-card-desc">Manage team members, learning paths, training packages, and cohorts.</div>
+                <span class="dash-card-badge badge-live">Live</span>
+            </a>
+
+            <a href="/updates" class="dash-card">
+                <div class="dash-card-icon amber">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/></svg>
+                </div>
+                <div class="dash-card-title">Updates & Roadmap</div>
+                <div class="dash-card-desc">View shipped features, changelog, and upcoming roadmap items.</div>
+                <span class="dash-card-badge badge-live">Public</span>
+            </a>
+
+            <div class="dash-card" style="opacity:0.5; cursor:default;">
+                <div class="dash-card-icon red">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                </div>
+                <div class="dash-card-title">User Management</div>
+                <div class="dash-card-desc">View registered users, manage roles, review subscriptions and memberships.</div>
+                <span class="dash-card-badge badge-soon">Coming Soon</span>
+            </div>
+
+            <div class="dash-card" style="opacity:0.5; cursor:default;">
+                <div class="dash-card-icon amber">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="dash-card-title">Site Settings</div>
+                <div class="dash-card-desc">Feature flags, maintenance mode, integrations, and site metadata.</div>
+                <span class="dash-card-badge badge-soon">Coming Soon</span>
+            </div>
+        </div>
+
+        <!-- Ideas Tracker -->
+        <div class="ideas-section" id="ideasSection">
+            <div class="ideas-header">
+                <h3>
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+                    Ideas & Scratch Pad
+                    <span class="ideas-count" id="ideasCount">0</span>
+                </h3>
+            </div>
+            <div class="ideas-input-row">
+                <input type="text" class="ideas-input" id="ideaInput" placeholder="Jot down a feature idea, bug, or note..." onkeydown="if(event.key==='Enter')addIdea()">
+                <button class="btn-add-idea" onclick="addIdea()">Add</button>
+            </div>
+            <ul class="ideas-list" id="ideasList"></ul>
+            <div class="ideas-empty" id="ideasEmpty">No ideas yet. Start jotting things down!</div>
+        </div>
+
+        <!-- Supabase Setup (collapsible) -->
+        <div class="setup-card">
+            <button class="setup-toggle" id="setupToggle" onclick="toggleSetup()">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                Supabase Setup (one-time)
+            </button>
+            <div class="setup-body" id="setupBody">
+                <p style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 16px;">
+                    Run this SQL in your Supabase SQL Editor to create the required tables and policies:
+                </p>
+                <pre><span class="cm">-- 1. Add role column to profiles</span>
+<span class="kw">ALTER TABLE</span> profiles <span class="kw">ADD COLUMN IF NOT EXISTS</span> role <span class="kw">TEXT DEFAULT</span> <span class="str">'user'</span>;
+
+<span class="cm">-- 2. Set yourself as admin (replace with your email)</span>
+<span class="kw">UPDATE</span> profiles <span class="kw">SET</span> role = <span class="str">'admin'</span>
+<span class="kw">WHERE</span> id = (<span class="kw">SELECT</span> id <span class="kw">FROM</span> auth.users <span class="kw">WHERE</span> email = <span class="str">'your-email@example.com'</span>);
+
+<span class="cm">-- 3. Create site_content table</span>
+<span class="kw">CREATE TABLE IF NOT EXISTS</span> site_content (
+    id <span class="kw">UUID DEFAULT</span> gen_random_uuid() <span class="kw">PRIMARY KEY</span>,
+    section_key <span class="kw">TEXT UNIQUE NOT NULL</span>,
+    label <span class="kw">TEXT NOT NULL</span>,
+    content <span class="kw">JSONB NOT NULL DEFAULT</span> <span class="str">'{}'</span>,
+    schema <span class="kw">JSONB DEFAULT NULL</span>,
+    updated_at <span class="kw">TIMESTAMPTZ DEFAULT</span> now(),
+    updated_by <span class="kw">UUID REFERENCES</span> auth.users(id)
+);
+
+<span class="cm">-- 4. Enable RLS & Policies</span>
+<span class="kw">ALTER TABLE</span> site_content <span class="kw">ENABLE ROW LEVEL SECURITY</span>;
+<span class="kw">CREATE POLICY</span> <span class="str">"Public read"</span> <span class="kw">ON</span> site_content <span class="kw">FOR SELECT USING</span> (<span class="kw">true</span>);
+<span class="kw">CREATE POLICY</span> <span class="str">"Admin write"</span> <span class="kw">ON</span> site_content <span class="kw">FOR ALL USING</span> (
+    <span class="kw">EXISTS</span> (<span class="kw">SELECT</span> 1 <span class="kw">FROM</span> profiles <span class="kw">WHERE</span> profiles.id = auth.uid() <span class="kw">AND</span> profiles.role = <span class="str">'admin'</span>)
+);</pre>
+            </div>
+        </div>
     </main>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="footer-content">
+            <div class="footer-bottom">
+                <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+                <p>Released under MIT License. Supported by <a href="https://www.pinpointventures.in" target="_blank" rel="noopener">PinPoint Ventures</a></p>
+            </div>
+        </div>
+    </footer>
 </div>
 
 <!-- Scripts -->
@@ -410,31 +615,147 @@ body {
 <script src="/js/admin-gate.js"></script>
 
 <script>
-// Theme toggle
-function toggleTheme() {
-    var html = document.documentElement;
-    var current = html.getAttribute('data-theme');
-    html.setAttribute('data-theme', current === 'light' ? 'dark' : 'light');
-    try { localStorage.setItem('impactmojo_admin_theme', html.getAttribute('data-theme')); } catch(e) {}
+// ============================================================
+// THEME (3-button: system / light / dark)
+// ============================================================
+function getPreferredTheme() {
+    return localStorage.getItem('impactmojo-theme') || 'system';
 }
+function applyTheme(theme) {
+    var resolved = theme;
+    if (theme === 'system') {
+        resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+    }
+    document.documentElement.setAttribute('data-theme', resolved);
+    localStorage.setItem('impactmojo-theme', theme);
+    document.querySelectorAll('.theme-btn').forEach(function(btn) {
+        btn.classList.toggle('active', btn.getAttribute('data-theme') === theme);
+    });
+}
+applyTheme(getPreferredTheme());
+document.querySelectorAll('.theme-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() { applyTheme(btn.getAttribute('data-theme')); });
+});
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+    if (getPreferredTheme() === 'system') applyTheme('system');
+});
 
-// Restore theme
+// ============================================================
+// MOBILE MENU
+// ============================================================
 (function() {
-    try {
-        var saved = localStorage.getItem('impactmojo_admin_theme');
-        if (saved) document.documentElement.setAttribute('data-theme', saved);
-    } catch(e) {}
+    var toggle = document.getElementById('mobileMenuToggle');
+    var overlay = document.getElementById('mobileOverlay');
+    var panel = document.getElementById('mobilePanel');
+    var closeBtn = document.getElementById('mobileNavClose');
+    function openMenu() { overlay.classList.add('active'); panel.classList.add('active'); document.body.style.overflow = 'hidden'; }
+    function closeMenu() { overlay.classList.remove('active'); panel.classList.remove('active'); document.body.style.overflow = ''; }
+    toggle.addEventListener('click', openMenu);
+    overlay.addEventListener('click', closeMenu);
+    closeBtn.addEventListener('click', closeMenu);
 })();
 
-// Sign out
+// ============================================================
+// SETUP TOGGLE
+// ============================================================
+function toggleSetup() {
+    var toggle = document.getElementById('setupToggle');
+    var body = document.getElementById('setupBody');
+    toggle.classList.toggle('open');
+    body.classList.toggle('open');
+}
+
+// ============================================================
+// IDEAS TRACKER (localStorage)
+// ============================================================
+var IDEAS_KEY = 'impactmojo_admin_ideas';
+
+function loadIdeas() {
+    try { return JSON.parse(localStorage.getItem(IDEAS_KEY)) || []; }
+    catch(e) { return []; }
+}
+
+function saveIdeas(ideas) {
+    try { localStorage.setItem(IDEAS_KEY, JSON.stringify(ideas)); } catch(e) {}
+}
+
+function renderIdeas() {
+    var ideas = loadIdeas();
+    var list = document.getElementById('ideasList');
+    var empty = document.getElementById('ideasEmpty');
+    var count = document.getElementById('ideasCount');
+    var pending = ideas.filter(function(i) { return !i.done; }).length;
+    count.textContent = pending;
+
+    if (ideas.length === 0) {
+        list.innerHTML = '';
+        empty.style.display = 'block';
+        return;
+    }
+    empty.style.display = 'none';
+    list.innerHTML = ideas.map(function(idea, i) {
+        var d = new Date(idea.created);
+        var dateStr = d.toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+        return '<li class="idea-item' + (idea.done ? ' done' : '') + '">' +
+            '<div class="idea-check" onclick="toggleIdea(' + i + ')">' +
+                (idea.done ? '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>' : '') +
+            '</div>' +
+            '<span class="idea-text">' + escapeHtml(idea.text) + '</span>' +
+            '<span class="idea-meta">' + dateStr + '</span>' +
+            '<button class="idea-delete" onclick="deleteIdea(' + i + ')" title="Delete">' +
+                '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>' +
+            '</button>' +
+            '</li>';
+    }).join('');
+}
+
+function addIdea() {
+    var input = document.getElementById('ideaInput');
+    var text = input.value.trim();
+    if (!text) return;
+    var ideas = loadIdeas();
+    ideas.unshift({ text: text, done: false, created: new Date().toISOString() });
+    saveIdeas(ideas);
+    input.value = '';
+    renderIdeas();
+}
+
+function toggleIdea(index) {
+    var ideas = loadIdeas();
+    if (ideas[index]) {
+        ideas[index].done = !ideas[index].done;
+        saveIdeas(ideas);
+        renderIdeas();
+    }
+}
+
+function deleteIdea(index) {
+    var ideas = loadIdeas();
+    ideas.splice(index, 1);
+    saveIdeas(ideas);
+    renderIdeas();
+}
+
+function escapeHtml(str) {
+    var div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
+
+// ============================================================
+// SIGN OUT
+// ============================================================
 async function handleSignOut() {
     if (confirm('Sign out of admin panel?')) {
         await ImpactMojoAuth.signOut();
     }
 }
 
-// Admin Gate
+// ============================================================
+// ADMIN GATE
+// ============================================================
 document.addEventListener('DOMContentLoaded', function() {
+    renderIdeas();
     AdminGate.protect({
         loadingEl: document.getElementById('loadingOverlay'),
         timeoutMs: 8000,
@@ -449,6 +770,5 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 </script>
-
 </body>
 </html>

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -366,6 +366,24 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
     width: 32px; height: 32px; border-radius: 8px; display: flex;
     align-items: center; justify-content: center; flex-shrink: 0;
 }
+.path-section-header {
+    display: flex; align-items: center; gap: 0.5rem; padding: 0.6rem 0.75rem 0.35rem;
+    font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--text-secondary); border-top: 1px solid var(--border-color); margin-top: 0.5rem;
+}
+.path-section-header:first-child { border-top: none; margin-top: 0; }
+.path-cat-btn {
+    padding: 0.3rem 0.7rem; font-size: 0.75rem; border-radius: 6px; border: 1px solid var(--border-color);
+    background: transparent; color: var(--text-secondary); cursor: pointer; font-weight: 500;
+    transition: all 0.15s ease; font-family: inherit;
+}
+.path-cat-btn:hover { background: var(--hover-bg); }
+.path-cat-btn.active { background: #6366F1; color: white; border-color: #6366F1; }
+.path-cat-count {
+    display: inline-block; font-size: 0.65rem; background: rgba(99,102,241,0.12); color: #6366F1;
+    padding: 1px 5px; border-radius: 4px; margin-left: 2px; font-weight: 600;
+}
+.path-cat-btn.active .path-cat-count { background: rgba(255,255,255,0.25); color: white; }
 .path-course-name { font-size: 0.88rem; font-weight: 600; line-height: 1.3; }
 .path-course-desc { font-size: 0.72rem; color: var(--text-muted); line-height: 1.3; margin-top: 1px; }
 .path-course-hours {
@@ -494,6 +512,10 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         </div>
         <h1 id="orgName">Your Organization</h1>
         <p>Manage your team, track learning progress, and build custom pathways.</p>
+        <a href="/admin/" id="adminPanelLink" style="display:none; margin-top:0.75rem; font-size:0.82rem; font-weight:600; color:var(--accent-color); text-decoration:none; align-items:center; gap:0.4rem;">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+            Admin Panel
+        </a>
     </div>
 
     <!-- Stats -->
@@ -619,12 +641,12 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                 </div>
                 <p style="font-size:0.82rem; color:var(--text-secondary); line-height:1.5;">Pre-built training paths, facilitator guides, assessment rubrics, and cohort management. Go to the <strong>Training</strong> tab below.</p>
             </div>
-            <div style="background:var(--card-bg); border:1px dashed var(--border-color); border-radius:12px; padding:1.25rem; opacity:0.85;">
+            <div style="background:var(--card-bg); border:1px solid var(--accent-color); border-radius:12px; padding:1.25rem;">
                 <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:0.5rem;">
-                    <span style="font-size:0.65rem; background:rgba(245,158,11,0.15); color:#D97706; padding:2px 8px; border-radius:4px; font-weight:600;">ROADMAP</span>
+                    <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600;">LIVE</span>
                     <h4 style="font-size:0.95rem; font-weight:600;">Open Badges & Micro-credentials</h4>
                 </div>
-                <p style="font-size:0.82rem; color:var(--text-secondary); line-height:1.5;">W3C-standard verifiable digital credentials shareable on LinkedIn, proving your team's mastery of development competencies.</p>
+                <p style="font-size:0.82rem; color:var(--text-secondary); line-height:1.5;">W3C-standard verifiable digital credentials shareable on LinkedIn, proving your team's mastery of development competencies. Badges are auto-issued on course completion and visible in the <strong>Account</strong> page.</p>
             </div>
             <div style="background:var(--card-bg); border:1px solid var(--accent-color); border-radius:12px; padding:1.25rem;">
                 <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:0.5rem;">
@@ -1233,22 +1255,36 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
 
 <!-- Create Learning Path Modal -->
 <div class="modal-overlay" id="pathModal">
-    <div class="modal" style="max-width:600px;">
+    <div class="modal" style="max-width:720px;">
         <div style="display:flex; align-items:center; gap:0.75rem; margin-bottom:1.25rem;">
             <div style="width:40px; height:40px; background:linear-gradient(135deg, #6366F1, #8B5CF6); border-radius:10px; display:flex; align-items:center; justify-content:center; flex-shrink:0;">
                 <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="white" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
             </div>
             <div>
                 <h3 style="margin:0; font-size:1.15rem;">Create Learning Path</h3>
-                <p style="margin:0; font-size:0.78rem; color:var(--text-secondary);">Build a custom course sequence for your team</p>
+                <p style="margin:0; font-size:0.78rem; color:var(--text-secondary);">Combine courses, labs, templates, games & challenges into a structured journey</p>
             </div>
         </div>
         <label>Path Title</label>
         <input type="text" id="pathTitle" placeholder="e.g., MEL Foundations for Field Staff">
         <label>Description</label>
         <textarea id="pathDesc" placeholder="What skills and competencies will this path develop for your team?" style="resize:vertical; min-height:80px;"></textarea>
-        <label style="margin-bottom:0.5rem;">Select Courses <span style="font-weight:400; color:var(--text-muted); font-size:0.78rem;">(click to add)</span></label>
-        <div id="courseSelector" style="max-height:320px; overflow-y:auto; border:1px solid var(--border-color); border-radius:12px; padding:0.25rem; margin-bottom:0.75rem;">
+
+        <!-- Category filter tabs -->
+        <div style="display:flex; gap:0.35rem; flex-wrap:wrap; margin-bottom:0.75rem;">
+            <button class="path-cat-btn active" data-cat="all" onclick="filterPathCategory('all', this)">All</button>
+            <button class="path-cat-btn" data-cat="course" onclick="filterPathCategory('course', this)">Courses <span class="path-cat-count" id="catCount-course">0</span></button>
+            <button class="path-cat-btn" data-cat="lab" onclick="filterPathCategory('lab', this)">Labs <span class="path-cat-count" id="catCount-lab">0</span></button>
+            <button class="path-cat-btn" data-cat="template" onclick="filterPathCategory('template', this)">Templates <span class="path-cat-count" id="catCount-template">0</span></button>
+            <button class="path-cat-btn" data-cat="game" onclick="filterPathCategory('game', this)">Games <span class="path-cat-count" id="catCount-game">0</span></button>
+            <button class="path-cat-btn" data-cat="challenge" onclick="filterPathCategory('challenge', this)">Challenges <span class="path-cat-count" id="catCount-challenge">0</span></button>
+        </div>
+
+        <!-- Search -->
+        <input type="text" id="pathSearch" placeholder="Search content..." style="margin-bottom:0.5rem; font-size:0.85rem;" oninput="filterPathSearch(this.value)">
+
+        <label style="margin-bottom:0.5rem;">Select Content <span style="font-weight:400; color:var(--text-muted); font-size:0.78rem;">(click to add)</span></label>
+        <div id="courseSelector" style="max-height:480px; overflow-y:auto; border:1px solid var(--border-color); border-radius:12px; padding:0.25rem; margin-bottom:0.75rem;">
             <label class="path-course-option" data-value="devecon">
                 <input type="checkbox" value="devecon" style="display:none;">
                 <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
@@ -1357,10 +1393,526 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                 </div>
                 <span class="path-course-hours">12 hrs</span>
             </label>
+
+            <!-- Section: Interactive Labs -->
+            <div class="path-section-header" data-cat="lab">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 3h6v4H9z"/><path d="M4 21l3.5-10h9L20 21z"/><path d="M7 11l-3 10h16l-3-10"/></svg>
+                Interactive Labs <span style="font-size:0.7rem; color:var(--text-muted); font-weight:400;">(12)</span>
+            </div>
+            <label class="path-course-option" data-value="lab-risk-mitigation" data-cat="lab">
+                <input type="checkbox" value="lab-risk-mitigation" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EF4444, #F97316);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 9v4M12 17h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Risk & Mitigation Lab</div>
+                    <div class="path-course-desc">Risk assessment, mitigation planning, scenario analysis</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-policy-advocacy" data-cat="lab">
+                <input type="checkbox" value="lab-policy-advocacy" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #6366F1, #8B5CF6);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Policy & Advocacy Lab</div>
+                    <div class="path-course-desc">Policy brief writing, advocacy campaign design, stakeholder mapping</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-resource-sustainability" data-cat="lab">
+                <input type="checkbox" value="lab-resource-sustainability" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #059669);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M16 8l-4 4-4-4"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Resource & Sustainability Lab</div>
+                    <div class="path-course-desc">Resource flow analysis, fundraising strategy, sustainability planning</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-impact-partnerships" data-cat="lab">
+                <input type="checkbox" value="lab-impact-partnerships" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #0EA5E9, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Impact & Partnerships Lab</div>
+                    <div class="path-course-desc">Partnership ecosystem mapping, MOU drafting, collaboration frameworks</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-mel-design" data-cat="lab">
+                <input type="checkbox" value="lab-mel-design" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #0EA5E9);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">MEL Design Lab</div>
+                    <div class="path-course-desc">M&E system design, indicator frameworks, data collection instruments</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-mel-plan" data-cat="lab">
+                <input type="checkbox" value="lab-mel-plan" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #0EA5E9);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">MEL Plan Lab</div>
+                    <div class="path-course-desc">Detailed MEL planning with indicators, baselines, and targets</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-design-thinking" data-cat="lab">
+                <input type="checkbox" value="lab-design-thinking" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F59E0B, #EC4899);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Design Thinking Lab</div>
+                    <div class="path-course-desc">Human-centered design methodology, empathy mapping, prototyping</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-toc" data-cat="lab">
+                <input type="checkbox" value="lab-toc" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Theory of Change Lab</div>
+                    <div class="path-course-desc">Build robust Theories of Change with causal pathways and assumptions</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-impact-storytelling" data-cat="lab">
+                <input type="checkbox" value="lab-impact-storytelling" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #06B6D4, #10B981);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Impact Storytelling Lab</div>
+                    <div class="path-course-desc">Narrative development for social impact, beneficiary stories</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-storytelling" data-cat="lab">
+                <input type="checkbox" value="lab-storytelling" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #06B6D4, #8B5CF6);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Storytelling Lab</div>
+                    <div class="path-course-desc">Advanced multimedia production, documentary techniques</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-community" data-cat="lab">
+                <input type="checkbox" value="lab-community" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EC4899, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Community Development & Engagement Lab</div>
+                    <div class="path-course-desc">Facilitation techniques, community mapping, participatory methods</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="lab-mle-design" data-cat="lab">
+                <input type="checkbox" value="lab-mle-design" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">MLE Design Lab</div>
+                    <div class="path-course-desc">Monitoring, Learning & Evaluation framework design and implementation</div>
+                </div>
+                <span class="path-course-hours">2 hrs</span>
+            </label>
+
+            <!-- Section: Interactive Templates -->
+            <div class="path-section-header" data-cat="template">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
+                Interactive Templates <span style="font-size:0.7rem; color:var(--text-muted); font-weight:400;">(7)</span>
+            </div>
+            <label class="path-course-option" data-value="tpl-toc-builder" data-cat="template">
+                <input type="checkbox" value="tpl-toc-builder" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #0EA5E9);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Theory of Change Builder</div>
+                    <div class="path-course-desc">Interactive ToC framework with causal pathways and assumptions</div>
+                </div>
+                <span class="path-course-hours">1 hr</span>
+            </label>
+            <label class="path-course-option" data-value="tpl-logframe" data-cat="template">
+                <input type="checkbox" value="tpl-logframe" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #059669);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Logframe Builder</div>
+                    <div class="path-course-desc">Construct complete logical frameworks with indicators and verification</div>
+                </div>
+                <span class="path-course-hours">1 hr</span>
+            </label>
+            <label class="path-course-option" data-value="tpl-stakeholder-map" data-cat="template">
+                <input type="checkbox" value="tpl-stakeholder-map" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #0EA5E9, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Stakeholder Map</div>
+                    <div class="path-course-desc">Map stakeholder influence, interest, and engagement strategies</div>
+                </div>
+                <span class="path-course-hours">1 hr</span>
+            </label>
+            <label class="path-course-option" data-value="tpl-empathy-map" data-cat="template">
+                <input type="checkbox" value="tpl-empathy-map" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EC4899, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Empathy Map</div>
+                    <div class="path-course-desc">Map what beneficiaries think, feel, say, and do</div>
+                </div>
+                <span class="path-course-hours">1 hr</span>
+            </label>
+            <label class="path-course-option" data-value="tpl-policy-canvas" data-cat="template">
+                <input type="checkbox" value="tpl-policy-canvas" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #6366F1, #8B5CF6);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Policy Analysis Canvas</div>
+                    <div class="path-course-desc">Structured policy design with stakeholder and impact analysis</div>
+                </div>
+                <span class="path-course-hours">1 hr</span>
+            </label>
+            <label class="path-course-option" data-value="tpl-ai-canvas" data-cat="template">
+                <input type="checkbox" value="tpl-ai-canvas" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #8B5CF6, #EC4899);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">AI Opportunity Canvas</div>
+                    <div class="path-course-desc">Assess AI opportunities for development projects</div>
+                </div>
+                <span class="path-course-hours">1 hr</span>
+            </label>
+            <label class="path-course-option" data-value="tpl-chart-decision" data-cat="template">
+                <input type="checkbox" value="tpl-chart-decision" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F59E0B, #10B981);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Chart Decision Tree</div>
+                    <div class="path-course-desc">Find the right chart type for your data through guided questions</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+
+            <!-- Section: Economics Games -->
+            <div class="path-section-header" data-cat="game">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+                Economics Games <span style="font-size:0.7rem; color:var(--text-muted); font-weight:400;">(12)</span>
+            </div>
+            <label class="path-course-option" data-value="game-real-middle" data-cat="game">
+                <input type="checkbox" value="game-real-middle" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #0EA5E9, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">The Real Middle</div>
+                    <div class="path-course-desc">India's middle class, wealth inequality, consumption patterns</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-risk-reward" data-cat="game">
+                <input type="checkbox" value="game-risk-reward" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F59E0B, #EF4444);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Risk & Reward Explorer</div>
+                    <div class="path-course-desc">Behavioral economics, prospect theory, decision-making under uncertainty</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-cooperation" data-cat="game">
+                <input type="checkbox" value="game-cooperation" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #0EA5E9);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Cooperation Paradox</div>
+                    <div class="path-course-desc">Game theory, strategic decision-making, collective action problems</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-public-good" data-cat="game">
+                <input type="checkbox" value="game-public-good" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #6366F1, #10B981);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Public Good Game</div>
+                    <div class="path-course-desc">Free-rider problems, collective contributions, social incentives</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-prisoners" data-cat="game">
+                <input type="checkbox" value="game-prisoners" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EF4444, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Prisoners' Dilemma</div>
+                    <div class="path-course-desc">Strategic cooperation, Nash equilibrium, iterative strategies</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-opportunity-cost" data-cat="game">
+                <input type="checkbox" value="game-opportunity-cost" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F97316, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Opportunity Cost Game</div>
+                    <div class="path-course-desc">Resource allocation, trade-offs, scarcity decision-making</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-network-effects" data-cat="game">
+                <input type="checkbox" value="game-network-effects" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #8B5CF6, #0EA5E9);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Network Effects Game</div>
+                    <div class="path-course-desc">Digital platforms, scaling dynamics, winner-take-all markets</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-bidding-wars" data-cat="game">
+                <input type="checkbox" value="game-bidding-wars" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EF4444, #F97316);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Bidding Wars</div>
+                    <div class="path-course-desc">Auction formats, price discovery, winner's curse</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-info-asymmetry" data-cat="game">
+                <input type="checkbox" value="game-info-asymmetry" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #06B6D4, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Information Asymmetry</div>
+                    <div class="path-course-desc">Adverse selection, moral hazard, signaling, screening</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-econ-concepts" data-cat="game">
+                <input type="checkbox" value="game-econ-concepts" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #0EA5E9, #10B981);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Economics Concepts Puzzle</div>
+                    <div class="path-course-desc">Puzzle-based reasoning through core economic concepts</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-externalities" data-cat="game">
+                <input type="checkbox" value="game-externalities" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F59E0B, #EF4444);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 9v4M12 17h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Externalities & Hidden Costs</div>
+                    <div class="path-course-desc">Market failures, Pigouvian taxes, social costs and benefits</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+            <label class="path-course-option" data-value="game-commons" data-cat="game">
+                <input type="checkbox" value="game-commons" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #10B981, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Commons Crisis</div>
+                    <div class="path-course-desc">Tragedy of the commons, resource stewardship, governance solutions</div>
+                </div>
+                <span class="path-course-hours">0.5 hr</span>
+            </label>
+
+            <!-- Section: Case Challenges -->
+            <div class="path-section-header" data-cat="challenge">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+                Live Case Challenges <span style="font-size:0.7rem; color:var(--text-muted); font-weight:400;">(10)</span>
+            </div>
+            <label class="path-course-option" data-value="ch-logframe-redesign" data-cat="challenge">
+                <input type="checkbox" value="ch-logframe-redesign" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EF4444, #F97316);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Redesign a Flawed Logframe</div>
+                    <div class="path-course-desc">HealthBridge Foundation MEL challenge</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-dashboard-critique" data-cat="challenge">
+                <input type="checkbox" value="ch-dashboard-critique" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F59E0B, #10B981);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Critique & Redesign a Dashboard</div>
+                    <div class="path-course-desc">POSHAN Abhiyaan data visualization challenge</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-ai-bias-audit" data-cat="challenge">
+                <input type="checkbox" value="ch-ai-bias-audit" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #8B5CF6, #EC4899);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Audit an AI Model for Bias</div>
+                    <div class="path-course-desc">Government of Jharkhand beneficiary targeting challenge</div>
+                </div>
+                <span class="path-course-hours">4 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-cost-effectiveness" data-cat="challenge">
+                <input type="checkbox" value="ch-cost-effectiveness" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #0EA5E9, #6366F1);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Cost-Effectiveness Analysis</div>
+                    <div class="path-course-desc">Government of Odisha nutrition interventions comparison</div>
+                </div>
+                <span class="path-course-hours">4 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-gesi-audit" data-cat="challenge">
+                <input type="checkbox" value="ch-gesi-audit" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EC4899, #8B5CF6);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">GESI Audit of a Livelihood Program</div>
+                    <div class="path-course-desc">Grameen Shakti gender equity & social inclusion challenge</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-gandhian-strategy" data-cat="challenge">
+                <input type="checkbox" value="ch-gandhian-strategy" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #F97316, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Gandhian Strategy for Social Movement</div>
+                    <div class="path-course-desc">Apply non-violent strategy to a contemporary campaign</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-rti-strategy" data-cat="challenge">
+                <input type="checkbox" value="ch-rti-strategy" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #6366F1, #8B5CF6);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Draft an RTI Accountability Strategy</div>
+                    <div class="path-course-desc">Jan Sarokar law & governance challenge</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-bcc-campaign" data-cat="challenge">
+                <input type="checkbox" value="ch-bcc-campaign" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #06B6D4, #10B981);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Design a BCC Campaign</div>
+                    <div class="path-course-desc">Adolescent nutrition behavior change communication</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-conflict-resolution" data-cat="challenge">
+                <input type="checkbox" value="ch-conflict-resolution" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #EC4899, #F59E0B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Design a Conflict Resolution Workshop</div>
+                    <div class="path-course-desc">Samarth Foundation SEL challenge for field teams</div>
+                </div>
+                <span class="path-course-hours">3 hrs</span>
+            </label>
+            <label class="path-course-option" data-value="ch-custom" data-cat="challenge">
+                <input type="checkbox" value="ch-custom" style="display:none;">
+                <div class="path-course-check"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></div>
+                <div class="path-course-icon" style="background:linear-gradient(135deg, #94A3B8, #64748B);">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                </div>
+                <div style="flex:1; min-width:0;">
+                    <div class="path-course-name">Request Custom Challenge</div>
+                    <div class="path-course-desc">Commission a challenge tailored to your organisation's programs</div>
+                </div>
+                <span class="path-course-hours">TBD</span>
+            </label>
         </div>
         <div id="pathSummary" style="display:none; background:var(--secondary-bg); border:1px solid var(--border-color); border-radius:10px; padding:0.75rem 1rem; margin-bottom:1rem;">
             <div style="display:flex; justify-content:space-between; align-items:center;">
-                <span style="font-size:0.85rem; font-weight:500;"><span id="pathCourseCount">0</span> courses selected</span>
+                <span style="font-size:0.85rem; font-weight:500;"><span id="pathCourseCount">0</span> items selected</span>
                 <span style="font-size:0.85rem; color:var(--accent-color); font-weight:600;"><span id="pathTotalHours">0</span> total hours</span>
             </div>
         </div>
@@ -1502,6 +2054,13 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             // Always fetch a fresh profile to get the latest subscription_tier from Supabase
             var profile = await ImpactMojoAuth.fetchProfile();
             console.log('[OrgDash] Profile:', profile ? { id: profile.id, tier: profile.subscription_tier } : null);
+
+            // Show admin panel link for admin users
+            if (profile && profile.role === 'admin') {
+                var adminLink = document.getElementById('adminPanelLink');
+                if (adminLink) adminLink.style.display = 'inline-flex';
+            }
+
             if (!profile || profile.subscription_tier !== 'organization') {
                 console.warn('[OrgDash] Access denied: tier is', profile ? profile.subscription_tier : 'no profile');
                 document.getElementById('authGate').style.display = 'block';
@@ -1684,8 +2243,51 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         updatePathSummary();
     };
 
-    // Course hours lookup
-    var COURSE_HOURS = { devecon: 20, mel: 16, dataviz: 12, devai: 12, gandhi: 14, poa: 10, media: 10, law: 14, sel: 12 };
+    // Content hours lookup (courses, labs, templates, games, challenges)
+    var CONTENT_HOURS = {
+        devecon: 20, mel: 16, dataviz: 12, devai: 12, gandhi: 14, poa: 10, media: 10, law: 14, sel: 12,
+        'lab-risk-mitigation': 2, 'lab-policy-advocacy': 2, 'lab-resource-sustainability': 2,
+        'lab-impact-partnerships': 2, 'lab-mel-design': 2, 'lab-mel-plan': 2, 'lab-design-thinking': 2,
+        'lab-toc': 2, 'lab-impact-storytelling': 2, 'lab-storytelling': 2, 'lab-community': 2, 'lab-mle-design': 2,
+        'tpl-toc-builder': 1, 'tpl-logframe': 1, 'tpl-stakeholder-map': 1, 'tpl-empathy-map': 1,
+        'tpl-policy-canvas': 1, 'tpl-ai-canvas': 1, 'tpl-chart-decision': 0.5,
+        'game-real-middle': 0.5, 'game-risk-reward': 0.5, 'game-cooperation': 0.5, 'game-public-good': 0.5,
+        'game-prisoners': 0.5, 'game-opportunity-cost': 0.5, 'game-network-effects': 0.5,
+        'game-bidding-wars': 0.5, 'game-info-asymmetry': 0.5, 'game-econ-concepts': 0.5,
+        'game-externalities': 0.5, 'game-commons': 0.5,
+        'ch-logframe-redesign': 3, 'ch-dashboard-critique': 3, 'ch-ai-bias-audit': 4,
+        'ch-cost-effectiveness': 4, 'ch-gesi-audit': 3, 'ch-gandhian-strategy': 3,
+        'ch-rti-strategy': 3, 'ch-bcc-campaign': 3, 'ch-conflict-resolution': 3, 'ch-custom': 0
+    };
+
+    // Category filtering
+    window.filterPathCategory = function(cat, btn) {
+        document.querySelectorAll('.path-cat-btn').forEach(function(b) { b.classList.remove('active'); });
+        btn.classList.add('active');
+        document.querySelectorAll('#courseSelector .path-course-option, #courseSelector .path-section-header').forEach(function(el) {
+            if (cat === 'all') { el.style.display = ''; }
+            else {
+                var elCat = el.getAttribute('data-cat') || 'course';
+                el.style.display = (elCat === cat) ? '' : 'none';
+            }
+        });
+    };
+
+    // Search filtering
+    window.filterPathSearch = function(query) {
+        query = query.toLowerCase().trim();
+        document.querySelectorAll('#courseSelector .path-course-option').forEach(function(opt) {
+            var name = opt.querySelector('.path-course-name')?.textContent?.toLowerCase() || '';
+            var desc = opt.querySelector('.path-course-desc')?.textContent?.toLowerCase() || '';
+            opt.style.display = (!query || name.includes(query) || desc.includes(query)) ? '' : 'none';
+        });
+        // Show section headers if any child in that category is visible
+        document.querySelectorAll('#courseSelector .path-section-header').forEach(function(hdr) {
+            var cat = hdr.getAttribute('data-cat');
+            var anyVisible = !!document.querySelector('#courseSelector .path-course-option[data-cat="' + cat + '"]:not([style*="display: none"])');
+            hdr.style.display = anyVisible ? '' : 'none';
+        });
+    };
 
     // Toggle course selection styling
     document.addEventListener('DOMContentLoaded', function() {
@@ -1704,7 +2306,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         var checked = document.querySelectorAll('#courseSelector input:checked');
         var count = checked.length;
         var hours = 0;
-        checked.forEach(function(c) { hours += (COURSE_HOURS[c.value] || 10); });
+        checked.forEach(function(c) { hours += (CONTENT_HOURS[c.value] || 1); });
         var summary = document.getElementById('pathSummary');
         if (count > 0) {
             summary.style.display = 'block';
@@ -1713,6 +2315,16 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         } else {
             summary.style.display = 'none';
         }
+        // Update category counts
+        ['course','lab','template','game','challenge'].forEach(function(cat) {
+            var n = document.querySelectorAll('#courseSelector .path-course-option[data-cat="' + cat + '"] input:checked').length;
+            var el = document.getElementById('catCount-' + cat);
+            if (el) el.textContent = n;
+        });
+        // Course items without data-cat count as courses
+        var courseNoAttr = document.querySelectorAll('#courseSelector .path-course-option:not([data-cat]) input:checked').length;
+        var courseEl = document.getElementById('catCount-course');
+        if (courseEl) courseEl.textContent = parseInt(courseEl.textContent || 0) + courseNoAttr;
     }
     window.closeModal = function(id) { document.getElementById(id).classList.remove('active'); };
 
@@ -1774,10 +2386,10 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         var title = document.getElementById('pathTitle').value.trim();
         var desc = document.getElementById('pathDesc').value.trim();
         var checked = document.querySelectorAll('#courseSelector input:checked');
-        var courseIds = Array.from(checked).map(function(c) { return c.value; });
+        var contentIds = Array.from(checked).map(function(c) { return c.value; });
 
         if (!title) { alert('Please enter a path title.'); return; }
-        if (courseIds.length === 0) { alert('Please select at least one course.'); return; }
+        if (contentIds.length === 0) { alert('Please select at least one item.'); return; }
 
         var { error } = await supabaseClient
             .from('learning_paths')
@@ -1785,7 +2397,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                 org_id: orgData.id,
                 title: title,
                 description: desc,
-                course_ids: courseIds,
+                course_ids: contentIds,
                 created_by: ImpactMojoAuth.getUser().id
             });
 
@@ -1795,6 +2407,10 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         document.getElementById('pathTitle').value = '';
         document.getElementById('pathDesc').value = '';
         document.querySelectorAll('#courseSelector input').forEach(function(c) { c.checked = false; });
+        document.querySelectorAll('#courseSelector .path-course-option').forEach(function(o) { o.classList.remove('selected'); });
+        document.getElementById('pathSearch').value = '';
+        filterPathCategory('all', document.querySelector('.path-cat-btn[data-cat="all"]'));
+        updatePathSummary();
         await loadPaths();
         updateStats();
     };

--- a/updates.html
+++ b/updates.html
@@ -538,9 +538,9 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
     <p class="section-sub">Features and tools we're building to push development education forward</p>
 
     <div class="roadmap-grid">
-        <div class="roadmap-item">
-            <h4><svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/></svg>Learning Pathways</h4>
-            <p>Structured credential tracks combining courses, labs, and games into coherent professional development journeys</p>
+        <div class="roadmap-item" style="border-color: #10B981;">
+            <h4><svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/></svg>Learning Pathways <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
+            <p>Custom learning path builder in the <a href="org-dashboard.html" style="color:var(--accent-color);">Organization Dashboard</a>. Combine courses, interactive labs, templates, economics games, and case challenges into structured professional development journeys for your team.</p>
         </div>
         <div class="roadmap-item">
             <h4><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>Vernacular Content</h4>
@@ -554,13 +554,13 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             <h4><svg viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>Interactive Assessments</h4>
             <p>Auto-graded quizzes, portfolio submissions, and peer review for flagship courses</p>
         </div>
-        <div class="roadmap-item">
-            <h4><svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>Open Badges & Micro-credentials</h4>
-            <p>W3C-standard verifiable digital credentials shareable on LinkedIn, proving mastery of specific development competencies</p>
+        <div class="roadmap-item" style="border-color: #10B981;">
+            <h4><svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>Open Badges & Micro-credentials <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
+            <p>W3C Open Badges 3.0 verifiable digital credentials shareable on LinkedIn. 9 course-level badges and 5 track-level credentials, auto-issued on completion. Available in your <a href="account.html" style="color:var(--accent-color);">Account</a> page.</p>
         </div>
-        <div class="roadmap-item">
-            <h4><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Live Case Challenges</h4>
-            <p>Real development problems submitted by partner NGOs and organisations for learners to solve collaboratively with expert feedback</p>
+        <div class="roadmap-item" style="border-color: #10B981;">
+            <h4><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Live Case Challenges <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
+            <p>Real development problems from partner NGOs and organisations. 10+ challenges across all tracks with expert feedback. Browse them on the <a href="challenges.html" style="color:var(--accent-color);">Challenges</a> page.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- **Path Builder**: Expanded from 9 courses to 50+ items across 5 categories (courses, labs, templates, games, challenges) with category filters and search
- **Status Fixes**: Open Badges, Live Case Challenges, and Learning Pathways changed from ROADMAP to LIVE/SHIPPED
- **Admin Panel**: Complete redesign with ImpactMojo design language, 3-button theme selector, paper plane, quick links, ideas tracker/scratch pad
- **Org Dashboard**: Admin panel link for admin-role users
- **Analytics**: Paper plane decoration, improved bar chart styling with gradients

## Test plan
- [ ] Verify path builder modal shows all 5 content categories with filters
- [ ] Confirm Open Badges shows LIVE in org-dashboard and SHIPPED in updates
- [ ] Test admin panel ideas tracker add/complete/delete
- [ ] Verify 3-button theme selector works
- [ ] Check admin panel link appears for admin users on org dashboard

https://claude.ai/code/session_01Uyj7Ju7QJmaoDyNBHku34Y