### PR TITLE
Fix mobile menu not rendering behind overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -6480,16 +6480,9 @@ footer::before {
     }
 
     .nav-with-badge {
-        position: static !important;
-        display: block !important;
-        width: 0 !important;
-        height: 0 !important;
-        overflow: visible !important;
-        padding: 0 !important;
-        margin: 0 !important;
-        flex: 0 0 0px !important;
+        display: contents !important;
     }
-    
+
     .logo-container {
         flex: 0 0 auto !important;
         min-width: 0 !important;
@@ -13920,14 +13913,7 @@ PASTE THIS ENTIRE BLOCK JUST BEFORE
     }
 
     .nav-with-badge {
-        position: static !important;
-        display: block !important;
-        width: 0 !important;
-        height: 0 !important;
-        padding: 0 !important;
-        margin: 0 !important;
-        flex: 0 0 0px !important;
-        overflow: visible !important;
+        display: contents !important;
     }
 
     .nav-buttons,


### PR DESCRIPTION
## Summary
- Fix mobile menu showing grey overlay but no clickable content
- Root cause: nav-with-badge had position:absolute with zero dimensions, creating a containing block that broke position:fixed on the menu panel
- Fix: use display:contents to remove the wrapper from layout entirely

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo