### PR TITLE
Fix course URL mismatch and tier naming inconsistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -13306,7 +13306,7 @@ textarea:focus-visible,
 <div class="modal-item">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewbox="0 0 24 24"><path d="M9 11l3 3L22 4"></path><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"></path></svg></div>
 <div class="modal-item-content">
-<a href="https://101.impactmojo.in/climate-essentials" data-fallback="https://climate-science-101-qy4r9r6.gamma.site/" target="_blank" rel="noopener noreferrer">
+<a href="https://101.impactmojo.in/cost-effectiveness" data-fallback="https://impact-evaluation-design-vrx1svd.gamma.site/" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         Cost Effectiveness 101
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">

--- a/premium.html
+++ b/premium.html
@@ -1263,7 +1263,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             <line x1="12" y1="1" x2="12" y2="23"/>
             <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
         </svg>
-        <span><strong>International payments welcome!</strong> INR via UPI &bull; USD via PayPal/Wise &mdash; email <a href="mailto:hello@impactmojo.in" style="color:var(--secondary-accent);text-decoration:underline">hello@impactmojo.in</a> for USD invoicing. Approximate USD rates: Practitioner ~$5/mo &bull; Professional ~$12/mo &bull; Organization ~$18/user/mo.</span>
+        <span><strong>International payments welcome!</strong> INR via UPI &bull; USD via PayPal/Wise &mdash; email <a href="mailto:hello@impactmojo.in" style="color:var(--secondary-accent);text-decoration:underline">hello@impactmojo.in</a> for USD invoicing. Approximate USD rates: Practitioner ~$5/mo &bull; Professional ~$12/mo &bull; Team Plan ~$18/user/mo.</span>
     </div>
 </section>
 
@@ -1628,7 +1628,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                         <option value="Practitioner - ₹3,990/year (2 months free)">Practitioner - ₹3,990/year (Annual)</option>
                         <option value="Professional - ₹999/month">Professional - ₹999/month</option>
                         <option value="Professional - ₹9,990/year (2 months free)">Professional - ₹9,990/year (Annual)</option>
-                        <option value="Organization - Custom">Organization - Custom Quote</option>
+                        <option value="Team Plan - Custom">Team Plan - Custom Quote</option>
                     </select>
                 </div>
                 


### PR DESCRIPTION
## Summary
- **index.html**: Cost Effectiveness 101 was incorrectly linking to `/climate-essentials` — fixed to `/cost-effectiveness`
- **premium.html**: "Organization" → "Team Plan" in USD rates text and form dropdown to match tier name used everywhere else

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo