### PR TITLE
Fix text contrast in gender-equity and externality games

### DIFF
--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -27,7 +27,7 @@ body{font-family:'Amaranth',-apple-system,BlinkMacSystemFont,sans-serif;backgrou
 .start-wrap{text-align:center;margin-top:1rem}
 .top-bar{background:#1E293B;border-bottom:1px solid #334155;padding:.75rem 1rem;position:sticky;top:0;z-index:100}
 .top-bar-inner{max-width:900px;margin:0 auto;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:.5rem}
-.stat .label{font-size:.65rem;color:#64748B;text-transform:uppercase;letter-spacing:.05em}
+.stat .label{font-size:.7rem;color:#94A3B8;text-transform:uppercase;letter-spacing:.05em}
 .stat .value{font-size:1.2rem;font-weight:700;color:#F8FAFC}
 .game-area{max-width:900px;margin:0 auto;padding:1.5rem 1rem}
 .regulation-banner{background:linear-gradient(135deg,#1E40AF,#3B82F6);border-radius:12px;padding:1rem 1.5rem;margin-bottom:1.25rem;text-align:center;animation:fadeIn .6s ease;display:none}
@@ -44,7 +44,7 @@ input[type=range]{width:100%;height:8px;-webkit-appearance:none;background:linea
 input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;height:22px;border-radius:50%;background:#F8FAFC;box-shadow:0 2px 8px rgba(0,0,0,.3);cursor:pointer}
 .preview{display:grid;grid-template-columns:repeat(3,1fr);gap:.5rem;margin-bottom:1rem}
 .preview-item{text-align:center;padding:.6rem;background:#0F172A;border-radius:8px}
-.preview-item .plabel{font-size:.65rem;color:#64748B;text-transform:uppercase}
+.preview-item .plabel{font-size:.7rem;color:#94A3B8;text-transform:uppercase}
 .preview-item .pval{font-size:1.3rem;font-weight:700}
 .pval.green{color:#84CC16}.pval.red{color:#EF4444}.pval.blue{color:#3B82F6}
 .submit-btn{width:100%;padding:.75rem;background:linear-gradient(135deg,#84CC16,#65A30D);color:#0F172A;font-weight:700;font-size:1rem;border:none;border-radius:10px;cursor:pointer;transition:transform .2s}

--- a/Games/gender-equity-game.html
+++ b/Games/gender-equity-game.html
@@ -353,8 +353,8 @@ a:hover{text-decoration:underline}
         <line x1="38" y1="60" x2="15" y2="80" stroke="#111" stroke-width="2.5"/>
         <!-- Blackboard -->
         <rect x="85" y="30" width="60" height="45" rx="3" fill="#2E7D32" stroke="#111" stroke-width="2"/>
-        <text x="95" y="52" fill="#FDD835" font-size="10" font-weight="bold">A B C</text>
-        <text x="100" y="66" fill="#FDD835" font-size="9">1+1=2</text>
+        <text x="95" y="52" fill="#FFFFFF" font-size="10" font-weight="bold">A B C</text>
+        <text x="100" y="66" fill="#FFFFFF" font-size="9">1+1=2</text>
         <!-- Child figure -->
         <g transform="translate(-10,80)">
           <circle cx="25" cy="20" r="10" fill="#FDD835" stroke="#111" stroke-width="2"/>


### PR DESCRIPTION
## Summary
- Fixed yellow-on-green blackboard text in gender equity game (now white)
- Improved stat/preview label contrast and size in externality game

https://claude.ai/code/session_01PJt2niQhTw8wnCZ34ojtwV