### PR TITLE
Fix game section cards: replace Netlify URLs with /Games/ paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -9890,7 +9890,7 @@ body.introjs-active-tour .nav-links > li.has-dropdown:not(.tour-dropdown-open):h
 <p class="section-subtitle">Learn economic concepts through engaging simulations</p>
 <div class="cards-grid">
 <div class="card">
-<a href="https://therealmiddle.netlify.app" rel="noopener noreferrer" target="_blank">
+<a href="/Games/real-middle-india.html" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
@@ -9921,7 +9921,7 @@ body.introjs-active-tour .nav-links > li.has-dropdown:not(.tour-dropdown-open):h
 </a>
 </div>
 <div class="card">
-<a href="https://risk-reward-be.netlify.app" rel="noopener noreferrer" target="_blank">
+<a href="/Games/risk-reward-game.html" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
@@ -9952,7 +9952,7 @@ body.introjs-active-tour .nav-links > li.has-dropdown:not(.tour-dropdown-open):h
 </a>
 </div>
 <div class="card">
-<a href="https://cooperationparadox.netlify.app/" rel="noopener noreferrer" target="_blank">
+<a href="/Games/cooperation-paradox-game.html" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>


### PR DESCRIPTION
## Summary
- Fixed 3 game showcase cards still pointing to Netlify (The Real Middle, Risk & Reward, Cooperation Paradox)
- Updated to self-hosted /Games/*.html paths

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo