### PR TITLE
Rewrite mobile menu: single handler with inline styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -14014,142 +14014,127 @@ PASTE THIS ENTIRE BLOCK JUST BEFORE
 </style>
 
 <script>
-// FINAL MOBILE FIX - Runs after everything else
+// FINAL MOBILE FIX — single authoritative handler
+// Uses inline styles to bypass all CSS specificity conflicts
+// Moves navLinks to <body> to escape backdrop-filter containing block
 (function() {
     'use strict';
-    
-    
-    function fixMobileMenu() {
-        var btn = document.getElementById('mobile-menu-btn');
-        var navLinks = document.getElementById('navLinks');
-        var overlay = document.getElementById('mobileMenuOverlay');
-        
-        if (!btn) {
-            console.error('[MobileFix] Hamburger button not found!');
-            return false;
-        }
-        
-        
-        // Remove ALL existing event listeners by replacing the element
-        var newBtn = btn.cloneNode(true);
-        btn.parentNode.replaceChild(newBtn, btn);
-        btn = newBtn;
-        
-        // Clear any onclick attribute
-        btn.removeAttribute('onclick');
-        
-        // The one and only toggle function
-        function doToggle() {
-            
-            if (!navLinks) {
-                navLinks = document.getElementById('navLinks');
-            }
-            if (!overlay) {
-                overlay = document.getElementById('mobileMenuOverlay');
-            }
-            
-            if (navLinks) {
-                var isCurrentlyOpen = navLinks.classList.contains('active');
-                
-                if (isCurrentlyOpen) {
-                    navLinks.classList.remove('active');
-                    btn.classList.remove('active');
-                    if (overlay) overlay.classList.remove('active');
-                    document.body.style.overflow = '';
-                } else {
-                    navLinks.classList.add('active');
-                    btn.classList.add('active');
-                    if (overlay) overlay.classList.add('active');
-                    document.body.style.overflow = 'hidden';
-                }
-            }
-        }
-        
-        // Add click handler
-        btn.addEventListener('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            doToggle();
-        }, true);
-        
-        // Add touch handler for mobile
-        btn.addEventListener('touchend', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            doToggle();
-        }, { passive: false, capture: true });
-        
-        // Prevent touchstart from causing issues
-        btn.addEventListener('touchstart', function(e) {
-            e.stopPropagation();
-        }, { passive: true });
-        
-        return true;
-    }
-    
-    function fixFABs() {
-        var speedDial = document.getElementById('imxSpeedDial');
-        var mojini = document.getElementById('mojini-chat-toggle');
-        
-        if (speedDial) {
-            speedDial.style.cssText = 'display:block!important;visibility:visible!important;opacity:1!important;position:fixed!important;bottom:24px!important;left:20px!important;right:auto!important;top:auto!important;z-index:9000!important;';
-        }
-        
-        if (mojini) {
-            mojini.style.cssText = 'display:flex!important;visibility:visible!important;opacity:1!important;position:fixed!important;bottom:24px!important;right:20px!important;left:auto!important;top:auto!important;z-index:9000!important;width:56px!important;height:56px!important;align-items:center!important;justify-content:center!important;';
-        }
-    }
-    
-    function initAll() {
-        // Only run on mobile
-        if (window.innerWidth > 768) {
-            return;
-        }
-        
-        fixMobileMenu();
-        fixFABs();
-    }
-    
-    // Run when DOM is ready
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initAll);
-    } else {
-        initAll();
-    }
-    
-    // Also run after a delay to catch late-loading elements
-    setTimeout(initAll, 500);
-    setTimeout(initAll, 1500);
-    
-    // Run on resize in case user rotates device
-    window.addEventListener('resize', function() {
-        if (window.innerWidth <= 768) {
-            setTimeout(initAll, 100);
-        }
-    });
-    
-})();
+    var menuOpen = false;
+    var ready = false;
 
-// Move navLinks and overlay out of header to body so position:fixed works
-// (backdrop-filter on .header creates a containing block that traps fixed children)
-(function() {
-    function moveMenuToBody() {
-        if (window.innerWidth > 768) return;
-        var navLinks = document.getElementById('navLinks');
+    var MENU_OPEN_STYLE = 'display:flex;position:fixed;top:60px;left:0;right:0;bottom:0;' +
+        'width:100%;height:calc(100vh - 60px);background:var(--primary-bg,#0F172A);' +
+        'flex-direction:column;padding:1rem;overflow-y:auto;-webkit-overflow-scrolling:touch;' +
+        'z-index:100000;gap:0;list-style:none;margin:0;';
+    var MENU_CLOSED_STYLE = 'display:none;';
+    var OVERLAY_OPEN_STYLE = 'display:block;position:fixed;top:0;left:0;width:100%;height:100%;' +
+        'background:rgba(0,0,0,0.5);z-index:99999;';
+    var OVERLAY_CLOSED_STYLE = 'display:none;';
+
+    function openMenu() {
+        var nav = document.getElementById('navLinks');
         var overlay = document.getElementById('mobileMenuOverlay');
-        if (navLinks && navLinks.closest('.header')) {
-            document.body.appendChild(navLinks);
-        }
-        if (overlay && overlay.closest('.header')) {
-            document.body.appendChild(overlay);
-        }
+        var btn = document.getElementById('mobile-menu-btn');
+        if (!nav) return;
+        // Move to body if still inside header (backdrop-filter breaks position:fixed)
+        if (nav.closest && nav.closest('.header')) document.body.appendChild(nav);
+        nav.style.cssText = MENU_OPEN_STYLE;
+        nav.classList.add('active');
+        if (btn) btn.classList.add('active');
+        if (overlay) { overlay.style.cssText = OVERLAY_OPEN_STYLE; overlay.classList.add('active'); }
+        document.body.style.overflow = 'hidden';
+        document.body.classList.add('menu-open');
+        // Move theme selector into menu if not already there
+        var ts = document.querySelector('.theme-selector');
+        if (ts && !nav.contains(ts)) nav.appendChild(ts);
+        if (ts) ts.style.cssText = 'display:flex;justify-content:center;gap:0.5rem;padding:1rem;border-top:1px solid var(--border-color,#334155);margin-top:auto;';
+        menuOpen = true;
     }
+
+    function closeMenu() {
+        var nav = document.getElementById('navLinks');
+        var overlay = document.getElementById('mobileMenuOverlay');
+        var btn = document.getElementById('mobile-menu-btn');
+        if (nav) { nav.style.cssText = MENU_CLOSED_STYLE; nav.classList.remove('active'); }
+        if (btn) btn.classList.remove('active');
+        if (overlay) { overlay.style.cssText = OVERLAY_CLOSED_STYLE; overlay.classList.remove('active'); }
+        document.body.style.overflow = '';
+        document.body.classList.remove('menu-open');
+        document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(el) { el.classList.remove('open'); });
+        menuOpen = false;
+    }
+
+    function toggle() {
+        if (menuOpen) closeMenu(); else openMenu();
+    }
+
+    // Expose globally
+    window.closeMobileMenu = closeMenu;
+    window.toggleMobileMenu = toggle;
+
+    function setup() {
+        if (ready) return;
+        if (window.innerWidth > 768) return;
+        var btn = document.getElementById('mobile-menu-btn');
+        var overlay = document.getElementById('mobileMenuOverlay');
+        if (!btn) return;
+        ready = true;
+
+        // Clone to remove ALL old listeners
+        var fresh = btn.cloneNode(true);
+        btn.parentNode.replaceChild(fresh, btn);
+        fresh.removeAttribute('onclick');
+        fresh.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); toggle(); }, true);
+        fresh.addEventListener('touchend', function(e) { e.preventDefault(); e.stopPropagation(); toggle(); }, { passive: false, capture: true });
+
+        // Overlay close
+        if (overlay) {
+            overlay.onclick = null;
+            overlay.addEventListener('click', function() { closeMenu(); });
+            overlay.addEventListener('touchstart', function(e) { e.preventDefault(); closeMenu(); }, { passive: false });
+        }
+
+        // Dropdown toggles inside menu
+        document.querySelectorAll('.nav-links > li.has-dropdown > a').forEach(function(link) {
+            link.addEventListener('click', function(e) {
+                if (window.innerWidth > 768) return;
+                e.preventDefault();
+                e.stopPropagation();
+                var li = link.closest('li.has-dropdown');
+                document.querySelectorAll('.nav-links > li.has-dropdown').forEach(function(other) {
+                    if (other !== li) other.classList.remove('open');
+                });
+                li.classList.toggle('open');
+            });
+        });
+
+        // Dropdown sub-links: open modal, close menu
+        document.querySelectorAll('.dropdown-menu a').forEach(function(link) {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) setTimeout(closeMenu, 100);
+            });
+        });
+
+        // Regular nav links close menu
+        document.querySelectorAll('.nav-links > li:not(.has-dropdown) > a').forEach(function(link) {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) setTimeout(closeMenu, 100);
+            });
+        });
+
+        // Escape key
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && menuOpen) closeMenu();
+        });
+    }
+
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', moveMenuToBody);
+        document.addEventListener('DOMContentLoaded', setup);
     } else {
-        moveMenuToBody();
+        setup();
     }
-    setTimeout(moveMenuToBody, 100);
+    // Re-run once after delay for late elements
+    setTimeout(setup, 800);
 })();
 </script>
 
@@ -14326,214 +14311,10 @@ waitForDependencies(patchSaveFunctions);
 
 
 
-<script>
-/* Mobile Touch Handler - Enhanced */
-(function() {
-    'use strict';
-    
-    // Wait for DOM
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initMobile);
-    } else {
-        initMobile();
-    }
-    
-    function initMobile() {
-        var hamburger = document.getElementById('mobile-menu-btn');
-        var navLinks = document.getElementById('navLinks');
-        var overlay = document.getElementById('mobileMenuOverlay');
-        var mobileAuth = document.getElementById('mobileAuthSection');
-        
-        if (!hamburger || !navLinks) {
-            console.warn('[Mobile] Missing elements');
-            return;
-        }
-        
-        // Enhanced touch handling for hamburger
-        hamburger.addEventListener('touchstart', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleMenu();
-        }, { passive: false });
-        
-        hamburger.addEventListener('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleMenu();
-        });
-        
-        function toggleMenu() {
-            var isOpen = navLinks.classList.contains('active');
-            
-            if (isOpen) {
-                closeMenu();
-            } else {
-                openMenu();
-            }
-        }
-        
-        function openMenu() {
-            navLinks.classList.add('active');
-            hamburger.classList.add('active');
-            if (overlay) overlay.classList.add('active');
-            if (mobileAuth) mobileAuth.classList.add('active');
-            document.body.classList.add('menu-open');
-        }
-        
-        function closeMenu() {
-            navLinks.classList.remove('active');
-            hamburger.classList.remove('active');
-            if (overlay) overlay.classList.remove('active');
-            if (mobileAuth) mobileAuth.classList.remove('active');
-            document.body.classList.remove('menu-open');
-            
-            // Close all dropdowns
-            document.querySelectorAll('.nav-links > li.has-dropdown').forEach(function(item) {
-                item.classList.remove('open');
-            });
-        }
-        
-        // Make closeMenu globally available
-        window.closeMobileMenu = closeMenu;
-        
-        // Overlay click to close
-        if (overlay) {
-            overlay.addEventListener('click', closeMenu);
-            overlay.addEventListener('touchstart', function(e) {
-                e.preventDefault();
-                closeMenu();
-            }, { passive: false });
-        }
-        
-        // Dropdown toggle on mobile
-        var dropdowns = document.querySelectorAll('.nav-links > li.has-dropdown');
-        dropdowns.forEach(function(item) {
-            var link = item.querySelector(':scope > a');
-            if (link) {
-                link.addEventListener('click', function(e) {
-                    if (window.innerWidth <= 768) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        
-                        // Close other dropdowns
-                        dropdowns.forEach(function(other) {
-                            if (other !== item) {
-                                other.classList.remove('open');
-                            }
-                        });
-                        
-                        item.classList.toggle('open');
-                    }
-                });
-            }
-        });
-        
-        // Close menu when clicking dropdown links
-        document.querySelectorAll('.dropdown-menu a').forEach(function(link) {
-            link.addEventListener('click', function() {
-                if (window.innerWidth <= 768) {
-                    setTimeout(closeMenu, 100);
-                }
-            });
-        });
-        
-        // Close menu when clicking regular nav links
-        document.querySelectorAll('.nav-links > li:not(.has-dropdown) > a').forEach(function(link) {
-            link.addEventListener('click', function() {
-                if (window.innerWidth <= 768) {
-                    setTimeout(closeMenu, 100);
-                }
-            });
-        });
-        
-        // Close on escape key
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && navLinks.classList.contains('active')) {
-                closeMenu();
-            }
-        });
-        
-        // Handle window resize - close menu if moving to desktop
-        window.addEventListener('resize', function() {
-            if (window.innerWidth > 768 && navLinks.classList.contains('active')) {
-                closeMenu();
-            }
-        });
-        
-    }
-})();
-</script>
+<!-- Mobile Touch Handler removed — consolidated into FINAL MOBILE FIX above -->
 
 
-<script>
-/* ============================================================
-   MOBILE MENU - ENHANCED EVENT LISTENERS
-   (Core functions defined in <head> for onclick support)
-   ============================================================ */
-(function() {
-    'use strict';
-    
-    var MOBILE_BREAKPOINT = 768;
-    
-    function isMobile() {
-        return window.innerWidth <= MOBILE_BREAKPOINT;
-    }
-    
-    function init() {
-        var toggle = document.getElementById('mobile-menu-btn');
-        var overlay = document.getElementById('mobileMenuOverlay');
-        
-        // Add touch support to hamburger (in addition to onclick)
-        if (toggle) {
-            toggle.addEventListener('touchstart', function(e) {
-                // Just highlight on touch
-                this.style.transform = 'scale(0.95)';
-            }, { passive: true });
-            
-            toggle.addEventListener('touchend', function(e) {
-                this.style.transform = '';
-            }, { passive: true });
-        }
-        
-        // Overlay click to close
-        if (overlay) {
-            overlay.addEventListener('click', function() {
-                if (typeof closeMobileMenu === 'function') {
-                    closeMobileMenu();
-                }
-            });
-            overlay.addEventListener('touchend', function(e) {
-                e.preventDefault();
-                if (typeof closeMobileMenu === 'function') {
-                    closeMobileMenu();
-                }
-            }, { passive: false });
-        }
-        
-        // Close on resize to desktop
-        window.addEventListener('resize', function() {
-            if (!isMobile() && typeof closeMobileMenu === 'function') {
-                closeMobileMenu();
-            }
-        });
-        
-        // Close on escape key
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && typeof closeMobileMenu === 'function') {
-                closeMobileMenu();
-            }
-        });
-        
-    }
-    
-    // Run on DOM ready
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
-})();
-</script>
+<!-- Mobile Enhanced Event Listeners removed — consolidated into FINAL MOBILE FIX above -->
 
 <script>
 // Section Navigator scroll-spy


### PR DESCRIPTION
## Summary
- **Root cause**: 4 competing JS scripts fighting over hamburger button + 25+ conflicting CSS blocks + backdrop-filter containing block issue
- **Fix**: Replace all 3 mobile menu scripts with ONE authoritative handler that uses inline styles (style.cssText) to bypass all CSS specificity wars
- Moves navLinks to document.body on open to escape backdrop-filter
- Net -219 lines (109 added, 328 removed)

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo