### PR TITLE
Fix motif visibility + dark contrast via CSS variable overrides

### DIFF
--- a/Games/bidding-wars-game.html
+++ b/Games/bidding-wars-game.html
@@ -998,6 +998,6 @@ function spawnConfetti(){
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/commons-crisis-game.html
+++ b/Games/commons-crisis-game.html
@@ -911,6 +911,6 @@ window.addEventListener('resize', function(){
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/cooperation-paradox-game.html
+++ b/Games/cooperation-paradox-game.html
@@ -866,6 +866,6 @@ window.restartGame = function() {
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/econ-concepts-game.html
+++ b/Games/econ-concepts-game.html
@@ -600,6 +600,6 @@ function spawnConfetti() {
 init();
 </script>
 <script src="../js/game-agents.js"></script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -259,6 +259,6 @@ function resetGame(){
   document.getElementById('prod-slider').value=50;
 }
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/info-asymmetry-game.html
+++ b/Games/info-asymmetry-game.html
@@ -1094,6 +1094,6 @@ button:active { transform: scale(.97); }
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/network-effects-game.html
+++ b/Games/network-effects-game.html
@@ -1868,6 +1868,6 @@ body {
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/opportunity-cost-game.html
+++ b/Games/opportunity-cost-game.html
@@ -895,6 +895,6 @@ window.addEventListener('resize', function() {
 updateBarVisuals();
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/prisoners-dilemma-game.html
+++ b/Games/prisoners-dilemma-game.html
@@ -916,6 +916,6 @@ init();
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/public-good-game.html
+++ b/Games/public-good-game.html
@@ -1578,6 +1578,6 @@ input[type="range"]::-moz-range-thumb {
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/real-middle-india.html
+++ b/Games/real-middle-india.html
@@ -938,6 +938,6 @@ window.addEventListener("resize", function() {
 });
 </script>
 <script src="../js/game-agents.js"></script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/Games/risk-reward-game.html
+++ b/Games/risk-reward-game.html
@@ -751,6 +751,6 @@ function drawPTCurve(){
 
 })();
 </script>
-<script src="../js/game-shell.js?v=4"></script>
+<script src="../js/game-shell.js?v=5"></script>
 </body>
 </html>

--- a/js/game-shell.js
+++ b/js/game-shell.js
@@ -360,6 +360,15 @@
     '</div>';
   document.body.appendChild(footer);
 
+  // ── Override CSS variables for dark mode contrast ─────────
+  // Games define --text-muted:#64748B etc. which are unreadable on dark bg.
+  // Override the CSS custom properties directly so var() references pick up readable values.
+  var varFix = document.createElement('style');
+  varFix.textContent =
+    'body:not(.light-mode) { --text-dim: #CBD5E1 !important; --text-muted: #94A3B8 !important; --text: #F1F5F9 !important; --border: #475569 !important; }' +
+    'body.light-mode { --bg: #FFFBF5 !important; --card: #FFFFFF !important; --text: #1E293B !important; --text-dim: #78350F !important; --text-muted: #92400E !important; --border: #E7DDD0 !important; }';
+  document.head.appendChild(varFix);
+
   // ── Inject Styles ──────────────────────────────────────────
   var css = document.createElement('style');
   css.textContent =
@@ -433,8 +442,8 @@
 
     /* ═══ DECORATIVE ELEMENTS ═════════════════════════════ */
 
-    /* Indian folk art motifs — z-index 1 so they float above content backgrounds */
-    '.imx-game-motif { position: fixed; pointer-events: none; z-index: 1; }' +
+    /* Indian folk art motifs — high z-index so they float above game content */
+    '.imx-game-motif { position: fixed; pointer-events: none; z-index: 9998; opacity: 0.6; }' +
     '.imx-game-motif svg { width: 100%; height: 100%; }' +
     '.imx-motif-warli { bottom: 0; left: 0; width: 420px; height: 320px; color: #F59E0B; }' +
     'body.light-mode .imx-motif-warli { color: #92400E; }' +


### PR DESCRIPTION
## Summary
- **Motifs invisible**: z-index was 1 but game content has opaque backgrounds covering them. Raised to z-index:9998 with opacity:0.6
- **Dark text unreadable**: Games use CSS custom properties (`--text-muted:#64748B`) — CSS !important on class selectors cannot override `var()` references. Now overrides the CSS variables themselves at the body level
- Cache-bust bumped to v5

## Test plan
- [ ] Open any game page, verify Warli scene (bottom-left), Madhubani border (top-right), Gond tree (bottom-right) are visible
- [ ] Verify dark mode text is readable (no #64748B grey-on-dark)
- [ ] Toggle to light mode, verify it still looks correct

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo