### PR TITLE
Unify premium gating: server-side auth on all Netlify sites

### DIFF
--- a/index.html
+++ b/index.html
@@ -10311,7 +10311,7 @@ textarea:focus-visible,
     </div>
     <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.15);">
         <div style="font-weight: 700; font-size: 0.88rem; color: #c4b5fd; margin-bottom: 0.4rem;">Professional Tier</div>
-        <div style="font-size: 0.8rem; color: var(--text-secondary, #94a3b8); line-height: 1.5;">Qual Lab, Stats Assistant, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, 7 interactive workshop templates (ToC Builder, Logframe, Chart Chooser, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
+        <div style="font-size: 0.8rem; color: var(--text-secondary, #94a3b8); line-height: 1.5;">Qual Lab, Stats Assistant, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, Field Notes Pro, 7 Workshop Pro templates (ToC, LogFrame, Chart Selector, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
     </div>
 </div>
 <div class="cards-grid">
@@ -10369,8 +10369,8 @@ textarea:focus-visible,
 <p class="card-description">Build, iterate, and export publication-ready theories of change with assumption mapping, evidence linkage, version history, and PDF/PNG export</p>
 </a>
 </div>
-<div class="card">
-<a href="https://marginmuse.space/themarginmuse" rel="noopener noreferrer" target="_blank">
+<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 70+ field observations from development economics fieldwork across South Asia!">
+<a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Direction_alt"/></svg>
@@ -10378,10 +10378,10 @@ textarea:focus-visible,
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
-                                450 Subscribers
+                                70+ Notes
                             </span>
 </div>
-<h3 class="card-title">Field Notes from a Development Economist</h3>
+<h3 class="card-title">Field Notes Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10560,7 +10560,7 @@ textarea:focus-visible,
 </div>
 <!-- Interactive Workshop Templates (Professional Tier) -->
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Theory of Change builder with drag-and-drop causal pathways and assumption mapping!">
-<a href="/templates/theory-of-change.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Crosshair_detailed"/></svg>
@@ -10571,7 +10571,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Theory of Change Builder</h3>
+<h3 class="card-title">ToC Workshop Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10587,7 +10587,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Logframe builder with linked indicators and exportable results frameworks!">
-<a href="/templates/logframe-builder.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
@@ -10598,7 +10598,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Logframe Builder</h3>
+<h3 class="card-title">LogFrame Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10614,7 +10614,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the interactive Chart Selection Guide with decision tree and best-practice examples!">
-<a href="/templates/chart-decision-tree.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
@@ -10625,7 +10625,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Chart Selection Guide</h3>
+<h3 class="card-title">Chart Selector Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10641,7 +10641,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Stakeholder Power Map for collaborative stakeholder analysis workshops!">
-<a href="/templates/stakeholder-map.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -10652,7 +10652,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Stakeholder Power Map</h3>
+<h3 class="card-title">Stakeholder Map Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10668,7 +10668,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Empathy Map Builder for user-centered design workshops!">
-<a href="/templates/empathy-map.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Chat"/></svg>
@@ -10679,7 +10679,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Empathy Map Builder</h3>
+<h3 class="card-title">Empathy Map Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10695,7 +10695,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Policy Analysis Canvas for structured policy evaluation workshops!">
-<a href="/templates/policy-analysis-canvas.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
@@ -10706,7 +10706,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Policy Analysis Canvas</h3>
+<h3 class="card-title">Policy Canvas Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10722,7 +10722,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the AI Opportunity Canvas for mapping responsible AI use cases!">
-<a href="/templates/ai-opportunity-canvas.html" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Lightning"/></svg>
@@ -10733,7 +10733,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">AI Opportunity Canvas</h3>
+<h3 class="card-title">AI Canvas Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -11909,12 +11909,12 @@ textarea:focus-visible,
 </a>
 </div>
 </div>
-<div class="modal-item">
+<div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock 70+ field observations from development fieldwork!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="https://marginmuse.space/themarginmuse" rel="noopener noreferrer" target="_blank">
+<a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        Field Notes from a Development Economist
+                        Field Notes Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12057,8 +12057,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#si_Crosshair_detailed"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/theory-of-change.html" target="_blank">
-<div class="modal-item-title">Theory of Change Builder
+<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">ToC Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12073,8 +12073,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/logframe-builder.html" target="_blank">
-<div class="modal-item-title">Logframe Builder
+<a href="https://impactmojo-workshop-pro.netlify.app/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">LogFrame Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12089,8 +12089,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/chart-decision-tree.html" target="_blank">
-<div class="modal-item-title">Chart Selection Guide
+<a href="https://impactmojo-workshop-pro.netlify.app/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">Chart Selector Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12105,8 +12105,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/stakeholder-map.html" target="_blank">
-<div class="modal-item-title">Stakeholder Power Map
+<a href="https://impactmojo-workshop-pro.netlify.app/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">Stakeholder Map Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12121,8 +12121,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/empathy-map.html" target="_blank">
-<div class="modal-item-title">Empathy Map Builder
+<a href="https://impactmojo-workshop-pro.netlify.app/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">Empathy Map Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12137,8 +12137,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/policy-analysis-canvas.html" target="_blank">
-<div class="modal-item-title">Policy Analysis Canvas
+<a href="https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">Policy Canvas Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12153,8 +12153,8 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></div>
 <div class="modal-item-content">
-<a href="/templates/ai-opportunity-canvas.html" target="_blank">
-<div class="modal-item-title">AI Opportunity Canvas
+<a href="https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">AI Canvas Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>

--- a/js/resource-launch.js
+++ b/js/resource-launch.js
@@ -19,14 +19,24 @@
   // so the ?token= query param reaches the auth-gate / token-gate.
   const RESOURCE_URLS = {
     // Practitioner tier
-    'rq-builder':       'https://researchquestions.netlify.app/',
+    'rq-builder':         'https://researchquestions.netlify.app/',
     // Professional tier
-    'code-convert-pro': 'https://stats-assist.netlify.app/',
-    'qual-insights':    'https://qual-lab.netlify.app/',
-    'vaniscribe':       'https://vaniscribe.netlify.app/',
-    'devdata-practice': 'https://varnasr.github.io/devdata-practice/',
-    'viz-cookbook':      'https://varnasr.github.io/devdata-practice/charts.html',
-    'devecon-toolkit':  'https://varnasr.github.io/deveconomics-toolkit/',
+    'code-convert-pro':   'https://stats-assist.netlify.app/',
+    'qual-insights':      'https://qual-lab.netlify.app/',
+    'vaniscribe':         'https://vaniscribe.netlify.app/',
+    'devdata-practice':   'https://varnasr.github.io/devdata-practice/',
+    'viz-cookbook':        'https://varnasr.github.io/devdata-practice/charts.html',
+    'devecon-toolkit':    'https://varnasr.github.io/deveconomics-toolkit/',
+    // Workshop Pro templates
+    'toc-workshop-pro':   'https://impactmojo-workshop-pro.netlify.app/toc-pro.html',
+    'logframe-pro':       'https://impactmojo-workshop-pro.netlify.app/logframe-pro.html',
+    'chart-selector-pro': 'https://impactmojo-workshop-pro.netlify.app/chart-selector-pro.html',
+    'stakeholder-pro':    'https://impactmojo-workshop-pro.netlify.app/stakeholder-pro.html',
+    'empathy-pro':        'https://impactmojo-workshop-pro.netlify.app/empathy-pro.html',
+    'policy-canvas-pro':  'https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html',
+    'ai-canvas-pro':      'https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html',
+    // Field Notes Pro
+    'field-notes-pro':    'https://impactmojo-field-notes-pro.netlify.app/',
   };
 
   // Supabase Edge Function URL (auto-derived from the Supabase project URL in auth.js)

--- a/supabase/functions/mint-resource-token/index.ts
+++ b/supabase/functions/mint-resource-token/index.ts
@@ -28,6 +28,16 @@ const TIER_RESOURCES: Record<string, string[]> = {
     "devdata-practice",
     "viz-cookbook",
     "devecon-toolkit",
+    // Workshop Pro templates
+    "toc-workshop-pro",
+    "logframe-pro",
+    "chart-selector-pro",
+    "stakeholder-pro",
+    "empathy-pro",
+    "policy-canvas-pro",
+    "ai-canvas-pro",
+    // Field Notes Pro
+    "field-notes-pro",
   ],
   organization: [
     "rq-builder",
@@ -37,6 +47,16 @@ const TIER_RESOURCES: Record<string, string[]> = {
     "devdata-practice",
     "viz-cookbook",
     "devecon-toolkit",
+    // Workshop Pro templates
+    "toc-workshop-pro",
+    "logframe-pro",
+    "chart-selector-pro",
+    "stakeholder-pro",
+    "empathy-pro",
+    "policy-canvas-pro",
+    "ai-canvas-pro",
+    // Field Notes Pro
+    "field-notes-pro",
   ],
 };
 


### PR DESCRIPTION
## Summary
- Deploy 7 workshop templates to `impactmojo-workshop-pro.netlify.app` with Netlify Edge Function server-side auth-gate
- Deploy Field Notes Pro (Margin Muse clone with 70 entries) to `impactmojo-field-notes-pro.netlify.app` with same auth-gate
- Add 8 new resource IDs to `mint-resource-token` Supabase function
- Update `resource-launch.js` with all new Netlify URLs
- Update all `index.html` links to use `data-resource-id` for JWT launcher
- Apply PRO naming convention across all tools
- Gate Field Notes (previously ungated) as Professional tier

## Architecture
Content never reaches the browser without a valid, server-verified JWT. No client-side secrets. Same pattern as existing tools (VaniScribe, Qual Lab, etc.)

## New repos created
- `Varnasr/impactmojo-workshop-pro` (private)
- `Varnasr/impactmojo-field-notes-pro` (private)

## Manual step needed
Set `RESOURCE_TOKEN_SECRET` env var on both new Netlify sites (same value as existing sites like vaniscribe). Cannot be copied via API (write-only).

## Test plan
- [ ] Set RESOURCE_TOKEN_SECRET on both new Netlify sites
- [ ] Verify workshop-pro.netlify.app redirects to premium page without token
- [ ] Verify field-notes-pro.netlify.app redirects without token
- [ ] Verify JWT launch flow works for Professional tier users
- [ ] Verify premium lock overlay appears for free users on index.html

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo