### PR TITLE
Cache-bust game-shell.js v4 + short cache headers

### DIFF
--- a/Games/bidding-wars-game.html
+++ b/Games/bidding-wars-game.html
@@ -998,6 +998,6 @@ function spawnConfetti(){
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/commons-crisis-game.html
+++ b/Games/commons-crisis-game.html
@@ -911,6 +911,6 @@ window.addEventListener('resize', function(){
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/cooperation-paradox-game.html
+++ b/Games/cooperation-paradox-game.html
@@ -866,6 +866,6 @@ window.restartGame = function() {
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/econ-concepts-game.html
+++ b/Games/econ-concepts-game.html
@@ -600,6 +600,6 @@ function spawnConfetti() {
 init();
 </script>
 <script src="/js/game-agents.js"></script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -259,6 +259,6 @@ function resetGame(){
   document.getElementById('prod-slider').value=50;
 }
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/info-asymmetry-game.html
+++ b/Games/info-asymmetry-game.html
@@ -1094,6 +1094,6 @@ button:active { transform: scale(.97); }
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/network-effects-game.html
+++ b/Games/network-effects-game.html
@@ -1868,6 +1868,6 @@ body {
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/opportunity-cost-game.html
+++ b/Games/opportunity-cost-game.html
@@ -895,6 +895,6 @@ window.addEventListener('resize', function() {
 updateBarVisuals();
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/prisoners-dilemma-game.html
+++ b/Games/prisoners-dilemma-game.html
@@ -916,6 +916,6 @@ init();
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/public-good-game.html
+++ b/Games/public-good-game.html
@@ -1578,6 +1578,6 @@ input[type="range"]::-moz-range-thumb {
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/real-middle-india.html
+++ b/Games/real-middle-india.html
@@ -938,6 +938,6 @@ window.addEventListener("resize", function() {
 });
 </script>
 <script src="/js/game-agents.js"></script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/risk-reward-game.html
+++ b/Games/risk-reward-game.html
@@ -751,6 +751,6 @@ function drawPTCurve(){
 
 })();
 </script>
-<script src="/js/game-shell.js"></script>
+<script src="/js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,17 @@
   command = "echo '{\"v\":\"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'\"}' > version.json"
   publish = "."
 
+# Short cache for JS/CSS so updates propagate quickly
+[[headers]]
+  for = "/js/*"
+  [headers.values]
+    Cache-Control = "public, max-age=300, must-revalidate"
+
+[[headers]]
+  for = "/Games/*"
+  [headers.values]
+    Cache-Control = "public, max-age=300, must-revalidate"
+
 # GitBook documentation — 200 proxy rewrite avoids redirect loops
 [[redirects]]
   from = "/docs"


### PR DESCRIPTION
## Summary
- Add `?v=4` to game-shell.js in all 12 games to bust browser/CDN cache
- Add Netlify headers: 5-min max-age for /js/* and /Games/* so updates propagate fast

This should fix the issue where artwork and contrast fixes were deployed but not visible due to cached old JS.

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo