### PR TITLE
Make index.html fully responsive, remove mobile redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,7 @@
 <html lang="en">
 <head>
 
-<!-- MOBILE REDIRECT - Send mobile users to optimized mobile site -->
-<script>
-(function() {
-    // Skip if user chose to view desktop site
-    if (sessionStorage.getItem('forceDesktop') === 'true') return;
-    
-    // Check if mobile
-    var isMobile = window.innerWidth <= 768 || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-    
-    if (isMobile) {
-        window.location.replace('mobile-index.html');
-    }
-})();
-</script>
+<!-- mobile-index.html is kept as legacy; index.html is now fully responsive -->
 
 <script>
 /* ============================================================
@@ -7033,6 +7020,273 @@ footer::before {
     
     .logo-text {
         font-size: 1rem !important;
+    }
+}
+
+/* ── MOBILE RESPONSIVE ENHANCEMENTS (Option A: make index.html work on phones) ── */
+@media screen and (max-width: 768px) {
+    /* ── Card grids: force single column ── */
+    .cards-grid,
+    .modal-grid,
+    .card-grid,
+    .flagship-grid,
+    .imx-resource-grid,
+    .imx-premium-tiers,
+    .imx-community-grid,
+    .support-options-grid,
+    .support-options {
+        grid-template-columns: 1fr !important;
+        gap: 0.75rem !important;
+    }
+
+    /* ── Section padding: tighter on mobile ── */
+    .section,
+    section {
+        padding: 1.5rem 0.75rem !important;
+    }
+
+    .section-title {
+        font-size: 1.25rem !important;
+    }
+
+    .section-subtitle {
+        font-size: 0.85rem !important;
+    }
+
+    /* ── Cards: compact on mobile ── */
+    .card {
+        padding: 1rem !important;
+    }
+
+    .card-title {
+        font-size: 0.95rem !important;
+    }
+
+    .card-description {
+        font-size: 0.8rem !important;
+        -webkit-line-clamp: 3;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .card-testimonial {
+        display: none !important;
+    }
+
+    .card-header {
+        margin-bottom: 0.5rem !important;
+    }
+
+    /* ── Hero: mobile-friendly ── */
+    .v3-hero-title {
+        font-size: clamp(1.5rem, 6vw, 2.2rem) !important;
+        line-height: 1.2 !important;
+    }
+
+    .v3-hero-description {
+        font-size: 0.9rem !important;
+        max-width: 100% !important;
+    }
+
+    .v3-hero-cta-wrapper {
+        padding: 0 0.5rem !important;
+    }
+
+    .v3-hero-buttons {
+        flex-direction: column !important;
+        gap: 0.5rem !important;
+        width: 100% !important;
+    }
+
+    .v3-btn-primary,
+    .v3-btn-secondary {
+        width: 100% !important;
+        max-width: 320px !important;
+        margin: 0 auto !important;
+        font-size: 0.9rem !important;
+        padding: 0.75rem 1.25rem !important;
+    }
+
+    /* ── Modals: full-width on mobile ── */
+    .modal-content {
+        width: 95% !important;
+        max-width: 95vw !important;
+        margin: 2rem auto !important;
+        max-height: 85vh !important;
+        overflow-y: auto !important;
+    }
+
+    .modal-grid {
+        gap: 0.5rem !important;
+    }
+
+    .modal-item {
+        padding: 0.75rem !important;
+    }
+
+    .modal-item-description {
+        font-size: 0.8rem !important;
+        -webkit-line-clamp: 2;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    /* ── Oversized fonts: scale down ── */
+    .imx-streak-fire {
+        font-size: 2.5rem !important;
+    }
+
+    .imx-streak-count {
+        font-size: 2rem !important;
+    }
+
+    .imx-pomodoro-time {
+        font-size: 2.5rem !important;
+    }
+
+    .testimonial-quote::before {
+        font-size: 2rem !important;
+    }
+
+    /* ── Footer: stack on mobile ── */
+    .footer-links {
+        flex-direction: column !important;
+        gap: 1.5rem !important;
+    }
+
+    .footer-section {
+        text-align: center !important;
+    }
+
+    .footer-section ul {
+        padding: 0 !important;
+    }
+
+    .footer-content {
+        padding: 1.5rem 1rem !important;
+    }
+
+    /* ── Stats row: 2-col grid ── */
+    .stats-row,
+    .imx-analytics-stats,
+    .imx-streak-stats {
+        grid-template-columns: repeat(2, 1fr) !important;
+        gap: 0.5rem !important;
+    }
+
+    /* ── Buttons: touch-friendly ── */
+    .btn,
+    .action-buttons .btn {
+        min-height: 44px !important;
+        font-size: 0.85rem !important;
+        padding: 0.6rem 1rem !important;
+    }
+
+    /* ── WhatsApp, newsletter, case study banners ── */
+    .impactlex-banner-inner,
+    .casestudies-banner-inner,
+    .devdiscourses-banner-inner {
+        flex-direction: column !important;
+        text-align: center !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+    }
+
+    /* ── Learning tracks: single column ── */
+    .imx-tracks-compact-grid {
+        grid-template-columns: 1fr !important;
+    }
+
+    /* ── Flagship courses: compact ── */
+    #flagship-courses {
+        padding: 1.5rem 0.75rem !important;
+    }
+
+    #flagship-courses h2 {
+        font-size: 1.3rem !important;
+    }
+
+    .flagship-card {
+        padding: 1rem !important;
+    }
+
+    .flagship-card h3 {
+        font-size: 1rem !important;
+    }
+
+    /* ── Star ratings in cards: smaller ── */
+    .star-rating {
+        flex-wrap: wrap !important;
+    }
+
+    .stars {
+        gap: 1px !important;
+    }
+
+    .star-icon {
+        width: 14px !important;
+        height: 14px !important;
+    }
+
+    .rating-text,
+    .rating-count {
+        font-size: 0.7rem !important;
+    }
+
+    /* ── Daily tip: compact ── */
+    .imx-daily-tip {
+        margin: 0.5rem 0.75rem !important;
+        padding: 0.75rem !important;
+    }
+
+    /* ── Coaching cards ── */
+    .coaching-card,
+    .enhanced-support-card {
+        padding: 1rem !important;
+    }
+
+    /* ── Speed dial: reposition ── */
+    .imx-speed-dial {
+        bottom: 1rem !important;
+        right: 0.75rem !important;
+    }
+
+    /* ── Hide decorative elements ── */
+    .v3-organic-bg,
+    .v3-floating-elements,
+    .v3-paper-plane,
+    .v3-speech-bubble,
+    .v3-callout-bubble,
+    .new-starburst {
+        display: none !important;
+    }
+}
+
+/* ── Extra compact for very small phones ── */
+@media screen and (max-width: 380px) {
+    .cards-grid,
+    .modal-grid {
+        gap: 0.5rem !important;
+    }
+
+    .section,
+    section {
+        padding: 1rem 0.5rem !important;
+    }
+
+    .card {
+        padding: 0.75rem !important;
+    }
+
+    .v3-hero-title {
+        font-size: 1.3rem !important;
+    }
+
+    .stats-row,
+    .imx-analytics-stats {
+        grid-template-columns: 1fr !important;
     }
 }
 


### PR DESCRIPTION
## Summary
- **Removed mobile redirect** to mobile-index.html — index.html now serves all devices
- **Added ~250 lines of mobile CSS** covering card grids, hero, modals, footer, stats, buttons, banners, typography
- Cards go single-column, descriptions truncate, testimonials hide on mobile
- Touch targets min 44px, stacked CTAs, tighter section padding
- Decorative elements (blobs, planes, sparkles) hidden on mobile
- Extra compact rules for phones <380px
- mobile-index.html kept as legacy (no redirect to it)

## Test plan
- [ ] Test on iPhone Safari (375px)
- [ ] Test on Android Chrome (360px)
- [ ] Test hamburger menu, Learn dropdown, modal opening
- [ ] Test game links from Games section and modal
- [ ] Verify no horizontal scroll on any section

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo