### PR TITLE
Full dashboard audit: fix course selection, loading spinner, cleanup

### DIFF
--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -465,6 +465,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
 @media (max-width: 768px) { .v3-paper-plane { width: 100px; height: 100px; top: 10%; right: 5%; opacity: 0.15; } }
 @media (prefers-reduced-motion: reduce) { .v3-paper-plane { animation: none !important; } }
 @media print { .v3-paper-plane { display: none !important; } }
+@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 </style>
 </head>
 <body>
@@ -2351,18 +2352,19 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         });
     };
 
-    // Toggle course selection styling
-    document.addEventListener('DOMContentLoaded', function() {
-        document.querySelectorAll('.path-course-option').forEach(function(opt) {
-            opt.addEventListener('click', function(e) {
-                e.preventDefault();
-                var cb = opt.querySelector('input[type=checkbox]');
-                cb.checked = !cb.checked;
-                opt.classList.toggle('selected', cb.checked);
-                updatePathSummary();
-            });
+    // Toggle course selection styling (event delegation — no DOMContentLoaded needed)
+    var courseSelector = document.getElementById('courseSelector');
+    if (courseSelector) {
+        courseSelector.addEventListener('click', function(e) {
+            var opt = e.target.closest('.path-course-option');
+            if (!opt) return;
+            e.preventDefault();
+            var cb = opt.querySelector('input[type=checkbox]');
+            cb.checked = !cb.checked;
+            opt.classList.toggle('selected', cb.checked);
+            updatePathSummary();
         });
-    });
+    }
 
     function updatePathSummary() {
         var checked = document.querySelectorAll('#courseSelector input:checked');
@@ -2694,12 +2696,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
         }
     };
 
-    window.switchTrainingSection = function(section, btn) {
-        document.querySelectorAll('.training-section').forEach(function(s) { s.classList.remove('active'); });
-        document.querySelectorAll('.training-sub-btn').forEach(function(b) { b.classList.remove('active'); });
-        document.getElementById('training-' + section).classList.add('active');
-        btn.classList.add('active');
-    };
+    // switchTrainingSection handled by event delegation in inline <script> after #trainingSubNav
 
     window.deployPackage = async function(packageId, courseIds, title) {
         if (!orgData) { alert('Organization data not loaded.'); return; }


### PR DESCRIPTION
Full line-by-line audit of org-dashboard.html (3114 lines).

## Fixes
- Course selection in Learning Paths modal now uses event delegation
- Added missing @keyframes spin for analytics loading spinner
- Removed dead switchTrainingSection window function

## Verified Working
- All 6 main tabs (event delegation)
- 4 training sub-tabs (event delegation)
- 19 onclick/onsubmit handlers (window.* from IIFE)
- Auth flow: Supabase session persistence, token refresh, profile caching
- Lazy-loading: analytics, cohorts, challenges via window._org* bridges

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo