### PR TITLE
Standardize art style references across games

### DIFF
--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -88,7 +88,7 @@ input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;heigh
 
 <div id="story-intro" class="screen active">
 <div class="story-intro">
-  <h1 style="font-size:2.2rem;font-weight:800;background:linear-gradient(135deg,#FF6B35,#00BFA5);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:1rem">The Hidden Cost — A Gond Tale</h1>
+  <h1 style="font-size:2.2rem;font-weight:800;background:linear-gradient(135deg,#FF6B35,#00BFA5);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:1rem">The Hidden Cost — A Forest Fable</h1>
   <div class="story-art">
     <svg viewBox="0 0 800 400" xmlns="http://www.w3.org/2000/svg">
       <defs>
@@ -357,6 +357,7 @@ input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;heigh
   </div>
   <div class="narrative">
     <p>In <strong>Kanpur</strong>, the leather factories bring prosperity — but the <strong>Ganga</strong> carries their waste downstream. The factory counts its profits. The village counts its sick. The cost is real, but invisible on any balance sheet. <strong>This is an externality.</strong></p>
+    <div style="font-size:0.8rem;color:#64748B;margin-top:1rem;">Inspired by Gond art of the indigenous communities of Central India</div>
   </div>
   <div class="start-wrap"><button class="btn" onclick="showWelcome()">Start Production &rarr;</button></div>
 </div>

--- a/Games/info-asymmetry-game.html
+++ b/Games/info-asymmetry-game.html
@@ -418,7 +418,7 @@ h1, h2, h3, h4 { font-family: 'Inter', sans-serif; }
 <div id="storyIntro" class="screen fade-in">
 
   <div class="story-title">The Market for Lemons</div>
-  <div class="story-subtitle">A Pattachitra Tale of Hidden Truth</div>
+  <div class="story-subtitle">A Tale of Hidden Truth</div>
 
   <div class="pattachitra-frame">
     <svg viewBox="0 0 800 400" xmlns="http://www.w3.org/2000/svg">
@@ -767,6 +767,7 @@ h1, h2, h3, h4 { font-family: 'Inter', sans-serif; }
     </div>
   </div>
 
+  <div style="font-size:0.8rem;color:#64748B;margin-top:1rem;">Inspired by Pattachitra art of the scroll-painting traditions of Eastern India</div>
   <button class="btn-primary" onclick="startGame()">Enter the Market</button>
 </div>
 

--- a/Games/public-health-game.html
+++ b/Games/public-health-game.html
@@ -824,6 +824,7 @@ body {
       </div>
     </div>
 
+    <div style="font-size:0.8rem;color:#64748B;margin-top:1rem;">Inspired by Pattachitra art of the scroll-painting traditions of Eastern India</div>
     <div class="start-container">
       <button class="btn-primary" onclick="startGame()">
         Begin Response ▸


### PR DESCRIPTION
## Summary
- Removed art style names from game titles (kept them creative/thematic)
- Added consistent credit/attribution lines to all games that use Indian folk art styles
- Network-effects game already had proper credits — now all games follow the same pattern

## Changes
| Game | Before | After |
|------|--------|-------|
| externality | "A Gond Tale" (title) | "A Forest Fable" + Gond credit line |
| info-asymmetry | "A Pattachitra Tale of Hidden Truth" (subtitle) | "A Tale of Hidden Truth" + Pattachitra credit |
| public-health | No credit | Added Pattachitra credit line |
| network-effects | Already had credit line | No change |

https://claude.ai/code/session_01PJt2niQhTw8wnCZ34ojtwV