### PR TITLE
Add Labs section to mobile-index.html, fix remaining redirect loops

### DIFF
--- a/mobile-index.html
+++ b/mobile-index.html
@@ -1314,11 +1314,7 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
             <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
             All Courses
         </a>
-        <a href="catalog.html#courses" class="menu-item">
-            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-            MEAL & M&E
-        </a>
-        <a href="catalog.html#labs" class="menu-item">
+        <a href="#labs-list" class="menu-item">
             <svg viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
             Interactive Labs
         </a>
@@ -1489,7 +1485,7 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
                 <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
                 <span>Courses</span>
             </a>
-            <a href="catalog.html#labs" class="quick-link">
+            <a href="#labs-list" class="quick-link">
                 <svg viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
                 <span>Labs</span>
             </a>
@@ -1828,6 +1824,57 @@ body.user-authenticated .auth-logged-in { display: flex !important; }
         </div>
     </section>
     
+    <!-- Interactive Labs -->
+    <section class="section" id="labs-list" style="background: var(--secondary-bg);">
+        <h2 class="section-title">
+            <svg viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+            Interactive Labs
+        </h2>
+        <p style="font-size: 0.85rem; color: var(--text-secondary); text-align: center; margin-bottom: 1rem;">10 hands-on workbenches for development practitioners</p>
+        <div class="card-grid">
+            <a href="https://101.impactmojo.in/risk-mitigation-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #EF4444;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Risk & Mitigation Lab</div>
+                <div class="card-desc">Scenario planning, risk matrices, and mitigation strategies for development projects</div>
+            </a>
+            <a href="https://101.impactmojo.in/policy-advocacy-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #0EA5E9;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Policy & Advocacy Lab</div>
+                <div class="card-desc">Stakeholder analysis, message testing, and strategic communication for policy change</div>
+            </a>
+            <a href="https://101.impactmojo.in/resource-sustainability-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #10B981;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Resource & Sustainability Lab</div>
+                <div class="card-desc">Resource flows, sustainability plans, and fundraising strategies</div>
+            </a>
+            <a href="https://101.impactmojo.in/impact-partnerships" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #8B5CF6;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Impact & Partnerships Lab</div>
+                <div class="card-desc">Partnership ecosystems, collaboration frameworks, and collective impact</div>
+            </a>
+            <a href="https://101.impactmojo.in/mel-design-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #F59E0B;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">MLE Design Lab</div>
+                <div class="card-desc">Build M&E systems from scratch — results frameworks, data tools, learning agendas</div>
+            </a>
+            <a href="https://101.impactmojo.in/mel-plan-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #6366F1;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">MEL Plan Lab</div>
+                <div class="card-desc">Indicators, targets, dashboards, and feedback loops for evidence-based decisions</div>
+            </a>
+            <a href="https://101.impactmojo.in/design-thinking-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #EC4899;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Design Thinking Lab</div>
+                <div class="card-desc">Human-centered design for development — prototyping, journey mapping, ideation</div>
+            </a>
+            <a href="https://101.impactmojo.in/toc-workbench" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #14B8A6;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Theory of Change Lab</div>
+                <div class="card-desc">Construct robust theories of change with assumption mapping and evidence review</div>
+            </a>
+            <a href="https://101.impactmojo.in/storytelling-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #F59E0B;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Storytelling Lab</div>
+                <div class="card-desc">Transform data into compelling narratives — ethical storytelling for social change</div>
+            </a>
+            <a href="https://101.impactmojo.in/community-lab" target="_blank" rel="noopener noreferrer" class="card" style="border-left: 4px solid #0EA5E9;">
+                <div class="card-title" style="margin: 0; font-size: 0.95rem;">Community Development Lab</div>
+                <div class="card-desc">Participatory facilitation, community mapping, and consensus-building</div>
+            </a>
+        </div>
+    </section>
+
     <!-- Economics Games -->
     <section class="section" id="games-list">
         <h2 class="section-title">


### PR DESCRIPTION
## Summary
- Added 10-lab section to mobile-index.html with direct links
- Fixed Labs menu/quick-links to use on-page anchors instead of catalog.html
- Removed MEAL & M&E link that redirected to desktop catalog.html

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo