### PR TITLE
Rename premium cards, fix login redirect, mark dead resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -10331,7 +10331,7 @@ textarea:focus-visible,
                                 340 Users
                             </span>
 </div>
-<h3 class="card-title">RQ Builder Pro</h3>
+<h3 class="card-title">Research Question Builder Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10358,7 +10358,7 @@ textarea:focus-visible,
                                 520 Users
                             </span>
 </div>
-<h3 class="card-title">TOC Workbench Pro</h3>
+<h3 class="card-title">Theory of Change Workbench Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10401,7 +10401,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock AI-assisted thematic coding, memo generation, and transcript analysis for qualitative research!">
-<a href="https://qual-lab.netlify.app/" data-resource-id="qual-insights" rel="noopener noreferrer" target="_blank">
+<a href="/premium" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
@@ -10412,7 +10412,7 @@ textarea:focus-visible,
                                 680 Users
                             </span>
 </div>
-<h3 class="card-title">Qualitative Research Lab</h3>
+<h3 class="card-title">Qualitative Insights Lab Pro <span style="font-size:0.7em;color:#F59E0B;">(Coming Soon)</span></h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10428,7 +10428,7 @@ textarea:focus-visible,
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock regression diagnostics, effect size calculators, power analysis, and code conversion across Stata, R, Python &amp; SPSS!">
-<a href="https://stats-assist.netlify.app/" data-resource-id="code-convert-pro" rel="noopener noreferrer" target="_blank">
+<a href="/premium" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
@@ -10439,7 +10439,7 @@ textarea:focus-visible,
                                 920 Users
                             </span>
 </div>
-<h3 class="card-title">Statistical Code Converter Pro</h3>
+<h3 class="card-title">Statistical Code Converter Pro <span style="font-size:0.7em;color:#F59E0B;">(Coming Soon)</span></h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10575,7 +10575,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">ToC Workshop Pro</h3>
+<h3 class="card-title">Theory of Change Workshop Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10602,7 +10602,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">LogFrame Pro</h3>
+<h3 class="card-title">Logical Framework Builder Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10629,7 +10629,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Chart Selector Pro</h3>
+<h3 class="card-title">Data Visualization Chart Selector Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10656,7 +10656,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Stakeholder Map Pro</h3>
+<h3 class="card-title">Stakeholder Mapping Workshop Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10683,7 +10683,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Empathy Map Pro</h3>
+<h3 class="card-title">Empathy Mapping Workshop Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10710,7 +10710,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Policy Canvas Pro</h3>
+<h3 class="card-title">Policy Analysis Canvas Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10737,7 +10737,7 @@ textarea:focus-visible,
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">AI Canvas Pro</h3>
+<h3 class="card-title">AI Strategy Canvas Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -11872,9 +11872,9 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI tools, templates, webinars & priority coaching!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="https://stats-assist.netlify.app/" data-resource-id="code-convert-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        Statistical Code Convertor Pro
+                        Statistical Code Converter Pro <span style="font-size:0.75em;color:#F59E0B;">(Coming Soon)</span>
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -11894,9 +11894,9 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI analysis, expert webinars & priority support!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="https://qual-lab.netlify.app/" data-resource-id="qual-insights" target="_blank" rel="noopener noreferrer">
+<a href="/premium" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        Qualitative Insights Lab Pro
+                        Qualitative Insights Lab Pro <span style="font-size:0.75em;color:#F59E0B;">(Coming Soon)</span>
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -11940,7 +11940,7 @@ textarea:focus-visible,
 <div class="modal-item-content">
 <a href="https://researchquestions.netlify.app/" data-resource-id="rq-builder" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        RQ Builder Pro
+                        Research Question Builder Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.26 12 2"></polygon></svg>
@@ -11963,7 +11963,7 @@ textarea:focus-visible,
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        TOC Workbench Pro
+                        Theory of Change Workbench Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12062,7 +12062,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#si_Crosshair_detailed"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">ToC Workshop Pro
+<div class="modal-item-title">Theory of Change Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12078,7 +12078,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">LogFrame Pro
+<div class="modal-item-title">Logical Framework Builder Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12094,7 +12094,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Chart Selector Pro
+<div class="modal-item-title">Data Visualization Chart Selector Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12110,7 +12110,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Stakeholder Map Pro
+<div class="modal-item-title">Stakeholder Mapping Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12126,7 +12126,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Empathy Map Pro
+<div class="modal-item-title">Empathy Mapping Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12142,7 +12142,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Policy Canvas Pro
+<div class="modal-item-title">Policy Analysis Canvas Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -12158,7 +12158,7 @@ textarea:focus-visible,
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></div>
 <div class="modal-item-content">
 <a href="https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">AI Canvas Pro
+<div class="modal-item-title">AI Strategy Canvas Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>

--- a/js/resource-launch.js
+++ b/js/resource-launch.js
@@ -1,30 +1,30 @@
 /**
  * ImpactMojo Premium Resource Launcher
- * Version: 1.1.0
+ * Version: 2.0.0
  *
- * Client-side helper that requests a short-lived JWT from the
- * Supabase Edge Function and opens the gated resource in a new tab.
+ * Opens premium resources directly for authenticated users.
+ * No JWT minting — resource sites are access-gated at the platform level
+ * (via premium.js tier checks), not at the resource site level.
  *
  * Usage:
  *   <button onclick="ImpactMojoResource.launch('vaniscribe')">Open VaniScribe</button>
  *
- * Depends on: js/config.js, js/auth.js (provides `supabaseClient` and `ImpactMojoAuth`)
+ * Depends on: js/auth.js (provides `ImpactMojoAuth`)
  */
 
 (function () {
   'use strict';
 
-  // ── Map resource IDs to their REAL deployment URLs ─────────────────
-  const RESOURCE_URLS = {
+  // ── Map resource IDs to their deployment URLs ─────────────────────
+  var RESOURCE_URLS = {
     // Practitioner tier
     'rq-builder':         'https://researchquestions.netlify.app/',
     // Professional tier
-    'code-convert-pro':   'https://stats-assist.netlify.app/',
-    'qual-insights':      'https://qual-lab.netlify.app/',
     'vaniscribe':         'https://vaniscribe.netlify.app/',
     'devdata-practice':   'https://impactmojo-devdata-pro.netlify.app/',
     'viz-cookbook':        'https://impactmojo-devdata-pro.netlify.app/charts.html',
     'devecon-toolkit':    'https://impactmojo-devecon-toolkit.netlify.app/',
+    'field-notes-pro':    'https://impactmojo-field-notes-pro.netlify.app/',
     // Workshop Pro templates
     'toc-workshop-pro':   'https://impactmojo-workshop-pro.netlify.app/toc-pro.html',
     'logframe-pro':       'https://impactmojo-workshop-pro.netlify.app/logframe-pro.html',
@@ -33,34 +33,14 @@
     'empathy-pro':        'https://impactmojo-workshop-pro.netlify.app/empathy-pro.html',
     'policy-canvas-pro':  'https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html',
     'ai-canvas-pro':      'https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html',
-    // Field Notes Pro
-    'field-notes-pro':    'https://impactmojo-field-notes-pro.netlify.app/',
   };
-
-  // Resolve the Edge Function URL at call time (not parse time)
-  // so config.js and auth.js are guaranteed to have loaded first.
-  function getEdgeFnUrl() {
-    var base = (window.ImpactMojoConfig && window.ImpactMojoConfig.SUPABASE_URL)
-            || (typeof SUPABASE_URL !== 'undefined' && SUPABASE_URL)
-            || 'https://ddyszmfffyedolkcugld.supabase.co';
-    return base + '/functions/v1/mint-resource-token';
-  }
-
-  // Navigate a tab to a URL, with window.open fallback
-  function navigateTab(tab, url) {
-    if (tab && !tab.closed) {
-      tab.location.href = url;
-    } else {
-      window.open(url, '_blank');
-    }
-  }
 
   /**
    * Launch a premium resource.
    * @param {string} resourceId  — one of the keys in RESOURCE_URLS
    */
-  async function launch(resourceId) {
-    // 1. Resolve the resource URL first
+  function launch(resourceId) {
+    // 1. Resolve the resource URL
     var baseUrl = RESOURCE_URLS[resourceId];
     if (!baseUrl) {
       console.error('Unknown resource:', resourceId);
@@ -74,103 +54,15 @@
       return;
     }
 
-    // 3. Check supabaseClient is available
-    if (typeof supabaseClient === 'undefined') {
-      console.error('supabaseClient not available');
-      window.open(baseUrl, '_blank');
-      return;
-    }
-
-    // Open a blank tab immediately (must happen synchronously from the
-    // click event or browsers will block the popup)
-    var newTab = window.open('about:blank', '_blank');
-
-    try {
-      // 4. Get the user's current access token — try getSession first,
-      //    fall back to refreshSession if stale
-      var accessToken = null;
-
-      var sessionResult = await supabaseClient.auth.getSession();
-      if (sessionResult.data && sessionResult.data.session) {
-        accessToken = sessionResult.data.session.access_token;
-      }
-
-      if (!accessToken) {
-        // Session cache empty — try refreshing
-        var refreshResult = await supabaseClient.auth.refreshSession();
-        if (refreshResult.data && refreshResult.data.session) {
-          accessToken = refreshResult.data.session.access_token;
-        }
-      }
-
-      if (!accessToken) {
-        // Auth is truly gone — open resource directly as fallback
-        console.warn('No valid session, opening resource directly');
-        navigateTab(newTab, baseUrl);
-        return;
-      }
-
-      // 5. Call the Edge Function to mint a resource token
-      var edgeFnUrl = getEdgeFnUrl();
-      var res = await fetch(edgeFnUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer ' + accessToken,
-        },
-        body: JSON.stringify({ resource: resourceId }),
-      });
-
-      // If 401, the token may be stale — refresh and retry once
-      if (res.status === 401) {
-        var retry = await supabaseClient.auth.refreshSession();
-        if (retry.data && retry.data.session) {
-          accessToken = retry.data.session.access_token;
-          res = await fetch(edgeFnUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': 'Bearer ' + accessToken,
-            },
-            body: JSON.stringify({ resource: resourceId }),
-          });
-        }
-      }
-
-      // 403 = tier too low or inactive subscription
-      if (res.status === 403) {
-        var forbiddenBody = await res.json().catch(function () { return {}; });
-        if (forbiddenBody.code === 'TIER' || forbiddenBody.code === 'INACTIVE') {
-          if (newTab && !newTab.closed) newTab.close();
-          window.location.href = '/premium';
-          return;
-        }
-      }
-
-      if (!res.ok) {
-        var errBody = await res.json().catch(function () { return {}; });
-        console.error('Token mint failed:', res.status, errBody);
-        // Fallback: open the resource directly
-        navigateTab(newTab, baseUrl);
-        return;
-      }
-
-      var data = await res.json();
-
-      // 6. Navigate the pre-opened tab to the resource with the token
-      navigateTab(newTab, baseUrl + '?token=' + encodeURIComponent(data.token));
-    } catch (err) {
-      console.error('Resource launch error:', err);
-      // Fallback: open directly on any error
-      navigateTab(newTab, baseUrl);
-    }
+    // 3. Open the resource directly
+    window.open(baseUrl, '_blank');
   }
 
   // ── Public API ────────────────────────────────────────────────────
   window.ImpactMojoResource = {
     launch: launch,
     RESOURCE_URLS: RESOURCE_URLS,
-    version: '1.1.0',
+    version: '2.0.0',
   };
 
   // ── Auto-intercept clicks on links with data-resource-id ─────────


### PR DESCRIPTION
## Summary
- Renamed all premium cards to full descriptive names (RQ → Research Question, ToC → Theory of Change, etc.)
- Marked 2 dead resources as "Coming Soon" (stats-assist.netlify.app and qual-lab.netlify.app return 404)
- Simplified resource-launch.js v2.0: opens resources directly instead of JWT minting (no resource site checks tokens, so the JWT flow was causing blank tab → login redirect issues)

## Test plan
- [ ] Click each premium card while logged in — should open directly in new tab
- [ ] Verify all card titles display full names
- [ ] Verify Coming Soon cards link to /premium page

https://claude.ai/code/session_01MGdifa1M2g73imXuqEnUTo