### PR TITLE
Fix mobile: logo/menu overlap, content cutoff, disable tour

### DIFF
--- a/index.html
+++ b/index.html
@@ -6461,15 +6461,25 @@ footer::before {
     
     /* === HEADER === */
     .nav-container {
-        padding: 0.75rem 1rem !important;
+        padding: 0.5rem 0.75rem !important;
         gap: 0.5rem !important;
         flex-wrap: nowrap !important;
+        align-items: center !important;
+        justify-content: space-between !important;
+    }
+
+    .nav-with-badge {
+        display: flex !important;
+        align-items: center !important;
+        flex: 0 1 auto !important;
+        min-width: 0 !important;
+        max-width: 50% !important;
     }
     
     .logo-container {
-        flex: 1 1 auto !important;
+        flex: 0 0 auto !important;
         min-width: 0 !important;
-        max-width: none !important;
+        max-width: 140px !important;
         overflow: hidden;
     }
 
@@ -6479,18 +6489,19 @@ footer::before {
 
     .logo img,
     .logo-svg img {
-        height: 36px !important;
-        width: 36px !important;
+        height: 32px !important;
+        width: 32px !important;
     }
 
     .logo-text {
-        font-size: 1rem !important;
+        font-size: 0.9rem !important;
         overflow: hidden;
         text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .logo-main {
-        font-size: 1rem !important;
+        font-size: 0.9rem !important;
     }
 
     .logo-tagline {
@@ -6536,6 +6547,8 @@ footer::before {
         z-index: 10001 !important;
         position: relative !important;
         touch-action: manipulation !important;
+        margin-left: auto !important;
+        flex-shrink: 0 !important;
         -webkit-tap-highlight-color: transparent !important;
         flex-shrink: 0 !important;
         margin-left: auto !important;

--- a/js/tours.js
+++ b/js/tours.js
@@ -168,6 +168,9 @@
   }
 
   function init() {
+    // Skip auto-start on mobile — tour is too heavy for small screens
+    if (window.innerWidth <= 768) return;
+
     var page = detectPage();
     if (!TOURS[page]) return;
     if (hasSeenTour(page)) return;


### PR DESCRIPTION
## Summary
- **Logo/menu overlap**: Logo container was set to `flex: 1 1 auto` (grow), pushing hamburger off screen. Fixed to `flex: 0 0 auto` with `max-width: 140px`
- **Content cutoff**: `nav-with-badge` had `display: contents` breaking flex hierarchy. Overridden to `display: flex` on mobile with `max-width: 50%`
- **Hamburger alignment**: Added `margin-left: auto` and `flex-shrink: 0` to keep it right-aligned
- **Tour disabled on mobile**: Auto-start tour skipped on screens <= 768px (was slow and buggy on phones)

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo