### PR TITLE
Migrate premium tools from GitHub Pages to Netlify auth-gate

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -2088,7 +2088,7 @@ const allContent = [
     { id: 'g12', type: 'game', title: 'Econ Concepts Puzzle', description: 'Solve economic puzzles that teach concepts through engaging brain-teasers.', track: 'policy', rating: 4.8, users: '610', url: 'https://101.impactmojo.in/econ-concepts-game' },
     
     // PREMIUM (6)
-    { id: 'p1', type: 'premium', title: 'Field Notes from a Development Economist', description: 'In-depth analysis and insights from field experiences with Dr. Varna.', track: 'policy', rating: 5.0, users: '450', url: 'https://marginmuse.space/themarginmuse' },
+    { id: 'p1', type: 'premium', title: 'Field Notes from a Development Economist', description: 'In-depth analysis and insights from field experiences with Dr. Varna.', track: 'policy', rating: 5.0, users: '450', url: 'https://impactmojo-field-notes-pro.netlify.app/' },
     { id: 'p2', type: 'premium', title: 'Qualitative Research Lab Pro', description: 'Advanced qualitative research methods and AI-assisted coding tools.', track: 'mel', rating: 4.5, users: '680', url: 'https://101.impactmojo.in/qual-insights' },
     { id: 'p3', type: 'premium', title: 'Statistical Code Converter Pro', description: 'Comprehensive statistical analysis toolkit for development research.', track: 'data-tech', rating: 4.5, users: '920', url: 'https://101.impactmojo.in/code-convert-pro' },
     { id: 'p4', type: 'premium', title: 'RQ Builder Pro', description: 'Advanced research question formulation and hypothesis development framework.', track: 'mel', rating: 4.9, users: '540', url: 'https://101.impactmojo.in/researchQ-pro' },

--- a/docs/content-catalog.md
+++ b/docs/content-catalog.md
@@ -227,13 +227,13 @@ Advanced tools for researchers and practitioners. Requires a paid membership.
 |---|------|------|-------------|------|
 | 1 | RQ Builder Pro | Practitioner | Guided research question builder with PICO/SPIDER framing | [Open](https://101.impactmojo.in/researchQ-pro) |
 | 2 | TOC Workbench Pro | Practitioner | Advanced ToC building with assumption mapping and PDF/PNG export | [Open](https://101.impactmojo.in/toc-workbench) |
-| 3 | Field Notes from a Development Economist | Professional | Behind-the-scenes analysis of real programs and trade-offs | [Open](https://marginmuse.space/themarginmuse) |
+| 3 | Field Notes from a Development Economist | Professional | Behind-the-scenes analysis of real programs and trade-offs | [Open](https://impactmojo-field-notes-pro.netlify.app/) |
 | 4 | Qualitative Research Lab | Professional | AI-assisted thematic coding and memo generation | [Open](https://101.impactmojo.in/qual-insights) |
 | 5 | Statistical Code Converter Pro | Professional | Translate code between R, Stata, SPSS & Python with regression diagnostics and power analysis | [Open](https://101.impactmojo.in/code-convert-pro) |
-| 6 | DevData Practice | Professional | 36 dataset generators with 840k+ rows of realistic development data | [Open](https://varnasr.github.io/devdata-practice/) |
+| 6 | DevData Practice | Professional | 36 dataset generators with 840k+ rows of realistic development data | [Open](https://impactmojo-devdata-pro.netlify.app/) |
 | 7 | VaniScribe: AI Transcription | Professional | Transcribe interviews in 10+ South Asian languages | [Open](https://101.impactmojo.in/vaniscribe) |
-| 8 | Visualization Cookbook | Professional | Question-driven chart recipes with production-ready Python code | [Open](https://varnasr.github.io/devdata-practice/charts.html) |
-| 9 | DevEconomics Toolkit | Professional | 11 interactive Shiny apps for impact evaluation and program design | [Open](https://varnasr.github.io/deveconomics-toolkit/) |
+| 8 | Visualization Cookbook | Professional | Question-driven chart recipes with production-ready Python code | [Open](https://impactmojo-devdata-pro.netlify.app/charts.html) |
+| 9 | DevEconomics Toolkit | Professional | 11 interactive Shiny apps for impact evaluation and program design | [Open](https://impactmojo-devecon-toolkit.netlify.app/) |
 
 ---
 

--- a/docs/devdata-practice-guide.md
+++ b/docs/devdata-practice-guide.md
@@ -6,7 +6,7 @@ DevData Practice is ImpactMojo's **synthetic dataset generator** — a tool that
 
 If you've ever needed practice data for a training session, a classroom exercise, or testing an analytical approach — but couldn't use real data because it's sensitive, restricted, or messy in ways that distract from learning — DevData Practice solves that problem.
 
-**Access:** Professional tier (₹999/month) — [Open DevData Practice](https://varnasr.github.io/devdata-practice/)
+**Access:** Professional tier (₹999/month) — [Open DevData Practice](https://impactmojo-devdata-pro.netlify.app/)
 
 ---
 

--- a/docs/deveconomics-toolkit-guide.md
+++ b/docs/deveconomics-toolkit-guide.md
@@ -6,7 +6,7 @@ The DevEconomics Toolkit is a collection of **11 interactive web applications** 
 
 You don't need to install anything. Each app runs in your web browser.
 
-**Access:** Professional tier (₹999/month) — [Open DevEconomics Toolkit](https://varnasr.github.io/deveconomics-toolkit/)
+**Access:** Professional tier (₹999/month) — [Open DevEconomics Toolkit](https://impactmojo-devecon-toolkit.netlify.app/)
 
 ---
 

--- a/docs/premium-tools-guide.md
+++ b/docs/premium-tools-guide.md
@@ -44,7 +44,7 @@ Premium tools require a paid membership (Practitioner or Professional tier). The
 
 **Why synthetic data?** Real development data is often sensitive, restricted, or messy in ways that distract from learning. DevData Practice generates clean, realistic datasets so learners can focus on methods, not data cleaning.
 
-**Access:** Professional tier — [Open DevData Practice](https://varnasr.github.io/devdata-practice/)
+**Access:** Professional tier — [Open DevData Practice](https://impactmojo-devdata-pro.netlify.app/)
 
 ---
 
@@ -54,7 +54,7 @@ Premium tools require a paid membership (Practitioner or Professional tier). The
 
 **Who it's for:** Practitioners who need to create publication-quality charts for reports and presentations and want ready-to-use code rather than starting from scratch.
 
-**Access:** Part of DevData Practice — [Open Visualization Cookbook](https://varnasr.github.io/devdata-practice/charts.html)
+**Access:** Part of DevData Practice — [Open Visualization Cookbook](https://impactmojo-devdata-pro.netlify.app/charts.html)
 
 ---
 
@@ -78,7 +78,7 @@ Premium tools require a paid membership (Practitioner or Professional tier). The
 
 **Who it's for:** Development economists, evaluation specialists, and students learning econometric methods. Each app makes a complex method interactive — you adjust parameters and see results in real time.
 
-**Access:** Professional tier — [Open DevEconomics Toolkit](https://varnasr.github.io/deveconomics-toolkit/)
+**Access:** Professional tier — [Open DevEconomics Toolkit](https://impactmojo-devecon-toolkit.netlify.app/)
 
 ---
 
@@ -90,7 +90,7 @@ Premium tools require a paid membership (Practitioner or Professional tier). The
 | **TOC Workbench Pro** | Advanced Theory of Change building with assumption mapping, evidence linkage, and PDF/PNG export | Practitioner+ |
 | **Qualitative Research Lab (Qual Insights)** | AI-assisted qualitative coding and analysis | Professional |
 | **Statistical Code Converter Pro** | Translate code between R, Stata, SPSS & Python with regression diagnostics and power analysis | Professional |
-| **Field Notes from a Dev Economist** ([The Margin Muse](https://marginmuse.space/themarginmuse)) | Practical field observations from development work — not a blog, but grounded notes from real programme experiences | Professional |
+| **Field Notes from a Dev Economist** ([The Margin Muse](https://impactmojo-field-notes-pro.netlify.app/)) | Practical field observations from development work — not a blog, but grounded notes from real programme experiences | Professional |
 
 ---
 

--- a/docs/visualization-cookbook-guide.md
+++ b/docs/visualization-cookbook-guide.md
@@ -6,7 +6,7 @@ The Visualization Cookbook is a **question-driven chart selection tool** with pr
 
 It includes **14 chart types** covering the most common data stories in development work.
 
-**Access:** Part of DevData Practice (Professional tier) — [Open Visualization Cookbook](https://varnasr.github.io/devdata-practice/charts.html)
+**Access:** Part of DevData Practice (Professional tier) — [Open Visualization Cookbook](https://impactmojo-devdata-pro.netlify.app/charts.html)
 
 ---
 

--- a/docs/why-impactmojo.md
+++ b/docs/why-impactmojo.md
@@ -143,4 +143,4 @@ Sliding scale is always available for grassroots organizations.
 | Handouts | [www.impactmojo.in/Handouts/](https://www.impactmojo.in/Handouts/) |
 | Blog | [www.impactmojo.in/blog.html](https://www.impactmojo.in/blog.html) |
 | Contact | [hello@impactmojo.in](mailto:hello@impactmojo.in) |
-| Field Notes: The Margin Muse | [marginmuse.space](https://marginmuse.space/themarginmuse) |
+| Field Notes Pro | [impactmojo-field-notes-pro.netlify.app](https://impactmojo-field-notes-pro.netlify.app/) |

--- a/index.html
+++ b/index.html
@@ -10451,7 +10451,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 36 dataset generators, 840k+ rows of realistic development data, and practice exercises!">
-<a href="https://varnasr.github.io/devdata-practice/" data-resource-id="devdata-practice" rel="noopener noreferrer" target="_blank">
+<a href="https://impactmojo-devdata-pro.netlify.app/" data-resource-id="devdata-practice" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Database"/></svg>
@@ -10505,7 +10505,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Visualization Cookbook with 14 chart types and production-ready Python code!">
-<a href="https://varnasr.github.io/devdata-practice/charts.html" data-resource-id="viz-cookbook" rel="noopener noreferrer" target="_blank">
+<a href="https://impactmojo-devdata-pro.netlify.app/charts.html" data-resource-id="viz-cookbook" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
@@ -10532,7 +10532,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 11 interactive Shiny apps for impact evaluation, poverty analysis, and program design!">
-<a href="https://varnasr.github.io/deveconomics-toolkit/" data-resource-id="devecon-toolkit" rel="noopener noreferrer" target="_blank">
+<a href="https://impactmojo-devecon-toolkit.netlify.app/" data-resource-id="devecon-toolkit" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Lightning"/></svg>
@@ -12006,7 +12006,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional: Unlock 36 dataset generators, 840k+ rows of realistic development data!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg></div>
 <div class="modal-item-content">
-<a href="https://varnasr.github.io/devdata-practice/" data-resource-id="devdata-practice" target="_blank" rel="noopener noreferrer">
+<a href="https://impactmojo-devdata-pro.netlify.app/" data-resource-id="devdata-practice" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">DevData Practice: Realistic Development Datasets
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12023,7 +12023,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional: Unlock question-driven chart recipes with production-ready Python code!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></div>
 <div class="modal-item-content">
-<a href="https://varnasr.github.io/devdata-practice/charts.html" data-resource-id="viz-cookbook" target="_blank" rel="noopener noreferrer">
+<a href="https://impactmojo-devdata-pro.netlify.app/charts.html" data-resource-id="viz-cookbook" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Visualization Cookbook: Chart Recipes for Development Data
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12040,7 +12040,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional: Unlock 11 interactive Shiny apps for development economics!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg></div>
 <div class="modal-item-content">
-<a href="https://varnasr.github.io/deveconomics-toolkit/" data-resource-id="devecon-toolkit" target="_blank" rel="noopener noreferrer">
+<a href="https://impactmojo-devecon-toolkit.netlify.app/" data-resource-id="devecon-toolkit" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">DevEconomics Toolkit: Interactive Shiny Apps
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>

--- a/js/faq-bank.js
+++ b/js/faq-bank.js
@@ -247,7 +247,7 @@
 
     // DevData Practice
     { re: /devdata|dataset|data.*practice|realistic.*data|household.*survey|rct.*data/i,
-      a: "**DevData Practice** is our premium resource with 36 realistic dataset generators producing 840k+ rows of development economics data. Covers household surveys, RCTs, health, education, agriculture, gender, climate, WASH, humanitarian, IRT psychometrics, and more. Includes practice exercises. Visit: https://varnasr.github.io/devdata-practice/" },
+      a: "**DevData Practice** is our premium resource with 36 realistic dataset generators producing 840k+ rows of development economics data. Covers household surveys, RCTs, health, education, agriculture, gender, climate, WASH, humanitarian, IRT psychometrics, and more. Includes practice exercises. Visit: https://impactmojo-devdata-pro.netlify.app/" },
     // Constitution & Law
     { re: /constitution|law.*course|pil|article.*21|fundamental.*right|basic.*structure|rights.*based/i,
       a: "**Constitution & Law for Development Practice** is our flagship course on rights, institutions and justice in South Asia. 13 modules covering the Indian Constitution, fundamental rights, PIL, Article 21, reservations, rights-based legislation, criminal justice, environmental law, digital rights, and comparative constitutional systems. Visit: /courses/law/" },
@@ -259,9 +259,9 @@
       a: "**VaniScribe** is our premium AI transcription tool for development researchers. Transcribe field interviews, FGDs, and KIIs in Hindi, Tamil, Bengali, and 10+ South Asian languages using Sarvam AI. Features speaker diarization, auto-timestamping, and export to structured formats for qualitative analysis. Visit: https://101.impactmojo.in/vaniscribe" },
     // Visualization Cookbook
     { re: /viz.*cookbook|visualization.*cookbook|chart.*recipe|chart.*type|python.*chart|data.*viz.*code/i,
-      a: "The **Visualization Cookbook** is a premium resource with 14 chart types and production-ready Python code. Question-driven: pick the story your data tells (comparison, distribution, relationship, composition, time series, spatial) and get the right chart with code. Part of DevData Practice. Visit: https://varnasr.github.io/devdata-practice/charts.html" },
+      a: "The **Visualization Cookbook** is a premium resource with 14 chart types and production-ready Python code. Question-driven: pick the story your data tells (comparison, distribution, relationship, composition, time series, spatial) and get the right chart with code. Part of DevData Practice. Visit: https://impactmojo-devdata-pro.netlify.app/charts.html" },
     { re: /deveconomics.*toolkit|shiny.*app|rct.*power|did.*simulator|rdd.*explorer|synthetic.*control|gini.*tool|mpi.*explorer|logframe|wdi.*dashboard|poverty.*line.*analysis|cost.*benefit.*tool/i,
-      a: "**DevEconomics Toolkit** is our premium collection of 11 interactive Shiny apps for development economics. Includes RCT power calculator, DiD simulator, RDD explorer, synthetic control visualizer, Gini and Lorenz curve tool, MPI explorer, poverty line analysis, Theory of Change visualizer, cost-benefit analysis tool, LogFrame builder, and WDI dashboard. Visit: https://varnasr.github.io/deveconomics-toolkit/" }
+      a: "**DevEconomics Toolkit** is our premium collection of 11 interactive Shiny apps for development economics. Includes RCT power calculator, DiD simulator, RDD explorer, synthetic control visualizer, Gini and Lorenz curve tool, MPI explorer, poverty line analysis, Theory of Change visualizer, cost-benefit analysis tool, LogFrame builder, and WDI dashboard. Visit: https://impactmojo-devecon-toolkit.netlify.app/" }
   ];
 
   // Dynamic course objective matcher (covers "What's the objective of X?"  without listing all regexes)

--- a/js/resource-launch.js
+++ b/js/resource-launch.js
@@ -24,9 +24,9 @@
     'code-convert-pro':   'https://stats-assist.netlify.app/',
     'qual-insights':      'https://qual-lab.netlify.app/',
     'vaniscribe':         'https://vaniscribe.netlify.app/',
-    'devdata-practice':   'https://varnasr.github.io/devdata-practice/',
-    'viz-cookbook':        'https://varnasr.github.io/devdata-practice/charts.html',
-    'devecon-toolkit':    'https://varnasr.github.io/deveconomics-toolkit/',
+    'devdata-practice':   'https://impactmojo-devdata-pro.netlify.app/',
+    'viz-cookbook':        'https://impactmojo-devdata-pro.netlify.app/charts.html',
+    'devecon-toolkit':    'https://impactmojo-devecon-toolkit.netlify.app/',
     // Workshop Pro templates
     'toc-workshop-pro':   'https://impactmojo-workshop-pro.netlify.app/toc-pro.html',
     'logframe-pro':       'https://impactmojo-workshop-pro.netlify.app/logframe-pro.html',

--- a/premium.html
+++ b/premium.html
@@ -1422,7 +1422,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             </div>
             <div class="detail-item">
                 <h4>Field Notes from a Development Economist</h4>
-                <p>Behind-the-scenes analysis of real development programs. Covers procurement dynamics, implementation trade-offs, political economy constraints, and the gap between program design and field reality. Written from direct experience working across South Asian contexts. <a href="https://marginmuse.space/themarginmuse" target="_blank" rel="noopener noreferrer">Read Field Notes &rarr;</a></p>
+                <p>Behind-the-scenes analysis of real development programs. Covers procurement dynamics, implementation trade-offs, political economy constraints, and the gap between program design and field reality. Written from direct experience working across South Asian contexts. <a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" target="_blank" rel="noopener noreferrer">Read Field Notes &rarr;</a></p>
             </div>
             <div class="detail-item">
                 <h4>Progress Tracking & ImpactLex</h4>

--- a/supabase/functions/mint-resource-token/index.ts
+++ b/supabase/functions/mint-resource-token/index.ts
@@ -60,6 +60,20 @@ const TIER_RESOURCES: Record<string, string[]> = {
   ],
 };
 
+// ── Resource → Site RESOURCE_ID mapping ──────────────────────────────
+// When multiple resources share a single Netlify site, the JWT `resource`
+// claim must match that site's RESOURCE_ID env var.
+const RESOURCE_SITE_ID: Record<string, string> = {
+  "viz-cookbook":        "devdata-practice",   // same Netlify site as devdata-practice
+  "toc-workshop-pro":   "workshop-pro",       // all workshop templates share one site
+  "logframe-pro":       "workshop-pro",
+  "chart-selector-pro": "workshop-pro",
+  "stakeholder-pro":    "workshop-pro",
+  "empathy-pro":        "workshop-pro",
+  "policy-canvas-pro":  "workshop-pro",
+  "ai-canvas-pro":      "workshop-pro",
+};
+
 // ── Allowed origins ─────────────────────────────────────────────────
 const ALLOWED_ORIGINS = [
   "https://www.impactmojo.in",
@@ -237,7 +251,7 @@ serve(async (req: Request) => {
       { alg: "HS256", typ: "JWT" },
       {
         sub: user.id,
-        resource,
+        resource: RESOURCE_SITE_ID[resource] ?? resource,
         iat: now,
         exp: getNumericDate(5 * 60), // 5 minutes from now
       },

--- a/updates.html
+++ b/updates.html
@@ -463,7 +463,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             <div class="whats-new-card-title">DevData Practice</div>
             <div class="whats-new-card-desc">36 dataset generators producing 840k+ rows of realistic development economics data with practice exercises.</div>
             <span class="whats-new-card-tag tag-new">Premium</span>
-            <div class="whats-new-card-expand"><div class="whats-new-card-expand-content"><strong>Datasets include:</strong><ul><li>LSMS-style household surveys (75k rows), multi-arm RCTs (25k), DHS-style health (35k)</li><li>Education, agriculture, gender, climate, WASH, humanitarian response, IRT psychometrics</li><li>Practice exercises organized by difficulty</li><li><strong>NEW: Visualization Cookbook</strong> with 14 chart types and production-ready Python code</li></ul></div><a href="https://varnasr.github.io/devdata-practice/" target="_blank" rel="noopener noreferrer" class="whats-new-card-action">Open DevData Practice &rarr;</a></div>
+            <div class="whats-new-card-expand"><div class="whats-new-card-expand-content"><strong>Datasets include:</strong><ul><li>LSMS-style household surveys (75k rows), multi-arm RCTs (25k), DHS-style health (35k)</li><li>Education, agriculture, gender, climate, WASH, humanitarian response, IRT psychometrics</li><li>Practice exercises organized by difficulty</li><li><strong>NEW: Visualization Cookbook</strong> with 14 chart types and production-ready Python code</li></ul></div><a href="https://impactmojo-devdata-pro.netlify.app/" target="_blank" rel="noopener noreferrer" class="whats-new-card-action">Open DevData Practice &rarr;</a></div>
         </div>
 
         <div class="whats-new-card card-compare" onclick="toggleCard(this)">
@@ -472,7 +472,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             <div class="whats-new-card-title">DevEconomics Toolkit</div>
             <div class="whats-new-card-desc">11 interactive Shiny apps: RCT power, DiD, RDD, synthetic control, Gini/MPI, CBA, LogFrame, WDI dashboard.</div>
             <span class="whats-new-card-tag tag-new">Premium</span>
-            <div class="whats-new-card-expand"><div class="whats-new-card-expand-content"><strong>Tools include:</strong><ul><li>Impact evaluation: RCT power calculator, DiD simulator, RDD explorer, synthetic control</li><li>Poverty and inequality: Gini/Lorenz curves, MPI explorer, poverty line analysis</li><li>Program design: ToC visualizer, cost-benefit analysis, LogFrame builder, WDI dashboard</li></ul></div><a href="https://varnasr.github.io/deveconomics-toolkit/" target="_blank" rel="noopener noreferrer" class="whats-new-card-action">Open Toolkit &rarr;</a></div>
+            <div class="whats-new-card-expand"><div class="whats-new-card-expand-content"><strong>Tools include:</strong><ul><li>Impact evaluation: RCT power calculator, DiD simulator, RDD explorer, synthetic control</li><li>Poverty and inequality: Gini/Lorenz curves, MPI explorer, poverty line analysis</li><li>Program design: ToC visualizer, cost-benefit analysis, LogFrame builder, WDI dashboard</li></ul></div><a href="https://impactmojo-devecon-toolkit.netlify.app/" target="_blank" rel="noopener noreferrer" class="whats-new-card-action">Open Toolkit &rarr;</a></div>
         </div>
 
         <div class="whats-new-card card-tour" onclick="toggleCard(this)">


### PR DESCRIPTION
## Summary
- Move DevData Practice, Viz Cookbook, DevEcon Toolkit from GitHub Pages to Netlify with server-side JWT auth-gate
- Fix Field Notes link from marginmuse.space to Netlify
- Update all URLs across 13 files
- Add RESOURCE_SITE_ID mapping for shared-site JWT claims

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo