### PR TITLE
Replace visible art style label in epidemic game

### DIFF
--- a/Games/public-health-game.html
+++ b/Games/public-health-game.html
@@ -797,7 +797,7 @@ body {
           <path d="M50,195 Q80,180 110,195 Q140,210 170,195 Q200,180 230,195 Q260,210 290,195 Q320,180 350,195 Q380,210 410,195 Q440,180 470,195 Q500,210 530,195 Q560,180 590,195 Q620,210 650,195"/>
         </g>
         <!-- Title -->
-        <text x="350" y="198" text-anchor="middle" fill="#FFF8E1" font-size="11" font-weight="600" letter-spacing="0.15em" opacity="0.6">PATTACHITRA SCROLL NARRATIVE</text>
+        <text x="350" y="198" text-anchor="middle" fill="#FFF8E1" font-size="11" font-weight="600" letter-spacing="0.15em" opacity="0.6">THE EPIDEMIC CHRONICLE</text>
       </svg>
     </div>
 


### PR DESCRIPTION
## Summary
- Replaced "PATTACHITRA SCROLL NARRATIVE" with "THE EPIDEMIC CHRONICLE" in the public health game SVG hero art
- Players should not see internal art style names — other games correctly keep these in comments/aria-labels only

https://claude.ai/code/session_01PJt2niQhTw8wnCZ34ojtwV