### PR TITLE
Fix critical JS syntax error breaking org dashboard IIFE

### DIFF
--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -2847,7 +2847,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
 
         // Generate a printable HTML document and trigger download
         var printHtml = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>' + guide.title + '</title>';
-        printHtml += '<style>body{font-family:'Amaranth', sans-serif;max-width:800px;margin:0 auto;padding:2rem;color:#1e293b;line-height:1.6}';
+        printHtml += '<style>body{font-family:Amaranth, sans-serif;max-width:800px;margin:0 auto;padding:2rem;color:#1e293b;line-height:1.6}';
         printHtml += 'h1{font-size:1.5rem;color:#0f172a;border-bottom:2px solid #f59e0b;padding-bottom:0.5rem}';
         printHtml += 'h2{font-size:1.1rem;color:#0f172a;margin:1.5rem 0 0.5rem}';
         printHtml += '.session{page-break-inside:avoid;border:1px solid #e2e8f0;border-radius:8px;padding:1.25rem;margin:1rem 0}';


### PR DESCRIPTION
## Summary
- Fix unescaped single quotes in `font-family:'Amaranth'` inside a JS string at line 2850 of org-dashboard.html
- This syntax error prevented the entire 1000+ line IIFE from parsing, breaking: auth, tab switching, analytics loading, facilitator guides, and all dynamic functionality

## Test plan
- [x] Verified with `node --check` that the script parses correctly
- [ ] Open org-dashboard.html and verify all 6 main tabs switch
- [ ] Verify training sub-tabs (Packages, Cohorts, Guides, Rubrics) switch
- [ ] Verify facilitator guide "View Guide" buttons open guides
- [ ] Verify Progress tab loads analytics

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo