### PR TITLE
Fix mobile auth buttons to use real login/signup pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8706,11 +8706,11 @@ textarea:focus-visible,
 
 <!-- Mobile Auth Buttons (inside nav-links so they appear in the fixed mobile menu overlay) -->
 <li class="mobile-auth-section" id="mobileAuthSection">
-    <a href="#" onclick="event.preventDefault(); closeMobileMenu(); if(window.ImpactMojoAuth) ImpactMojoAuth.showAuthModal('login');" class="mobile-auth-btn mobile-auth-login">
+    <a href="/login" onclick="closeMobileMenu();" class="mobile-auth-btn mobile-auth-login auth-logged-out">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
         Log In
     </a>
-    <a href="#" onclick="event.preventDefault(); closeMobileMenu(); if(window.ImpactMojoAuth) ImpactMojoAuth.showAuthModal('signup');" class="mobile-auth-btn mobile-auth-signup">
+    <a href="/signup" onclick="closeMobileMenu();" class="mobile-auth-btn mobile-auth-signup auth-logged-out">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>
         Sign Up
     </a>


### PR DESCRIPTION
## Summary
- Mobile Login/Sign Up buttons were calling `showAuthModal()` which does not exist in auth.js — silent failure
- Changed to direct `href="/login"` and `href="/signup"` links
- Added `auth-logged-out` class so buttons auto-hide when user is logged in

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo