### PR TITLE
Fix broken script paths: absolute to relative

### DIFF
--- a/Games/bidding-wars-game.html
+++ b/Games/bidding-wars-game.html
@@ -459,7 +459,7 @@ body{
 </div>
 
 <!-- ═══════════════ GAME AGENTS ═══════════════ -->
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function(){
 'use strict';
@@ -998,6 +998,6 @@ function spawnConfetti(){
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/commons-crisis-game.html
+++ b/Games/commons-crisis-game.html
@@ -395,7 +395,7 @@ h3{font-size:1.1rem;font-weight:600}
   </div>
 </div>
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function(){
 'use strict';
@@ -911,6 +911,6 @@ window.addEventListener('resize', function(){
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/cooperation-paradox-game.html
+++ b/Games/cooperation-paradox-game.html
@@ -448,7 +448,7 @@ a{color:var(--purple);text-decoration:none}
 
 </div><!-- /.app -->
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function(){
 'use strict';
@@ -866,6 +866,6 @@ window.restartGame = function() {
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/econ-concepts-game.html
+++ b/Games/econ-concepts-game.html
@@ -599,7 +599,7 @@ function spawnConfetti() {
 
 init();
 </script>
-<script src="/js/game-agents.js"></script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-agents.js"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -182,7 +182,7 @@ input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;heigh
 </div>
 </div>
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 var S={round:1,totalRounds:8,totalProfit:0,totalSocial:0,history:[],pre:[],post:[]};
 var agents;try{agents=new IMGameAgents('externality-game')}catch(e){agents=null}
@@ -259,6 +259,6 @@ function resetGame(){
   document.getElementById('prod-slider').value=50;
 }
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/info-asymmetry-game.html
+++ b/Games/info-asymmetry-game.html
@@ -481,7 +481,7 @@ button:active { transform: scale(.97); }
 <div id="endScreen" class="screen hidden"></div>
 
 <!-- ════════════════════════ GAME AGENTS ═══════════════════════════ -->
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function() {
   'use strict';
@@ -1094,6 +1094,6 @@ button:active { transform: scale(.97); }
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/network-effects-game.html
+++ b/Games/network-effects-game.html
@@ -1108,7 +1108,7 @@ body {
   <div class="loading-spinner"></div>
 </div>
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function() {
   'use strict';
@@ -1868,6 +1868,6 @@ body {
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/opportunity-cost-game.html
+++ b/Games/opportunity-cost-game.html
@@ -321,7 +321,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 </div>
 </div>
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function(){
 'use strict';
@@ -895,6 +895,6 @@ window.addEventListener('resize', function() {
 updateBarVisuals();
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/prisoners-dilemma-game.html
+++ b/Games/prisoners-dilemma-game.html
@@ -389,7 +389,7 @@ button{cursor:pointer;font-family:inherit;border:none;outline:none}
 </div>
 </div>
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function(){
 'use strict';
@@ -916,6 +916,6 @@ init();
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/public-good-game.html
+++ b/Games/public-good-game.html
@@ -1090,7 +1090,7 @@ input[type="range"]::-moz-range-thumb {
 <!-- ═══════════════════════════════════════════════════════════════
      GAME AGENTS LIBRARY
      ═══════════════════════════════════════════════════════════════ -->
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 
 <script>
 (function() {
@@ -1578,6 +1578,6 @@ input[type="range"]::-moz-range-thumb {
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/real-middle-india.html
+++ b/Games/real-middle-india.html
@@ -937,7 +937,7 @@ window.addEventListener("resize", function() {
   if (!document.getElementById("endscreen").classList.contains("hidden")) drawEndChart();
 });
 </script>
-<script src="/js/game-agents.js"></script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-agents.js"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>

--- a/Games/risk-reward-game.html
+++ b/Games/risk-reward-game.html
@@ -302,7 +302,7 @@ button{cursor:pointer;font-family:inherit;border:none;outline:none}
   <button class="btn-primary" onclick="location.reload()" style="margin-top:10px">Play Again</button>
 </div>
 
-<script src="/js/game-agents.js"></script>
+<script src="../js/game-agents.js"></script>
 <script>
 (function(){
 'use strict';
@@ -751,6 +751,6 @@ function drawPTCurve(){
 
 })();
 </script>
-<script src="/js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Changed `src="/js/game-shell.js"` → `src="../js/game-shell.js"` in all 12 games
- Changed `src="/js/game-agents.js"` → `src="../js/game-agents.js"` in all 12 games

## Root cause
The site is served at `varnasr.github.io/ImpactMojo/`, so absolute paths like `/js/game-shell.js` resolve to `varnasr.github.io/js/game-shell.js` — which **404s silently**. None of the artwork, theme, or contrast fixes were loading because the script never ran.

Relative paths (`../js/...`) work on both GitHub Pages and Netlify.

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo