### PR TITLE
Fix Field Notes description, RQ Builder login loop, link new tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -10397,11 +10397,11 @@ textarea:focus-visible,
 <span class="rating-text">5.0</span>
 <span class="rating-count">(78 reviews)</span>
 </div>
-<p class="card-description">Behind-the-scenes insights from real programs, procurement dynamics, and implementation trade-offs you won't find in textbooks</p>
+<p class="card-description">Raw field-level notes from a development economist's perspective — real observations from programs, policy implementation, and fieldwork across South Asia</p>
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock AI-assisted thematic coding, memo generation, and transcript analysis for qualitative research!">
-<a href="/premium" rel="noopener noreferrer">
+<a href="/premium-tools/qual-insights-lab.html" data-resource-id="qual-insights-lab" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
@@ -10412,7 +10412,7 @@ textarea:focus-visible,
                                 680 Users
                             </span>
 </div>
-<h3 class="card-title">Qualitative Insights Lab Pro <span style="font-size:0.7em;color:#F59E0B;">(Coming Soon)</span></h3>
+<h3 class="card-title">Qualitative Insights Lab Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10427,8 +10427,8 @@ textarea:focus-visible,
 <p class="card-description">AI-assisted thematic coding, memo generation, and pattern analysis for interview and FGD transcripts</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock regression diagnostics, effect size calculators, power analysis, and code conversion across Stata, R, Python &amp; SPSS!">
-<a href="/premium" rel="noopener noreferrer">
+<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock code conversion across Stata, R, Python &amp; SPSS with snippet library and quick reference!">
+<a href="/premium-tools/code-converter-pro.html" data-resource-id="code-converter-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
@@ -10439,7 +10439,7 @@ textarea:focus-visible,
                                 920 Users
                             </span>
 </div>
-<h3 class="card-title">Statistical Code Converter Pro <span style="font-size:0.7em;color:#F59E0B;">(Coming Soon)</span></h3>
+<h3 class="card-title">Statistical Code Converter Pro</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -10451,7 +10451,7 @@ textarea:focus-visible,
 <span class="rating-text">4.5</span>
 <span class="rating-count">(156 reviews)</span>
 </div>
-<p class="card-description">Interactive regression diagnostics, effect size calculators, and power analysis covering OLS, logit, DiD, RDD, and IV estimation</p>
+<p class="card-description">Convert statistical code between R, Stata, Python, and SPSS — with snippet library, quick reference table, and annotated output</p>
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 36 dataset generators, 840k+ rows of realistic development data, and practice exercises!">
@@ -11872,9 +11872,9 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI tools, templates, webinars & priority coaching!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="/premium" rel="noopener noreferrer">
+<a href="/premium-tools/code-converter-pro.html" data-resource-id="code-converter-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        Statistical Code Converter Pro <span style="font-size:0.75em;color:#F59E0B;">(Coming Soon)</span>
+                        Statistical Code Converter Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -11894,9 +11894,9 @@ textarea:focus-visible,
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock AI analysis, expert webinars & priority support!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="/premium" rel="noopener noreferrer">
+<a href="/premium-tools/qual-insights-lab.html" data-resource-id="qual-insights-lab" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        Qualitative Insights Lab Pro <span style="font-size:0.75em;color:#F59E0B;">(Coming Soon)</span>
+                        Qualitative Insights Lab Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>

