### PR TITLE
Fix: broken GitBook sidebar links on /docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -12,11 +12,16 @@
 /dictionary/        https://on-web.link/ImpactLex    301
 
 # ===========================================
-# DOCUMENTATION (GitBook) — redirect to GitBook-hosted docs
+# DOCUMENTATION (GitBook) — 200 proxy rewrite serves docs at /docs
 # ===========================================
-/docs               https://impactmojo.gitbook.io/impactmojo/  301
-/docs/              https://impactmojo.gitbook.io/impactmojo/  301
-/docs/*             https://impactmojo.gitbook.io/impactmojo/:splat  301
+/docs               https://impactmojo.gitbook.io/impactmojo/  200!
+/docs/              https://impactmojo.gitbook.io/impactmojo/  200!
+/docs/*             https://impactmojo.gitbook.io/impactmojo/:splat  200!
+
+# GitBook sidebar links use /impactmojo/* paths — redirect to /docs/*
+/impactmojo              /docs       301
+/impactmojo/             /docs/      301
+/impactmojo/*            /docs/:splat  301
 
 # ===========================================
 # INTERNAL PAGE REDIRECTS


### PR DESCRIPTION
## Summary
- Restore `200!` proxy rewrite for `/docs` → GitBook (was accidentally changed to 301)
- Add `/impactmojo/*` → `/docs/*` redirects to fix broken GitBook sidebar navigation
- GitBook sidebar generates links with `/impactmojo/` prefix (its native path), which break when served at `impactmojo.in/docs`. The new 301 redirects catch these and route them correctly.

## Test plan
- [ ] Visit https://www.impactmojo.in/docs — should load GitBook docs
- [ ] Click sidebar links (Changelog, Roadmap, etc.) — should navigate correctly instead of 404
- [ ] Visit https://www.impactmojo.in/impactmojo/operations/changelog — should redirect to /docs/operations/changelog

https://claude.ai/code/session_0182e6yYaW76Z7WNaEb1j1K3