### PR TITLE
Docs: add 11 GitBook guide pages for all platform resources

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,8 +10,22 @@
 * [Workshops & Facilitation](workshops-and-facilitation.md)
 * [Handouts Guide](handouts-guide.md)
 * [Dataverse Guide](dataverse-guide.md)
+* [BCT Repository Guide](bct-repository-guide.md)
+* [Games Guide](games-guide.md)
+* [Labs Guide](labs-guide.md)
+* [Live Case Challenges Guide](challenges-guide.md)
+* [Dojos Guide](dojos-guide.md)
+* [Podcast Guide](podcast-guide.md)
 * [Certificates & Progress](certificates-and-progress.md)
 * [FAQ](faq.md)
+
+## Tools & Resources
+
+* [Mojini (AI Assistant)](mojini-guide.md)
+* [ImpactLex (Glossary)](impactlex-guide.md)
+* [FieldCases (Case Library)](fieldcases-guide.md)
+* [Development Discourses (Research Library)](devdiscourses-guide.md)
+* [Premium Tools (VaniScribe, DevData, DevEcon Toolkit)](premium-tools-guide.md)
 
 ## Reference
 

--- a/docs/bct-repository-guide.md
+++ b/docs/bct-repository-guide.md
@@ -1,0 +1,122 @@
+# BCT Repository Guide
+
+## What Is the BCT Repository?
+
+The ImpactMojo BCT Repository is a **free, searchable collection of 200+ Behaviour Change Techniques** — combining the internationally recognised BCT Taxonomy v1 (93 core techniques) with 100+ additional techniques contextualised for South Asian development practice.
+
+If you design health programmes, WASH interventions, education campaigns, or any work that aims to change people's behaviour, this repository helps you find the right techniques backed by evidence — and use their standardised IDs in your proposals and logframes.
+
+---
+
+## What Are Behaviour Change Techniques?
+
+A **Behaviour Change Technique (BCT)** is a specific, replicable component of an intervention designed to change behaviour. Instead of vaguely saying "we'll raise awareness," a BCT gives you a precise technique with a definition, evidence base, and taxonomy ID.
+
+**Example:** BCT 1.1 "Goal Setting (behaviour)" — the person sets a specific behavioural goal (e.g., "I will wash hands before every meal"). This is a technique you can name, measure, and replicate.
+
+Using standardised BCTs in your programme design makes interventions more precise, evaluable, and comparable across studies.
+
+---
+
+## How the Repository Is Organised
+
+### By Category
+
+Techniques are organised by domain so you can find what's relevant to your sector:
+
+| Category | Focus |
+|----------|-------|
+| Health | Nutrition, maternal health, disease prevention, WASH behaviours |
+| Education | Learning habits, school attendance, teacher practices |
+| Livelihoods | Financial behaviours, agricultural practices, market participation |
+| WASH | Handwashing, sanitation adoption, water treatment |
+| Gender | Gender-equitable behaviours, GBV prevention, women's agency |
+| Governance | Civic participation, transparency, accountability behaviours |
+
+### By Evidence Level
+
+Every technique is tagged with an evidence rating:
+
+- **Strong** — Supported by multiple rigorous studies (RCTs, systematic reviews)
+- **Moderate** — Supported by observational studies or limited experimental evidence
+- **Emerging** — Promising but with limited formal evaluation
+
+When designing interventions, prioritise techniques with Strong evidence. Use Emerging techniques where no Strong alternatives exist, and plan to evaluate them.
+
+---
+
+## Key Features
+
+### Search and Filtering
+
+The repository has a full-text search with fuzzy matching — type a keyword, technique name, sector, or programme type and get ranked results. You can also filter by:
+
+- **Category** — Health, Education, WASH, Gender, Livelihoods, Governance
+- **Evidence level** — Strong, Moderate, Emerging
+- **Keyword** — any term in the technique name or definition
+
+### Technique Cards
+
+Each technique displays as a card showing:
+
+- **Taxonomy ID** (e.g., BCT 1.1) — the standardised identifier
+- **Name** — what the technique is called
+- **Definition** — precisely what the technique involves
+- **Evidence level** — colour-coded badge
+- **Category tags** — which sectors it applies to
+
+Click any card for an expanded view with related techniques and cross-links.
+
+### Bookmarks and Export
+
+- **Save techniques** to a personal collection for later reference
+- **Print individual cards** for workshop handouts
+- **Compare techniques** side by side to choose between alternatives
+- **Export to CSV** for inclusion in programme documents
+
+---
+
+## How Educators Can Use the BCT Repository
+
+### In Course Design
+
+Use the repository as a reference when teaching intervention design. Have students:
+
+1. Identify a behaviour they want to change
+2. Search the repository for relevant techniques
+3. Compare Strong vs. Emerging evidence options
+4. Select a combination of complementary techniques
+5. Write up their intervention using standardised BCT IDs
+
+### In Workshops
+
+- **Pre-read:** Assign participants to browse a specific category before the session
+- **Activity:** Give teams a case study and have them select 3–5 BCTs for their intervention design
+- **Discussion:** Compare team selections — why did different groups choose different techniques?
+
+### In Proposal Writing
+
+Teach participants to reference BCT taxonomy IDs in proposals. Funders increasingly expect evidence-based intervention design, and citing specific BCTs (e.g., "We will use BCT 1.1 Goal Setting and BCT 2.2 Feedback on behaviour") signals rigour.
+
+### Linking to Theory of Change
+
+BCTs map directly to the "activities" and "mechanisms" layers of a Theory of Change. Use the repository alongside the Theory of Change Lab to show how specific techniques drive specific outcomes.
+
+---
+
+## Getting Started
+
+1. **Visit the BCT Repository** at [impactmojo.in/bct-repository.html](https://www.impactmojo.in/bct-repository.html)
+2. **Browse by category** — start with your sector (Health, Education, WASH, etc.)
+3. **Filter by evidence level** — begin with Strong evidence techniques
+4. **Search by keyword** — try terms like "self-monitoring," "social support," or "incentive"
+5. **Bookmark useful techniques** — build a collection for your programme area
+
+---
+
+## Tips
+
+- **Combine complementary techniques.** Effective behaviour change interventions typically use 3–7 BCTs together, not just one.
+- **Check evidence in your context.** A technique with Strong evidence globally may have limited evidence in South Asian settings — the repository flags this where relevant.
+- **Use taxonomy IDs consistently.** When writing proposals, M&E plans, or research papers, always include the BCT ID alongside the name for clarity and comparability.
+- **Start with the familiar.** If you already do "awareness campaigns," search for what BCTs those campaigns actually use — you may find you're already applying techniques like BCT 5.1 "Information about health consequences" without naming them.

--- a/docs/challenges-guide.md
+++ b/docs/challenges-guide.md
@@ -1,0 +1,124 @@
+# Live Case Challenges Guide
+
+## What Are Live Case Challenges?
+
+Live Case Challenges are **authentic case studies from real partner organisations** where you apply your skills to solve actual development problems. Each challenge gives you a realistic scenario, a set of deliverables to produce, and a rubric for evaluation.
+
+ImpactMojo offers **9 challenges across 6 learning tracks**, ranging from Beginner to Advanced difficulty. Completed work can be submitted for peer feedback and earns portfolio badges.
+
+---
+
+## The 9 Challenges
+
+### MEL (Monitoring, Evaluation & Learning)
+
+| Challenge | Difficulty | Partner |
+|-----------|-----------|---------|
+| Redesign a Flawed Logframe | Intermediate | HealthBridge Foundation |
+
+**What you do:** Diagnose problems in a real logframe — weak indicators, missing assumptions, confused outcome levels — and redesign it using SMART criteria and proper causal logic.
+
+### Data & Technology
+
+| Challenge | Difficulty | Partner |
+|-----------|-----------|---------|
+| Critique and Redesign a Programme Dashboard | Intermediate | POSHAN Abhiyaan (Rajasthan) |
+| Audit an AI Model for Bias in Beneficiary Targeting | Advanced | Government of Jharkhand |
+
+**What you do:** Evaluate data visualisation choices and redesign for clarity, or audit an algorithmic targeting system for fairness across caste, gender, and geography.
+
+### Policy & Economics
+
+| Challenge | Difficulty | Partner |
+|-----------|-----------|---------|
+| Cost-Effectiveness Analysis of Two Nutrition Interventions | Intermediate | Government of Odisha |
+
+**What you do:** Compare two nutrition programmes using cost-effectiveness ratios, analyse equity implications, and make a policy recommendation with evidence.
+
+### Gender, Equity & Inclusion
+
+| Challenge | Difficulty | Partner |
+|-----------|-----------|---------|
+| Conduct a GESI Audit of a Livelihood Programme | Intermediate | Grameen Shakti |
+
+**What you do:** Analyse a livelihood programme for gender and inclusion gaps — who participates, who benefits, what barriers exist — and redesign indicators to capture equity dimensions.
+
+### Philosophy, Law & Governance
+
+| Challenge | Difficulty | Partner |
+|-----------|-----------|---------|
+| Apply Gandhian Strategy to a Contemporary Social Movement | Beginner | — |
+| Draft an RTI Strategy for an Accountability Campaign | Intermediate | Jan Sarokar (Citizens' Group) |
+
+**What you do:** Apply political philosophy frameworks to real social movements, or design a Right to Information strategy for a citizen accountability campaign.
+
+### Health, Communication & Wellbeing
+
+| Challenge | Difficulty | Partner |
+|-----------|-----------|---------|
+| Design a BCC Campaign for Adolescent Nutrition | Intermediate | District Health Society (Muzaffarpur) |
+| Design a Conflict Resolution Workshop for Field Teams | Beginner | Samarth Foundation |
+
+**What you do:** Design a behaviour change communication campaign using BCT techniques, or build a facilitation plan for managing team conflict in field settings.
+
+---
+
+## How Challenges Work
+
+Each challenge includes:
+
+1. **Case context** — 3–4 paragraphs describing a realistic scenario with specific problems to diagnose
+2. **Learning outcomes** — 4 specific skills you'll practise
+3. **Submission template** — a structured format for your deliverable
+4. **Resources** — partner documents, data files, and reference materials
+5. **Rubric** — 5–7 weighted criteria for evaluation
+6. **Time estimate** — typically 90 minutes
+
+You can save drafts as you work. Completed submissions go through peer feedback and earn badges for your ImpactMojo portfolio.
+
+---
+
+## Access
+
+| Tier | Access |
+|------|--------|
+| Explorer (free) | Selected challenges marked as Explorer tier |
+| Practitioner+ (paid) | All 9 challenges with full submission and feedback features |
+
+---
+
+## How Educators Can Use Challenges
+
+### As Capstone Assessments
+
+Challenges are ideal end-of-course assignments. After teaching MEL concepts, assign the logframe redesign challenge. After a data course, assign the dashboard critique. The rubric is already built — you can use or adapt it.
+
+### As Group Exercises
+
+Give a challenge to teams of 3–4 participants. Each team produces a joint submission and presents their approach. Different teams will make different choices — the comparison creates rich discussion.
+
+### For Portfolio Building
+
+Encourage participants to complete challenges across multiple tracks. The collection of work products (a redesigned logframe, a GESI audit, a policy brief) becomes a tangible portfolio of applied skills.
+
+### To Demonstrate Authentic Application
+
+Because challenges use real partner organisations and real scenarios, they demonstrate that learning translates to practice. This is especially valuable for training programmes that need to show funders that capacity building produces usable skills.
+
+---
+
+## Getting Started
+
+1. **Browse challenges** at [impactmojo.in/challenges.html](https://www.impactmojo.in/challenges.html)
+2. **Start with a Beginner challenge** — the Gandhian Strategy or Conflict Resolution challenges are accessible entry points
+3. **Read the full case context** before starting — understanding the scenario is half the work
+4. **Use the rubric** to self-assess before submitting — it tells you exactly what evaluators look for
+
+---
+
+## Tips
+
+- **These are real cases, not textbook exercises.** The scenarios come from actual partner organisations. Treat the work with the same rigour you'd bring to a consulting engagement.
+- **There's no single right answer.** The rubric evaluates your reasoning, evidence use, and communication — not whether you reached a specific conclusion.
+- **Combine with courses and labs.** A natural learning path is: course (concepts) → lab (practice building) → challenge (authentic application).
+- **Peer feedback is valuable.** Submit your work and engage with feedback — seeing how others approached the same problem is one of the most effective ways to learn.

--- a/docs/devdiscourses-guide.md
+++ b/docs/devdiscourses-guide.md
@@ -1,0 +1,64 @@
+# Development Discourses Guide
+
+## What Is Development Discourses?
+
+Development Discourses (DevDiscourses) is ImpactMojo's **curated open-access library of 500+ research papers, books, and grey literature** on development, social impact, and public policy.
+
+Unlike Google Scholar (which returns thousands of results of varying quality), DevDiscourses is a hand-curated collection where every resource has been selected for relevance, accessibility, and quality. It prioritises **open-access resources** — so you can actually read what you find.
+
+**Access:** Free — [Browse DevDiscourses](https://on-web.link/DevDiscourses)
+
+---
+
+## What DevDiscourses Covers
+
+| Topic area | Examples |
+|-----------|---------|
+| **MEL & Research** | Evaluation methods, indicator design, adaptive management, participatory research |
+| **Gender & Equity** | Gender mainstreaming, intersectionality, feminist research methods, GBV prevention |
+| **Climate & Environment** | Climate adaptation, environmental justice, resilience frameworks, disaster risk |
+| **Data & Governance** | Data ethics, algorithmic fairness, digital development, open data |
+| **Public Health** | Maternal health, nutrition, WASH, health systems strengthening |
+| **Livelihoods** | Financial inclusion, market systems, social protection, labour markets |
+| **Policy & Economics** | Development economics, political economy, cost-effectiveness, public finance |
+
+Resources are searchable by **topic, type, author, and keyword**.
+
+---
+
+## Types of Resources
+
+- **Journal articles** — peer-reviewed research from development and social science journals
+- **Books and book chapters** — foundational texts and recent publications
+- **Working papers** — pre-publication research from think tanks and research institutions
+- **Grey literature** — programme evaluations, policy briefs, and reports from NGOs and multilaterals
+- **Systematic reviews** — comprehensive evidence syntheses on specific topics
+
+---
+
+## How Educators Can Use DevDiscourses
+
+### Building Reading Lists
+
+Instead of spending hours searching for open-access readings, browse DevDiscourses by topic to build a reading list for your course or workshop. Every resource has been vetted for quality and accessibility.
+
+### For Literature Reviews
+
+When participants need to review evidence on a topic, DevDiscourses provides a curated starting point. It's especially useful for practitioners who aren't comfortable navigating academic databases.
+
+### As a Reference Library
+
+Point participants to DevDiscourses as an ongoing professional resource. The curated nature means they can browse by interest area and find high-quality resources without wading through noise.
+
+### Alongside Courses
+
+ImpactMojo's flagship courses reference specific papers and books. DevDiscourses extends this with a broader, cross-cutting collection that spans all learning tracks.
+
+---
+
+## Tips
+
+- **Open-access prioritised** — most resources in the collection can be read for free, unlike paywalled academic databases.
+- **Curated, not comprehensive** — DevDiscourses isn't trying to be Google Scholar. The value is in the curation: every resource was selected for relevance to South Asian development practice.
+- **500+ resources and growing** — suggest additions at hello@impactmojo.in.
+- **Combine with FieldCases** — DevDiscourses provides the theory and evidence; FieldCases provides the practice examples.

--- a/docs/dojos-guide.md
+++ b/docs/dojos-guide.md
@@ -1,0 +1,124 @@
+# Dojos Guide
+
+## What Are ImpactMojo Dojos?
+
+Dojos are **90-minute, cohort-based practice sessions** where development professionals build specific skills through structured exercises — not lectures. The name comes from martial arts: a dojo is a place where you practise, not where you watch someone else perform.
+
+ImpactMojo offers **56 sessions across 6 skill series**, available in Delhi, Bangalore, and Online.
+
+**Cost:** ₹1,500 per person per session. No long-term commitment — join individual sessions or follow a full series.
+
+---
+
+## The 6 Skill Series
+
+### S01: Thinking Clearly in Development (8 sessions)
+
+Build the foundation of clear reasoning for development work. Topics include calibrating your confidence, spotting cognitive biases in programme design, probabilistic thinking for uncertain environments, and avoiding common reasoning traps.
+
+**Who it's for:** Anyone who makes decisions under uncertainty — which is everyone in development.
+
+### S02: Evidence Reasoning (9 sessions)
+
+Develop the ability to read, interpret, and apply evidence critically. Topics include statistical thinking without the maths anxiety, hypothesis testing in field conditions, research design basics, cost-effectiveness analysis, and updating beliefs when new evidence arrives.
+
+**Who it's for:** Programme managers, MEL officers, and anyone who needs to make evidence-informed decisions.
+
+### S03: Political Economy & Implementation (16 sessions)
+
+The largest series, covering the practical realities of getting things done in complex systems. Topics include stakeholder mapping, implementation diagnosis, scaling decisions, adaptive management, systems mapping, negotiation tactics, service design, exit strategy design, value and pricing, live facilitation, and participatory methods.
+
+**Who it's for:** Senior programme staff, team leads, consultants, and anyone navigating organisational and political dynamics.
+
+### S04: Methods That Actually Work (9 sessions)
+
+Practical methodologies for development fieldwork — the techniques that experienced practitioners use but rarely teach formally. Focused on methods that survive contact with the field.
+
+**Who it's for:** Field researchers, evaluation specialists, and practitioners designing data collection.
+
+### S05: Epistemic Hygiene (8 sessions)
+
+Build intellectual honesty as a professional skill. Topics include catching common lies we tell ourselves, calibrating magnitude (does this number actually matter?), distinguishing evidence from intuition, Fermi estimation for quick sanity checks, and honest writing.
+
+**Who it's for:** Anyone who writes reports, makes claims, or presents findings — and wants to do so honestly.
+
+### S06: Gender, Power & Data (6 sessions)
+
+Apply GESI (Gender Equality and Social Inclusion) principles with rigour, not just rhetoric. Topics include third gender in South Asian fieldwork, quantifying social dynamics, power analysis, and designing gender-responsive data collection.
+
+**Who it's for:** Gender specialists, GESI advisors, and anyone designing programmes that claim to be inclusive.
+
+---
+
+## How Dojos Work
+
+Each dojo session follows a consistent format:
+
+1. **Orientation** — every series begins with a session that sets ground rules and calibrates the group
+2. **Brief framing** (10–15 minutes) — the facilitator introduces the skill and its relevance
+3. **Structured practice** (50–60 minutes) — participants work through exercises, often in pairs or small groups
+4. **Debrief** (15–20 minutes) — group reflection on what was learned and how it applies to real work
+
+The emphasis is on *doing*. Participants leave each session having practised a specific skill, not just having heard about it.
+
+---
+
+## How Educators Can Use Dojos
+
+### For Team Development
+
+Send team members to specific series based on their development needs:
+- New staff → S01 (Thinking Clearly) as a foundation
+- MEL team → S02 (Evidence Reasoning) for technical skills
+- Senior managers → S03 (Political Economy) for leadership challenges
+- Report writers → S05 (Epistemic Hygiene) for honest communication
+
+### As a Learning Pathway
+
+Series are designed to be taken in sequence within a series, but participants can join individual sessions. For a comprehensive development, consider:
+
+1. Start with S01 (foundations of clear thinking)
+2. Add S02 (evidence and research skills)
+3. Specialise with S03, S04, S05, or S06 based on role
+
+### For Workshop Facilitation Skills
+
+S03 includes sessions on live facilitation and participatory methods — valuable for anyone who runs workshops or training sessions.
+
+### Combined with Online Learning
+
+Dojos complement ImpactMojo's free courses. A participant might:
+1. Take the MEL course online (self-paced, free)
+2. Attend S02 dojos to practise evidence reasoning skills in person
+3. Complete the MEL Plan Lab to produce a real deliverable
+
+---
+
+## Logistics
+
+| Detail | Info |
+|--------|------|
+| **Duration** | 90 minutes per session |
+| **Cost** | ₹1,500 per person per session |
+| **Locations** | Delhi, Bangalore, Online |
+| **Group size** | Small cohorts for active participation |
+| **Commitment** | Pay-per-session, no subscription required |
+| **Prerequisites** | None for S01; other series are accessible independently but benefit from S01 foundations |
+
+---
+
+## Getting Started
+
+1. **Browse the Dojos catalogue** at [impactmojo.in/dojos.html](https://www.impactmojo.in/dojos.html)
+2. **Start with S01: Thinking Clearly** if you're new — it builds the mental foundations all other series rely on
+3. **Pick individual sessions** from any series if a specific topic matches your immediate needs
+4. **Contact** [hello@impactmojo.in](mailto:hello@impactmojo.in) for group bookings or custom cohorts
+
+---
+
+## Tips
+
+- **Dojos are not lectures.** Come prepared to participate, not just listen. The value is in the practice.
+- **One session builds one skill.** Each 90-minute session is focused and self-contained — you leave with a specific capability you didn't have before.
+- **Cohorts create accountability.** Attending with colleagues or joining a regular cohort builds peer learning relationships that extend beyond the sessions.
+- **Sliding scale available.** Grassroots organisations can request adjusted pricing — contact hello@impactmojo.in.

--- a/docs/fieldcases-guide.md
+++ b/docs/fieldcases-guide.md
@@ -1,0 +1,65 @@
+# FieldCases Guide
+
+## What Is FieldCases?
+
+FieldCases is ImpactMojo's **free, searchable library of 200 cited development case studies from 117 countries**. Every case is grounded in published research — no anecdotal stories or unverified claims.
+
+The library covers financial inclusion, health, education, governance, livelihoods, climate, gender, and more — organised by topic, region, and methodology so you can find exactly the cases you need for teaching, proposals, or programme design.
+
+**Access:** Free — [Browse FieldCases](https://varnasr.github.io/dev-case-studies/)
+
+---
+
+## What FieldCases Covers
+
+### By Topic (10 areas)
+
+Financial inclusion, health systems, education, governance and accountability, livelihoods, climate and environment, gender and equity, WASH, nutrition, and digital development.
+
+### By Region (7 regions)
+
+South Asia, Sub-Saharan Africa, East Asia & Pacific, Latin America & Caribbean, Middle East & North Africa, Europe & Central Asia, and global/multi-country studies.
+
+### By Methodology
+
+RCTs, quasi-experimental studies, mixed methods, qualitative research, programme evaluations, and systematic reviews.
+
+---
+
+## Key Features
+
+- **Every claim is cited** — case studies reference published research, not opinion
+- **Searchable by topic, region, and keyword** — find cases relevant to your specific programme area
+- **Practitioner-oriented summaries** — cases are written for programme designers and trainers, not academic audiences
+- **200 cases across 117 countries** — broad enough to find relevant parallels for almost any development context
+
+---
+
+## How Educators Can Use FieldCases
+
+### For Teaching
+
+Use cases as discussion material in workshops and courses. Instead of hypothetical scenarios, participants analyse real programmes with documented outcomes.
+
+**Example:** Teaching cost-effectiveness? Pull cases comparing two health interventions in similar contexts and have participants evaluate which delivered more impact per dollar.
+
+### For Proposal Writing
+
+When writing proposals, cite relevant cases to demonstrate that your approach has evidence. FieldCases makes it easy to find documented examples of similar interventions in similar contexts.
+
+### For Programme Design
+
+Before designing a new programme, search FieldCases for what's already been tried in your sector and region. Learning from others' successes and failures saves time and improves design.
+
+### As Assignment Material
+
+Assign students or participants a case study to analyse using a specific framework (ToC, GESI audit, cost-effectiveness). The documented evidence base makes these exercises rigorous.
+
+---
+
+## Tips
+
+- **Filter by region first** if you need context-specific examples — a case from Bihar is more persuasive than one from Bolivia when designing a programme in Odisha.
+- **Check the methodology** — if you're teaching RCTs, filter for experimental studies; if you're teaching adaptive management, look for mixed-methods evaluations.
+- **Combine with Live Case Challenges** — FieldCases provides background evidence; Challenges provide structured application exercises.
+- **200 cases and growing** — suggest additions at hello@impactmojo.in.

--- a/docs/games-guide.md
+++ b/docs/games-guide.md
@@ -1,0 +1,93 @@
+# Games Guide
+
+## What Are the ImpactMojo Games?
+
+ImpactMojo offers **12 interactive economics games** that teach development-relevant concepts through strategic decision-making and simulation. Each game takes 10–20 minutes to play and covers a specific economic concept — from game theory to market failures to collective action.
+
+These aren't quizzes or flashcards. They're interactive simulations where your decisions have consequences, and the concepts become clear through play rather than lecture.
+
+All 12 games are **free, browser-based, and require no login**.
+
+---
+
+## The 12 Games
+
+### Collective Action & Cooperation
+
+| Game | Concept | What You Learn |
+|------|---------|---------------|
+| **Public Good Game** | Free-rider problem | Why people under-contribute to shared resources, and what mechanisms sustain cooperation |
+| **Commons Crisis Game** | Tragedy of the commons | How communication, monitoring, and sanctions help communities manage shared resources like water, forests, or fisheries |
+| **Cooperation Paradox** | Game theory | Why cooperation yields better outcomes but individual incentives push toward competition — Nash equilibrium and Pareto efficiency in action |
+| **Prisoners' Dilemma Game** | Strategic interdependence | How trust, reputation, and repeated interactions overcome cooperation failures |
+
+### Markets & Decision-Making
+
+| Game | Concept | What You Learn |
+|------|---------|---------------|
+| **Opportunity Cost Game** | Tradeoffs | How every choice has a cost — the next-best alternative you gave up — and how this shapes policy decisions |
+| **Risk & Reward Explorer** | Behavioural economics | Risk preferences, expected utility, prospect theory — why people make seemingly irrational choices under uncertainty |
+| **Bidding Wars Game** | Auction theory | How different auction formats affect prices, why winners sometimes overpay (winner's curse), and how procurement works |
+| **Information Asymmetry Game** | Asymmetric information | Adverse selection, moral hazard, and signalling — what happens when buyers and sellers know different things |
+
+### Systems & Scale
+
+| Game | Concept | What You Learn |
+|------|---------|---------------|
+| **Network Effects Game** | Network economics | How value multiplies as more people join, critical mass dynamics, and why some platforms dominate |
+| **Externality Game** | Market failures | Hidden social costs and benefits — pollution, education spillovers — and why markets alone don't solve them |
+| **The Real Middle** | Inequality dynamics | Wealth distribution, income mobility, and the precarity of middle-class status in India |
+| **Econ Concepts Puzzle** | Mixed economics | Economic reasoning through puzzles and brain-teasers covering supply/demand, game theory, and market structure |
+
+---
+
+## How Educators Can Use the Games
+
+### As Workshop Openers
+
+Play a game at the start of a session to introduce a concept experientially. Participants engage with the idea *before* you explain the theory — this creates curiosity and gives them a shared reference point for discussion.
+
+**Example flow:**
+1. Play the Public Good Game (10 minutes)
+2. Debrief: "What happened? Why did contributions drop?" (10 minutes)
+3. Introduce the formal concept of public goods and free-riding (15 minutes)
+4. Discuss real-world applications in their programmes (15 minutes)
+
+### As Classroom Activities
+
+Games work well projected on a screen for group play. Have the class vote on decisions together, or split into teams and compare outcomes.
+
+**Good pairings:**
+- Public Good Game + Commons Crisis = comprehensive view of collective action
+- Information Asymmetry + Externality = understanding market failures together
+- Prisoners' Dilemma + Cooperation Paradox = deep dive into strategic thinking
+
+### As Self-Study Assignments
+
+Assign 2–3 games as pre-work before a workshop. Ask participants to write a one-paragraph reflection: "What surprised you? How does this concept show up in your work?"
+
+### For Debrief Discussions
+
+After any game, these questions work well:
+- What strategy did you use? Did it change over rounds?
+- What surprised you about the outcome?
+- Where do you see this dynamic in your development work?
+- What mechanisms could change the outcome?
+
+---
+
+## Getting Started
+
+1. **Visit the Games section** on [impactmojo.in](https://www.impactmojo.in) — scroll to the Games showcase or find them in the catalog
+2. **Start with Public Good Game or Prisoners' Dilemma** — these are the most intuitive entry points
+3. **Play each game yourself first** before using it in a workshop, so you can anticipate participant questions
+4. **No login or download required** — games run in any modern browser on desktop or mobile
+
+---
+
+## Tips
+
+- **Games are designed for adults, not children.** The framing, language, and complexity are pitched at development practitioners and university students.
+- **Debrief is where learning happens.** The game itself creates the experience; the discussion afterward creates the understanding. Always budget time for debrief.
+- **Play multiple rounds.** Most games reveal deeper dynamics on second and third plays as participants adjust their strategies.
+- **Connect to real programmes.** After playing the Commons Crisis Game, ask: "Where in your WASH programme do you see a commons dilemma?" This transfer step is essential.

--- a/docs/impactlex-guide.md
+++ b/docs/impactlex-guide.md
@@ -1,0 +1,61 @@
+# ImpactLex Guide
+
+## What Is ImpactLex?
+
+ImpactLex is ImpactMojo's **searchable glossary of 500+ development terms** — acronyms, concepts, formulas, frameworks, and case study references that development professionals encounter daily.
+
+It works as a standalone Progressive Web App (PWA), meaning you can install it on your phone and use it offline — handy when you're in the field and need to look up what "DALY" means or how a Gini coefficient is calculated.
+
+**Access:** Free — [Open ImpactLex](https://on-web.link/ImpactLex)
+
+---
+
+## What ImpactLex Covers
+
+| Category | Examples |
+|----------|---------|
+| **Acronyms** | DALY, WASH, NREGA, SDG, GBV, FGD, KII, ToC, MEL, BCC |
+| **Concepts** | Adverse selection, moral hazard, intersectionality, Pareto efficiency, social capital |
+| **Formulas** | Gini coefficient, cost-effectiveness ratio, sample size calculation, odds ratio |
+| **Frameworks** | Theory of Change, Logical Framework, Results-Based Management, GESI analysis |
+| **Methods** | RCT, difference-in-differences, propensity score matching, most significant change |
+| **Institutions** | World Bank, UNDP, 3ie, J-PAL, NITI Aayog, NSSO |
+
+Each entry includes a **contextual definition** written for practitioners, not academics — explaining not just what a term means but when and why you'd use it.
+
+---
+
+## Features
+
+- **Search** — type any term, acronym, or keyword and get instant results
+- **Finance Word of the Day** — daily featured term to build vocabulary over time
+- **Offline access** — install as a PWA on mobile for field use without internet
+- **Cross-referenced** — related terms link to each other for deeper exploration
+
+---
+
+## How Educators Can Use ImpactLex
+
+### As a Workshop Reference
+
+Project ImpactLex during sessions so participants can look up unfamiliar terms in real time. Development jargon is a real barrier — having a searchable reference reduces the "I don't want to ask what that means" problem.
+
+### As a Study Aid
+
+Assign participants to learn 5–10 new terms per week from ImpactLex. The contextual definitions help practitioners build vocabulary that connects to their actual work.
+
+### Alongside Courses
+
+Each ImpactMojo flagship course has its own interactive lexicon. ImpactLex complements these with a broader, cross-cutting glossary that spans all tracks.
+
+### For Report Writing
+
+When participants are writing proposals or reports, ImpactLex helps them use terminology correctly. Misusing terms like "output" vs. "outcome" or "monitoring" vs. "evaluation" is common — ImpactLex provides clear definitions.
+
+---
+
+## Tips
+
+- **Install the PWA** for offline access — especially useful for field-based staff who may not have reliable internet.
+- **500+ terms and growing** — if you can't find a term, contact hello@impactmojo.in to suggest additions.
+- **Use alongside course lexicons** — flagship courses have specialised glossaries; ImpactLex covers the broader development vocabulary.

--- a/docs/labs-guide.md
+++ b/docs/labs-guide.md
@@ -1,0 +1,94 @@
+# Labs Guide
+
+## What Are the ImpactMojo Labs?
+
+ImpactMojo offers **10 interactive labs** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), labs produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
+
+All labs are **free, browser-based, and require no login**.
+
+---
+
+## The 10 Labs
+
+### MEL & Research Labs
+
+| Lab | What You Build | Link |
+|-----|---------------|------|
+| **Theory of Change Lab** | A structured ToC with assumptions, indicators, and causal pathways | [Open](https://101.impactmojo.in/toc-workbench) |
+| **MLE Design Lab** | A monitoring, learning, and evaluation framework for your programme | [Open](https://101.impactmojo.in/mel-design-lab) |
+| **MEL Plan Lab** | A complete MEL plan with data collection schedule, tools, and responsibilities | [Open](https://101.impactmojo.in/mel-plan-lab) |
+| **Design Thinking Lab** | A human-centred design process from empathy mapping to prototyping | [Open](https://101.impactmojo.in/design-thinking-lab) |
+| **Community Development Lab** | A participatory community assessment and action plan | [Open](https://101.impactmojo.in/community-lab) |
+| **Risk and Mitigation Lab** | A risk register with likelihood, impact, and mitigation strategies | [Open](https://101.impactmojo.in/risk-mitigation-lab) |
+| **Resource and Sustainability Lab** | A resource mobilisation and sustainability plan | [Open](https://101.impactmojo.in/resource-sustainability-lab) |
+| **Impact and Partnerships Lab** | A partnership mapping and impact measurement framework | [Open](https://101.impactmojo.in/impact-partnerships) |
+
+### Communication & Governance Labs
+
+| Lab | What You Build | Link |
+|-----|---------------|------|
+| **Storytelling Lab** | A structured impact story with narrative arc and evidence integration | [Open](https://101.impactmojo.in/storytelling-lab) |
+| **Policy & Advocacy Lab** | A policy brief and advocacy strategy with stakeholder mapping | [Open](https://101.impactmojo.in/policy-advocacy-lab) |
+
+---
+
+## How Labs Work
+
+Each lab follows a structured, step-by-step process:
+
+1. **Context setting** — you describe your programme, target group, and objectives
+2. **Guided building** — the lab walks you through each component with prompts and examples
+3. **Output generation** — your work is assembled into a formatted, exportable document
+4. **Export** — download as PDF or PNG for use in proposals, reports, and presentations
+
+Labs are designed to be completed in **30–60 minutes**, though you can save progress and return later.
+
+---
+
+## How Educators Can Use the Labs
+
+### As Workshop Exercises
+
+Labs are ready-made workshop activities. Participants work through a lab using their own programme as the case study, producing an output they can actually use.
+
+**Example: Theory of Change Workshop (2 hours)**
+1. Brief intro to ToC concepts (20 minutes)
+2. Participants open the Theory of Change Lab (5 minutes)
+3. Guided building — facilitator walks the room while participants work (60 minutes)
+4. Pairs share and critique each other's ToCs (20 minutes)
+5. Plenary discussion on common challenges (15 minutes)
+
+### As Course Assignments
+
+Assign a lab as a graded deliverable. The exported output serves as the submission — it's a real work product, not an exam answer.
+
+**Good assignment pairings:**
+- MEL course → MEL Plan Lab
+- Policy course → Policy & Advocacy Lab
+- Programme design course → Theory of Change Lab + Risk and Mitigation Lab
+
+### As Team Planning Tools
+
+Use labs during actual programme planning meetings. The structured prompts help teams think through components they might otherwise skip.
+
+### For Portfolio Building
+
+Participants can collect lab outputs across multiple sessions to build a professional portfolio showing their ability to design ToCs, MEL frameworks, risk registers, and policy briefs.
+
+---
+
+## Getting Started
+
+1. **Start with the Theory of Change Lab** — it's the most widely applicable and gives you a feel for how labs work
+2. **Use your own programme** as the case study — the output will be immediately useful
+3. **Export your work** — every lab produces a downloadable PDF or PNG
+4. **Try 2–3 labs** to see how they build on each other (e.g., ToC → MEL Design → MEL Plan is a natural progression)
+
+---
+
+## Tips
+
+- **Labs produce real outputs.** Unlike simulations, what you build in a lab is something you can include in a proposal or report. Treat it as real work, not practice.
+- **Facilitators should complete each lab first.** Know what the prompts ask and where participants might get stuck before running a workshop.
+- **Pair labs with courses.** The MEL course teaches concepts; the MEL Plan Lab applies them. Using both together reinforces learning.
+- **Group work is effective.** Have 2–3 participants collaborate on one lab output — the discussion about what to include is as valuable as the output itself.

--- a/docs/mojini-guide.md
+++ b/docs/mojini-guide.md
@@ -1,0 +1,52 @@
+# Mojini Guide
+
+## What Is Mojini?
+
+Mojini is ImpactMojo's **AI-powered chatbot assistant** — available across the platform to answer questions about courses, labs, tools, pricing, and how to use ImpactMojo's resources.
+
+Think of Mojini as a knowledgeable guide who has read every page on the platform and can point you to exactly what you need. Ask about a specific course, a premium tool, how certificates work, or where to find a particular dataset — Mojini responds with accurate, contextual answers.
+
+---
+
+## What Mojini Can Help With
+
+| Question type | Examples |
+|--------------|---------|
+| **Finding resources** | "Where can I find MEL handouts?" / "Which course covers econometrics?" |
+| **Understanding features** | "How do certificates work?" / "What's the difference between Explorer and Practitioner tiers?" |
+| **Tool guidance** | "What is VaniScribe?" / "How do I use the Theory of Change Lab?" |
+| **Course navigation** | "Which course should I take first?" / "What topics does the Media course cover?" |
+| **Pricing and access** | "How much do Dojos cost?" / "What's included in the free tier?" |
+| **Technical help** | "How do I export my lab output?" / "Where is my certificate?" |
+
+---
+
+## How Mojini Works
+
+Mojini draws on a **structured FAQ knowledge base** covering 30+ topic patterns across the platform. Responses are grounded in actual platform content — Mojini doesn't generate speculative answers.
+
+The chatbot appears as a small widget on platform pages. Click it to open a conversation, type your question in natural language, and get an immediate response with links to relevant pages.
+
+---
+
+## How Educators Can Use Mojini
+
+### For Self-Service Support
+
+Point participants to Mojini when they have platform questions during a workshop. Instead of fielding "where do I find X?" questions yourself, participants can ask Mojini directly.
+
+### For Resource Discovery
+
+Mojini knows about all 48 courses, 12 games, 10 labs, 200+ handouts, and premium tools. When participants need to find something specific, Mojini can direct them faster than browsing the catalog.
+
+### As a Navigation Aid
+
+For first-time users who feel overwhelmed by the platform's breadth, Mojini provides a conversational entry point. Participants can describe what they're looking for in their own words and get pointed in the right direction.
+
+---
+
+## Tips
+
+- **Ask specific questions** for the best responses. "Which course covers gender mainstreaming?" works better than "tell me about gender."
+- **Mojini covers platform content, not general development questions.** It's a guide to ImpactMojo's resources, not a development encyclopedia.
+- **Available on most pages** — look for the chat widget in the corner of the screen.

--- a/docs/podcast-guide.md
+++ b/docs/podcast-guide.md
@@ -1,0 +1,52 @@
+# Podcast Guide
+
+## Between the Logframes
+
+**Between the Logframes: Development Conversations That Matter** is ImpactMojo's podcast — 30-minute episodes exploring the honest reality of development work.
+
+Hosted by **Dr. Varna Sri Raman** (Founder, ImpactMojo; PhD in Development Economics) and **Vandana Soni** (Business Partner, ImpactMojo), the podcast covers topics development professionals face every day but rarely discuss openly.
+
+---
+
+## What the Podcast Covers
+
+The podcast tackles the gap between how development work is *supposed* to go and how it *actually* goes:
+
+- When indicators lie — and what to do about it
+- Why Theory of Change becomes a tick-box exercise
+- What happens when community needs don't match donor priorities
+- The unglamorous realities of fieldwork
+- Honest conversations about failure, compromise, and learning
+
+The tone is conversational but rigorous — combining academic depth (Dr. Raman's economics background) with operational reality (Soni's business and partnerships experience).
+
+---
+
+## How Educators Can Use the Podcast
+
+### As Pre-Reading (Pre-Listening)
+
+Assign an episode before a workshop session. Use it as a discussion starter: "The hosts argued that most logframes are aspirational fiction. Do you agree? What's your experience?"
+
+### For Reflective Practice
+
+Recommend the podcast to participants as ongoing professional development. Episodes are designed to prompt honest reflection about development practice — the kind of thinking that doesn't happen in formal training.
+
+### As a Model for Honest Discourse
+
+The podcast models the kind of frank, evidence-informed conversation that development teams often avoid. Use episodes to show participants that questioning assumptions and admitting uncertainty are professional strengths, not weaknesses.
+
+---
+
+## Where to Listen
+
+- **Spotify** — search "Between the Logframes"
+- **Subscribe for updates** at [hello@impactmojo.in](mailto:hello@impactmojo.in) for notifications when new episodes drop, plus behind-the-scenes content
+
+---
+
+## Tips
+
+- **Episodes are 30 minutes** — short enough to assign as homework, long enough to go deep on a topic.
+- **The hosts bring contrasting expertise.** Dr. Raman approaches topics from an economics and evidence perspective; Soni from an operations and partnerships perspective. This tension creates useful discussion.
+- **New episodes are being added regularly.** Subscribe to stay current.

--- a/docs/premium-tools-guide.md
+++ b/docs/premium-tools-guide.md
@@ -1,0 +1,122 @@
+# Premium Tools Guide
+
+## Overview
+
+ImpactMojo's premium tools are **advanced, specialised resources** for researchers and practitioners who need capabilities beyond the free platform. They're designed for fieldwork, data analysis, and technical research tasks.
+
+Premium tools require a paid membership (Practitioner or Professional tier). The free platform covers 95% of learning content — premium tools serve specific professional needs.
+
+---
+
+## VaniScribe: AI Transcription
+
+**What it does:** Transcribes field interviews, focus group discussions (FGDs), and key informant interviews (KIIs) in **10+ South Asian languages** — Hindi, Tamil, Bengali, Marathi, Telugu, Kannada, Malayalam, Gujarati, Odia, Punjabi, and more.
+
+**Key features:**
+- Speaker diarization (identifies who said what)
+- Automated timestamping
+- Export to structured formats for qualitative analysis
+- Powered by Sarvam AI for South Asian language accuracy
+
+**Who it's for:** Qualitative researchers doing fieldwork in regional languages. Transcribing a 60-minute Hindi interview manually takes 4–6 hours. VaniScribe reduces this dramatically.
+
+**Access:** Professional tier — [Open VaniScribe](https://101.impactmojo.in/vaniscribe)
+
+---
+
+## DevData Practice: Dataset Generators
+
+**What it does:** Generates **realistic synthetic datasets** for learning and practice. 36 generators produce 840,000+ rows of data modelled on real development survey structures — DHS, NFHS, ASER, MGNREGA, and more.
+
+**Dataset categories:**
+- Household surveys and consumption data
+- RCT experimental data
+- Health and nutrition indicators
+- Education and learning outcomes
+- Agricultural and livelihood data
+- Gender and GBV indicators
+- Climate and environmental data
+- WASH coverage data
+- Humanitarian response data
+- IRT psychometric data
+
+**Who it's for:** Trainers teaching data analysis, students practising statistical methods, and researchers testing analytical approaches before working with real data.
+
+**Why synthetic data?** Real development data is often sensitive, restricted, or messy in ways that distract from learning. DevData Practice generates clean, realistic datasets so learners can focus on methods, not data cleaning.
+
+**Access:** Professional tier — [Open DevData Practice](https://varnasr.github.io/devdata-practice/)
+
+---
+
+## Visualization Cookbook
+
+**What it does:** Provides **14 chart types with production-ready Python code** using a question-driven approach. Instead of browsing chart galleries, you select the story your data tells (comparison, distribution, relationship, composition, time series, spatial) and get the right chart with working code.
+
+**Who it's for:** Practitioners who need to create publication-quality charts for reports and presentations and want ready-to-use code rather than starting from scratch.
+
+**Access:** Part of DevData Practice — [Open Visualization Cookbook](https://varnasr.github.io/devdata-practice/charts.html)
+
+---
+
+## DevEconomics Toolkit
+
+**What it does:** A collection of **11 interactive Shiny apps** covering core development economics methods:
+
+| App | What it does |
+|-----|-------------|
+| RCT Power Calculator | Calculate sample sizes for randomised controlled trials |
+| DiD Simulator | Visualise difference-in-differences estimation |
+| RDD Explorer | Explore regression discontinuity designs |
+| Synthetic Control Visualiser | Build synthetic control counterfactuals |
+| Gini & Lorenz Curve Tool | Calculate and visualise inequality measures |
+| MPI Explorer | Explore multidimensional poverty indices |
+| Poverty Line Analysis | Analyse poverty headcounts and gaps |
+| Theory of Change Visualiser | Build and visualise ToC diagrams |
+| Cost-Benefit Analysis Tool | Structure and calculate CBA |
+| LogFrame Builder | Construct logical frameworks |
+| WDI Dashboard | Explore World Development Indicators |
+
+**Who it's for:** Development economists, evaluation specialists, and students learning econometric methods. Each app makes a complex method interactive — you adjust parameters and see results in real time.
+
+**Access:** Professional tier — [Open DevEconomics Toolkit](https://varnasr.github.io/deveconomics-toolkit/)
+
+---
+
+## Other Premium Tools
+
+| Tool | What it does | Access |
+|------|-------------|--------|
+| **Qualitative Research Lab (Qual Insights)** | AI-assisted qualitative coding and analysis | Professional |
+| **Statistical Analysis Assistant** | Statistical toolkit for development research | Professional |
+| **RQ Builder Pro** | Research question formulation framework | Practitioner+ |
+| **Code Converter Pro** | Translate code between R, Stata, SPSS, and Python | Professional |
+| **Field Notes from a Dev Economist** | In-depth practitioner analysis and reflections | Free |
+
+---
+
+## How Educators Can Use Premium Tools
+
+### For Training Workshops
+
+- Use **DevData Practice** to generate datasets for hands-on data analysis exercises — no need to source or anonymise real data
+- Use the **DevEconomics Toolkit** apps to demonstrate econometric methods interactively — participants adjust parameters and see how results change
+- Use the **Visualization Cookbook** to teach chart selection — participants choose the right chart for their data story
+
+### For Research Support
+
+- **VaniScribe** saves enormous time on transcription during qualitative fieldwork
+- **Qual Insights** provides AI-assisted coding for interview and FGD transcripts
+- **Code Converter Pro** helps teams working across statistical packages (common when collaborating across organisations)
+
+### For Institutional Use
+
+The **Organization tier** (₹1,499/user/month) provides team-wide access to all premium tools plus a training dashboard. Contact [hello@impactmojo.in](mailto:hello@impactmojo.in) for group pricing and sliding scale options.
+
+---
+
+## Tips
+
+- **Start with the free platform.** Premium tools solve specific professional problems — make sure you've explored the free courses, games, labs, and handouts first.
+- **VaniScribe is the highest-impact tool** for qualitative researchers working in South Asian languages. If you do fieldwork in Hindi, Tamil, or Bengali, this alone justifies a Professional subscription.
+- **DevData Practice is ideal for trainers.** Instead of hunting for suitable practice datasets, generate exactly what you need in seconds.
+- **Sliding scale available** for grassroots organisations — contact hello@impactmojo.in.


### PR DESCRIPTION
## Summary
- Added 11 dedicated GitBook guide pages for every major platform resource
- New "For Educators" guides: BCT Repository, Games, Labs, Dojos, Live Case Challenges, Podcast
- New "Tools & Resources" section: Mojini, ImpactLex, FieldCases, DevDiscourses, Premium Tools (VaniScribe, DevData, DevEcon Toolkit)
- Updated SUMMARY.md sidebar with all new pages organized into clear sections

## Test plan
- [ ] Trigger GitBook sync and verify all 11 new pages appear in the sidebar
- [ ] Confirm "For Educators" section shows all resource guides
- [ ] Confirm new "Tools & Resources" section appears with 5 entries
- [ ] Spot-check links in each guide page