--- a/js/resource-launch.js
+++ b/js/resource-launch.js
@@ -1,6 +1,6 @@
 /**
  * ImpactMojo Premium Resource Launcher
- * Version: 2.0.0
+ * Version: 2.1.0
  *
  * Opens premium resources directly for authenticated users.
  * No JWT minting — resource sites are access-gated at the platform level
@@ -25,6 +25,8 @@
     'viz-cookbook':        'https://impactmojo-devdata-pro.netlify.app/charts.html',
     'devecon-toolkit':    'https://impactmojo-devecon-toolkit.netlify.app/',
     'field-notes-pro':    'https://impactmojo-field-notes-pro.netlify.app/',
+    'qual-insights-lab':  '/premium-tools/qual-insights-lab.html',
+    'code-converter-pro': '/premium-tools/code-converter-pro.html',
     // Workshop Pro templates
     'toc-workshop-pro':   'https://impactmojo-workshop-pro.netlify.app/toc-pro.html',
     'logframe-pro':       'https://impactmojo-workshop-pro.netlify.app/logframe-pro.html',
@@ -35,10 +37,29 @@
     'ai-canvas-pro':      'https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html',
   };
 
+  // Check if there is a Supabase session in localStorage (fallback for
+  // transient SIGNED_OUT states during token refresh)
+  function hasSupabaseSession() {
+    try {
+      var keys = Object.keys(localStorage);
+      for (var i = 0; i < keys.length; i++) {
+        if (keys[i].indexOf('supabase.auth.token') !== -1 ||
+            keys[i].indexOf('sb-') !== -1 && keys[i].indexOf('-auth-token') !== -1) {
+          var val = JSON.parse(localStorage.getItem(keys[i]));
+          if (val && (val.access_token || (val.currentSession && val.currentSession.access_token))) {
+            return true;
+          }
+        }
+      }
+    } catch (e) { /* ignore */ }
+    return false;
+  }
+
   /**
    * Launch a premium resource.
-   * Waits for auth to initialise before checking login state,
-   * preventing the false-negative redirect loop.
+   * Waits for auth to initialise before checking login state.
+   * Falls back to Supabase session check to prevent redirect loops
+   * caused by transient auth states during token refresh.
    * @param {string} resourceId  — one of the keys in RESOURCE_URLS
    */
   function launch(resourceId) {
@@ -51,6 +72,11 @@
 
     // 2. Auth may still be initialising — wait for it
     if (typeof ImpactMojoAuth === 'undefined') {
+      // Fallback: if Supabase has a session, open the resource directly
+      if (hasSupabaseSession()) {
+        window.open(baseUrl, '_blank');
+        return;
+      }
       sessionStorage.setItem('authRedirect', window.location.href);
       window.location.href = '/login';
       return;
@@ -62,7 +88,17 @@
 
     ImpactMojoAuth.waitForAuthReady().then(function () {
       if (!ImpactMojoAuth.isLoggedIn()) {
-        // Close the blank tab and redirect to login
+        // Double-check: Supabase may still have a valid session even if
+        // ImpactMojoAuth missed it during a token refresh race
+        if (hasSupabaseSession()) {
+          if (newTab) {
+            newTab.location.href = baseUrl;
+          } else {
+            window.open(baseUrl, '_blank');
+          }
+          return;
+        }
+        // Truly not logged in — redirect to login
         if (newTab) newTab.close();
         sessionStorage.setItem('authRedirect', window.location.href);
         window.location.href = '/login';
@@ -81,7 +117,7 @@
   window.ImpactMojoResource = {
     launch: launch,
     RESOURCE_URLS: RESOURCE_URLS,
-    version: '2.0.0',
+    version: '2.1.0',
   };
 
   // ── Auto-intercept clicks on links with data-resource-id ─────────

--- a/premium.html
+++ b/premium.html
@@ -1422,7 +1422,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             </div>
             <div class="detail-item">
                 <h4>Field Notes from a Development Economist</h4>
-                <p>Behind-the-scenes insights from real development programs. Covers procurement dynamics, implementation trade-offs, political economy constraints, and the gap between program design and field reality. Written from direct experience working across South Asian contexts. <a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" target="_blank" rel="noopener noreferrer">Read Field Notes &rarr;</a></p>
+                <p>Raw field-level notes from a development economist's perspective. Real observations from programs, policy implementation, and fieldwork across South Asia — the kind of unfiltered insights you won't find in textbooks or reports. <a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" target="_blank" rel="noopener noreferrer">Read Field Notes &rarr;</a></p>
             </div>
             <div class="detail-item">
                 <h4>Progress Tracking & ImpactLex</h4>


### PR DESCRIPTION
## Summary
- **Field Notes Pro**: Updated card description to reflect raw field-level dev econ notes (not procurement/trade-offs)
- **RQ Builder login loop**: Added Supabase session fallback in `resource-launch.js` v2.1.0 — if `isLoggedIn()` returns false during a token refresh race, checks localStorage for a valid Supabase session before redirecting to /login
- **Qual Insights Lab & Code Converter**: Removed "(Coming Soon)" labels, linked cards and modal items to actual `/premium-tools/` URLs with `data-resource-id` for click interception
- **Code Converter description**: Corrected from wrong feature list to actual converter description
- **resource-launch.js**: Added both new tools to `RESOURCE_URLS` map

## Test plan
- [ ] Verify Field Notes Pro card shows new description on index.html
- [ ] Log in and click RQ Builder — should open without redirect loop
- [ ] Verify Qual Insights Lab and Code Converter cards link to /premium-tools/ files
- [ ] Verify no "(Coming Soon)" labels remain on these tools

https://claude.ai/code/session_01PJt2niQhTw8wnCZ34ojtwV