### PR TITLE
Fix blog card thumbnail paths in blog.html

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1709,7 +1709,7 @@ body.dark-mode .icon-moon { display: block; }
             <!-- Post 1: SMART vs SPICED Indicators -->
             <article class="blog-card" data-category="meal" data-tags="indicators,logframe,meal">
                 <div class="blog-card-image">
-                    <img src="assets/images/blog/smart-vs-spiced/illustration-1.png" alt="SMART vs SPICED Indicators" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><path d=\'M12 20V10M18 20V4M6 20v-4\'/></svg></div>'">
+                    <img src="assets/images/blog/meal-demystified/illustration-1.png" alt="SMART vs SPICED Indicators" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><path d=\'M12 20V10M18 20V4M6 20v-4\'/></svg></div>'">
                 </div>
                 <div class="blog-card-content">
                     <div class="blog-card-meta">
@@ -1738,7 +1738,7 @@ body.dark-mode .icon-moon { display: block; }
             <!-- Post 2: Theory of Change Pitfalls -->
             <article class="blog-card" data-category="toc" data-tags="theory-of-change,evaluation">
                 <div class="blog-card-image">
-                    <img src="assets/images/blog/toc-pitfalls/illustration-1.png" alt="Theory of Change Pitfalls" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><circle cx=\'12\' cy=\'12\' r=\'10\'/><line x1=\'12\' y1=\'8\' x2=\'12\' y2=\'12\'/><line x1=\'12\' y1=\'16\' x2=\'12.01\' y2=\'16\'/></svg></div>'">
+                    <img src="assets/images/blog/theory-of-change-pitfalls/illustration-1.png" alt="Theory of Change Pitfalls" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><circle cx=\'12\' cy=\'12\' r=\'10\'/><line x1=\'12\' y1=\'8\' x2=\'12\' y2=\'12\'/><line x1=\'12\' y1=\'16\' x2=\'12.01\' y2=\'16\'/></svg></div>'">
                 </div>
                 <div class="blog-card-content">
                     <div class="blog-card-meta">
@@ -1766,7 +1766,7 @@ body.dark-mode .icon-moon { display: block; }
             <!-- Post 3: Qualitative Data Analysis -->
             <article class="blog-card" data-category="methods" data-tags="evaluation,ngo">
                 <div class="blog-card-image">
-                    <img src="assets/images/blog/qualitative-data/illustration-1.png" alt="Qualitative Data Analysis" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><path d=\'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z\'/><polyline points=\'14 2 14 8 20 8\'/><line x1=\'16\' y1=\'13\' x2=\'8\' y2=\'13\'/><line x1=\'16\' y1=\'17\' x2=\'8\' y2=\'17\'/><polyline points=\'10 9 9 9 8 9\'/></svg></div>'">
+                    <img src="assets/images/blog/learning-by-doing/illustration-1.png" alt="Qualitative Data Analysis" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><path d=\'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z\'/><polyline points=\'14 2 14 8 20 8\'/><line x1=\'16\' y1=\'13\' x2=\'8\' y2=\'13\'/><line x1=\'16\' y1=\'17\' x2=\'8\' y2=\'17\'/><polyline points=\'10 9 9 9 8 9\'/></svg></div>'">
                 </div>
                 <div class="blog-card-content">
                     <div class="blog-card-meta">
@@ -1794,7 +1794,7 @@ body.dark-mode .icon-moon { display: block; }
             <!-- Post 4: Why We Made It Free -->
             <article class="blog-card" data-category="stories" data-tags="capacity-building,south-asia">
                 <div class="blog-card-image">
-                    <img src="assets/images/blog/why-free/illustration-1.png" alt="Why We Made ImpactMojo Free" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><path d=\'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z\'/></svg></div>'">
+                    <img src="assets/images/blog/why-impactmojo-exists/illustration-1.png" alt="Why We Made ImpactMojo Free" onerror="this.parentElement.innerHTML='<div class=\'placeholder-icon\'><svg viewBox=\'0 0 24 24\'><path d=\'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z\'/></svg></div>'">
                 </div>
                 <div class="blog-card-content">
                     <div class="blog-card-meta">


### PR DESCRIPTION
## Summary
- Fixed 4 blog card thumbnail paths that referenced wrong folder names
- smart-vs-spiced → meal-demystified
- toc-pitfalls → theory-of-change-pitfalls
- qualitative-data → learning-by-doing
- why-free → why-impactmojo-exists

https://claude.ai/code/session_015HsrAm3SdoY8kXZY88bsbG