### PR TITLE
Fix mobile: games section + redirect loop in mobile-index.html

### DIFF
--- a/mobile-index.html
+++ b/mobile-index.html
@@ -1314,15 +1314,15 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
             <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
             All Courses
         </a>
-        <a href="index.html#courses" class="menu-item">
+        <a href="catalog.html#courses" class="menu-item">
             <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
             MEAL & M&E
         </a>
-        <a href="index.html#labs" class="menu-item">
+        <a href="catalog.html#labs" class="menu-item">
             <svg viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
             Interactive Labs
         </a>
-        <a href="index.html#games" class="menu-item">
+        <a href="#games-list" class="menu-item">
             <svg viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 12h4M8 10v4M15 11h.01M18 13h.01"/></svg>
             Economics Games
         </a>
@@ -1489,11 +1489,11 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
                 <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
                 <span>Courses</span>
             </a>
-            <a href="index.html#labs" class="quick-link">
+            <a href="catalog.html#labs" class="quick-link">
                 <svg viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
                 <span>Labs</span>
             </a>
-            <a href="index.html#games" class="quick-link">
+            <a href="#games-list" class="quick-link">
                 <svg viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 12h4M8 10v4"/></svg>
                 <span>Games</span>
             </a>
@@ -1828,6 +1828,65 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
         </div>
     </section>
     
+    <!-- Economics Games -->
+    <section class="section" id="games-list">
+        <h2 class="section-title">
+            <svg viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 12h4M8 10v4M15 11h.01M18 13h.01"/></svg>
+            Economics Games
+        </h2>
+        <p style="font-size: 0.85rem; color: var(--text-secondary); text-align: center; margin-bottom: 1rem;">12 interactive games powered by MiroFish AI agents</p>
+        <div class="card-grid">
+            <a href="/Games/public-good-game.html" class="card" style="border-left: 4px solid #0EA5E9;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Public Good Game</div>
+                <div class="card-desc">Free-rider problem — decide how much to contribute to shared resources</div>
+            </a>
+            <a href="/Games/prisoners-dilemma-game.html" class="card" style="border-left: 4px solid #10B981;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Prisoners' Dilemma</div>
+                <div class="card-desc">Cooperate or defect — strategic interdependence and trust</div>
+            </a>
+            <a href="/Games/commons-crisis-game.html" class="card" style="border-left: 4px solid #F59E0B;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Commons Crisis</div>
+                <div class="card-desc">Tragedy of the commons — manage shared resources before collapse</div>
+            </a>
+            <a href="/Games/cooperation-paradox-game.html" class="card" style="border-left: 4px solid #8B5CF6;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Cooperation Paradox</div>
+                <div class="card-desc">Nash equilibrium vs Pareto optimality — why cooperation fails</div>
+            </a>
+            <a href="/Games/opportunity-cost-game.html" class="card" style="border-left: 4px solid #EC4899;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Opportunity Cost</div>
+                <div class="card-desc">Budget allocation across sectors with diminishing returns</div>
+            </a>
+            <a href="/Games/risk-reward-game.html" class="card" style="border-left: 4px solid #EF4444;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Risk & Reward Explorer</div>
+                <div class="card-desc">Prospect theory and cognitive biases in decision-making</div>
+            </a>
+            <a href="/Games/bidding-wars-game.html" class="card" style="border-left: 4px solid #6366F1;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Bidding Wars</div>
+                <div class="card-desc">Auction theory — sealed bids, winner's curse, procurement</div>
+            </a>
+            <a href="/Games/info-asymmetry-game.html" class="card" style="border-left: 4px solid #14B8A6;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Information Asymmetry</div>
+                <div class="card-desc">The lemons problem — adverse selection and signalling</div>
+            </a>
+            <a href="/Games/network-effects-game.html" class="card" style="border-left: 4px solid #0EA5E9;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Network Effects</div>
+                <div class="card-desc">Platform adoption, critical mass, and S-curve dynamics</div>
+            </a>
+            <a href="/Games/externality-game.html" class="card" style="border-left: 4px solid #F59E0B;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Externality Game</div>
+                <div class="card-desc">Pollution, social costs, and Pigouvian taxation</div>
+            </a>
+            <a href="/Games/real-middle-india.html" class="card" style="border-left: 4px solid #10B981;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">The Real Middle</div>
+                <div class="card-desc">Income inequality in India — where do you really stand?</div>
+            </a>
+            <a href="/Games/econ-concepts-game.html" class="card" style="border-left: 4px solid #8B5CF6;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Econ Concepts Puzzle</div>
+                <div class="card-desc">12 brain-teasers on supply, demand, game theory & more</div>
+            </a>
+        </div>
+    </section>
+
     <!-- Connect & Community -->
     <section class="section" style="background: var(--secondary-bg);">
         <h2 class="section-title">


### PR DESCRIPTION
## Summary
- Added full 12-game section with direct `/Games/*.html` links to `mobile-index.html`
- Fixed menu links that caused redirect loops (`index.html#games` → mobile redirect → back to `index.html`)
- Changed courses/labs menu links to `catalog.html` instead of looping back to `index.html`

## Root cause
Mobile users get redirected to `mobile-index.html` (by design), but game/lab/course links pointed back to `index.html#games` which re-triggered the mobile redirect — infinite loop.

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo