### PR TITLE
Replace stale 101.impactmojo.in links on all premium resource cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -10320,7 +10320,7 @@ textarea:focus-visible,
 </div>
 <div class="cards-grid">
 <div class="card" data-required-tier="practitioner" data-tier-benefits="Upgrade to Practitioner (₹399/mo): Unlock guided research question building with PICO/SPIDER framing, method suggestions, and worked examples!">
-<a href="https://101.impactmojo.in/researchQ-pro" data-resource-id="rq-builder" rel="noopener noreferrer" target="_blank">
+<a href="https://researchquestions.netlify.app/" data-resource-id="rq-builder" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Search"/></svg>
@@ -10347,7 +10347,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="practitioner" data-tier-benefits="Upgrade to Practitioner (₹399/mo): Unlock advanced Theory of Change building with assumption mapping, evidence linkage, and PDF/PNG export!">
-<a href="https://101.impactmojo.in/toc-workbench" data-resource-id="toc-workbench-pro" rel="noopener noreferrer" target="_blank">
+<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Crosshair_detailed"/></svg>
@@ -10401,7 +10401,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock AI-assisted thematic coding, memo generation, and transcript analysis for qualitative research!">
-<a href="https://101.impactmojo.in/qual-insights" data-resource-id="qual-insights" rel="noopener noreferrer" target="_blank">
+<a href="https://qual-lab.netlify.app/" data-resource-id="qual-insights" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
@@ -10428,7 +10428,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock regression diagnostics, effect size calculators, power analysis, and code conversion across Stata, R, Python &amp; SPSS!">
-<a href="https://101.impactmojo.in/code-convert-pro" data-resource-id="code-convert-pro" rel="noopener noreferrer" target="_blank">
+<a href="https://stats-assist.netlify.app/" data-resource-id="code-convert-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
@@ -10482,7 +10482,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock AI transcription for 10+ South Asian languages with speaker diarization!">
-<a href="https://101.impactmojo.in/vaniscribe" data-resource-id="vaniscribe" rel="noopener noreferrer" target="_blank">
+<a href="https://vaniscribe.netlify.app/" data-resource-id="vaniscribe" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Chat"/></svg>
@@ -11872,7 +11872,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI tools, templates, webinars & priority coaching!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="https://101.impactmojo.in/code-convert-pro" data-resource-id="code-convert-pro" target="_blank" rel="noopener noreferrer">
+<a href="https://stats-assist.netlify.app/" data-resource-id="code-convert-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         Statistical Code Convertor Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
@@ -11894,7 +11894,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI analysis, expert webinars & priority support!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="https://101.impactmojo.in/qual-insights" data-resource-id="qual-insights" target="_blank" rel="noopener noreferrer">
+<a href="https://qual-lab.netlify.app/" data-resource-id="qual-insights" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         Qualitative Insights Lab Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
@@ -11938,7 +11938,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="practitioner" data-tier-benefits="Practitioner (₹399/mo): Unlock advanced research tools & community access!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M4 4h16v12H5.5L4 17.5V4z"></path><path d="M9 8h6M9 11h3"></path><circle cx="17" cy="17" r="3"></circle><path d="M19 19l1.5 1.5"></path></svg></div>
 <div class="modal-item-content">
-<a href="https://101.impactmojo.in/researchQ-pro" data-resource-id="rq-builder" target="_blank" rel="noopener noreferrer">
+<a href="https://researchquestions.netlify.app/" data-resource-id="rq-builder" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         RQ Builder Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
@@ -11961,7 +11961,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="practitioner" data-tier-benefits="Practitioner (₹399/mo): Unlock advanced ToC building with assumption mapping, evidence linkage & export!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#si_Crosshair_detailed"/></svg></div>
 <div class="modal-item-content">
-<a href="https://101.impactmojo.in/toc-workbench" data-resource-id="toc-workbench-pro" target="_blank" rel="noopener noreferrer">
+<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         TOC Workbench Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
@@ -11986,7 +11986,7 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI tools, field transcription & priority support!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></div>
 <div class="modal-item-content">
-<a href="https://101.impactmojo.in/vaniscribe" data-resource-id="vaniscribe" target="_blank" rel="noopener noreferrer">
+<a href="https://vaniscribe.netlify.app/" data-resource-id="vaniscribe" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         VaniScribe: AI Transcription for Development
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">


### PR DESCRIPTION
## Summary
- Updated 10 premium resource card hrefs from old `101.impactmojo.in` short.io links to actual Netlify deployment URLs
- Fixed `toc-workbench-pro` → `toc-workshop-pro` to match RESOURCE_URLS mapping
- All 15 `data-resource-id` values now have matching RESOURCE_URLS entries

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo