### PR TITLE
Add Grok, DeepSeek, Sarvam skills + fix session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -3,10 +3,20 @@ set -euo pipefail
 
 # Bootstrap API keys for Claude Code sessions
 # Reads from .claude/.env.keys (gitignored) and writes to CLAUDE_ENV_FILE
+# Keys: GITHUB_PAT, SUPABASE_PAT, NETLIFY_PAT, GAMMA_API_KEY, GEMINI_API_KEY,
+#        NAPKIN_API_KEY, GROK_API_KEY, DEEPSEEK_API_KEY, SARVAM_API_KEY
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 KEYS_FILE="$SCRIPT_DIR/../.env.keys"
 
-if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -f "$KEYS_FILE" ]; then
-  cat "$KEYS_FILE" >> "$CLAUDE_ENV_FILE"
+if [ -f "$KEYS_FILE" ]; then
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    # Claude Code session — inject keys into environment
+    cat "$KEYS_FILE" >> "$CLAUDE_ENV_FILE"
+  else
+    # Direct shell — export keys
+    set -a
+    source "$KEYS_FILE"
+    set +a
+  fi
 fi

--- a/.claude/skills/deepseek-ai/SKILL.md
+++ b/.claude/skills/deepseek-ai/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: deepseek-ai
+description: DeepSeek API operations — generate content, reason over code and data via $DEEPSEEK_API_KEY. Use when the user asks to call DeepSeek, needs code generation, or wants an alternative LLM provider.
+---
+
+# DeepSeek AI Skill
+
+Use the DeepSeek API via `$DEEPSEEK_API_KEY` for AI content and code generation. DeepSeek uses an OpenAI-compatible API format.
+
+## Authentication
+
+```
+Authorization: Bearer $DEEPSEEK_API_KEY
+```
+
+Base URL: `https://api.deepseek.com/v1`
+
+## Available Models
+
+- `deepseek-chat` — General-purpose chat (DeepSeek-V3)
+- `deepseek-reasoner` — Chain-of-thought reasoning (DeepSeek-R1)
+
+## Capabilities
+
+### Chat Completion
+```bash
+curl -s -X POST "https://api.deepseek.com/v1/chat/completions" \
+  -H "Authorization: Bearer $DEEPSEEK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-chat",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Your prompt here"}
+    ]
+  }'
+```
+
+### Reasoning (Chain-of-Thought)
+```bash
+curl -s -X POST "https://api.deepseek.com/v1/chat/completions" \
+  -H "Authorization: Bearer $DEEPSEEK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-reasoner",
+    "messages": [{"role": "user", "content": "Solve this step by step: ..."}]
+  }'
+```
+
+### With JSON Output
+```bash
+curl -s -X POST "https://api.deepseek.com/v1/chat/completions" \
+  -H "Authorization: Bearer $DEEPSEEK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-chat",
+    "messages": [{"role": "user", "content": "Return JSON: ..."}],
+    "response_format": {"type": "json_object"}
+  }'
+```
+
+## ImpactMojo Use Cases
+- Code generation for game and lab HTML/JS
+- Reasoning tasks for evaluation framework design
+- Cross-validate content against multiple LLM providers
+- Generate structured JSON for data files (search-index, catalog)
+
+## Best Practices
+- Use `deepseek-chat` for general tasks, `deepseek-reasoner` for complex reasoning
+- API follows OpenAI chat completions format — same structure as Grok
+- DeepSeek-R1 returns reasoning in `reasoning_content` field
+- Handle rate limits with exponential backoff
+- Never commit `$DEEPSEEK_API_KEY` to the repository

--- a/.claude/skills/grok-ai/SKILL.md
+++ b/.claude/skills/grok-ai/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: grok-ai
+description: Grok (xAI) API operations — generate content, reason over data, and use AI features via $GROK_API_KEY. Use when the user asks to call Grok, use xAI capabilities, or needs an alternative LLM provider.
+---
+
+# Grok AI Skill
+
+Use the Grok API via `$GROK_API_KEY` for AI content generation. Grok uses an OpenAI-compatible API format.
+
+## Authentication
+
+```
+Authorization: Bearer $GROK_API_KEY
+```
+
+Base URL: `https://api.x.ai/v1`
+
+## Available Models
+
+- `grok-3` — Latest, most capable
+- `grok-3-mini` — Fast, lightweight
+- `grok-2` — Previous generation
+
+## Capabilities
+
+### Chat Completion
+```bash
+curl -s -X POST "https://api.x.ai/v1/chat/completions" \
+  -H "Authorization: Bearer $GROK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "grok-3",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Your prompt here"}
+    ]
+  }'
+```
+
+### With Temperature/Max Tokens
+```bash
+curl -s -X POST "https://api.x.ai/v1/chat/completions" \
+  -H "Authorization: Bearer $GROK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "grok-3",
+    "messages": [{"role": "user", "content": "Your prompt"}],
+    "temperature": 0.7,
+    "max_tokens": 4096
+  }'
+```
+
+### List Models
+```bash
+curl -s "https://api.x.ai/v1/models" \
+  -H "Authorization: Bearer $GROK_API_KEY"
+```
+
+## ImpactMojo Use Cases
+- Alternative LLM for content generation and review
+- Cross-validate AI-generated course content against multiple providers
+- Generate quiz questions and assessment items
+- Summarize research papers for DevDiscourses
+
+## Best Practices
+- Use `grok-3-mini` for speed, `grok-3` for quality
+- API follows OpenAI chat completions format — same structure as DeepSeek
+- Handle rate limits with exponential backoff
+- Never commit `$GROK_API_KEY` to the repository

--- a/.claude/skills/sarvam-ai/SKILL.md
+++ b/.claude/skills/sarvam-ai/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: sarvam-ai
+description: Sarvam AI API operations — transcription, translation, and text-to-speech for South Asian languages via $SARVAM_API_KEY. Use when the user asks about VaniScribe, transcription, South Asian language processing, or Sarvam AI features.
+---
+
+# Sarvam AI Skill
+
+Use the Sarvam AI API via `$SARVAM_API_KEY` for South Asian language processing — transcription (Saaras), translation (Mayura), and text-to-speech (Bulbul).
+
+## Authentication
+
+```
+api-subscription-key: $SARVAM_API_KEY
+```
+
+Base URL: `https://api.sarvam.ai`
+
+## Available Models
+
+- **Saaras** — Speech-to-text (ASR) for 10+ South Asian languages
+- **Mayura** — Translation across Indian languages
+- **Bulbul** — Text-to-speech in Indian languages
+
+## Capabilities
+
+### Speech-to-Text (Transcription)
+```bash
+curl -s -X POST "https://api.sarvam.ai/speech-to-text-translate" \
+  -H "api-subscription-key: $SARVAM_API_KEY" \
+  -F "file=@audio.wav" \
+  -F "model=saaras:v2" \
+  -F "language_code=hi-IN"
+```
+
+Supported languages: `hi-IN`, `bn-IN`, `ta-IN`, `te-IN`, `mr-IN`, `gu-IN`, `kn-IN`, `ml-IN`, `pa-IN`, `od-IN`, `en-IN`
+
+### Translation
+```bash
+curl -s -X POST "https://api.sarvam.ai/translate" \
+  -H "api-subscription-key: $SARVAM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Text to translate",
+    "source_language_code": "en-IN",
+    "target_language_code": "hi-IN",
+    "model": "mayura:v1"
+  }'
+```
+
+### Text-to-Speech
+```bash
+curl -s -X POST "https://api.sarvam.ai/text-to-speech" \
+  -H "api-subscription-key: $SARVAM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputs": ["Text to speak"],
+    "target_language_code": "hi-IN",
+    "model": "bulbul:v1"
+  }' --output speech.wav
+```
+
+## ImpactMojo Use Cases
+- **VaniScribe**: Transcribe field interviews, FGDs, and KIIs in South Asian languages
+- **Course translation**: Translate course content into 6 supported languages
+- **Audio content**: Generate audio versions of handouts and course summaries
+- **Speaker diarization**: Identify speakers in multi-participant recordings
+
+## Integration with VaniScribe
+
+VaniScribe (premium tool at `101.impactmojo.in/vaniscribe`) uses Sarvam's Saaras v3 for:
+- Field interview transcription in 10+ languages
+- Speaker diarization and auto-timestamping
+- Export to structured formats for qualitative analysis
+
+## Best Practices
+- Use `saaras:v2` for transcription, `mayura:v1` for translation
+- Audio files should be WAV or MP3, under 25MB
+- Specify the correct `language_code` for best accuracy
+- Handle rate limits with exponential backoff
+- Never commit `$SARVAM_API_KEY` to the repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Free development education platform for South Asia. Static HTML/CSS/JS, Supabase
 
 ## API Keys
 
-`$GITHUB_PAT` · `$SUPABASE_PAT` · `$NETLIFY_PAT` · `$GAMMA_API_KEY` · `$GEMINI_API_KEY` · `$NAPKIN_API_KEY`
+`$GITHUB_PAT` · `$SUPABASE_PAT` · `$NETLIFY_PAT` · `$GAMMA_API_KEY` · `$GEMINI_API_KEY` · `$NAPKIN_API_KEY` · `$GROK_API_KEY` · `$DEEPSEEK_API_KEY` · `$SARVAM_API_KEY`
 
 See `.claude/rules/api-conventions.md` for endpoints and auth patterns.
 
@@ -43,6 +43,6 @@ See `.claude/rules/api-conventions.md` for endpoints and auth patterns.
 
 - **rules/** — modular instructions (code-style, content-management, api-conventions, testing)
 - **commands/** — `/project:review`, `/project:fix-issue`, `/project:deploy-check`, `/project:audit`, `/project:add-game`
-- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai)
+- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai)
 - **agents/** — subagent personas (code-reviewer, content-auditor)
 - **hooks/** — session-start (API key bootstrap), pre-tool-use (destructive command guard)


### PR DESCRIPTION
## Summary
- New skills: `grok-ai`, `deepseek-ai`, `sarvam-ai` with full API reference
- Session-start hook updated to handle both Claude Code and direct shell sessions
- CLAUDE.md updated with all 9 API keys and 10 skills listed

## Test plan
- [x] All 3 skills detected by Claude Code immediately after creation
- [x] Session-start hook handles both `CLAUDE_ENV_FILE` and direct `source` paths
- [x] No API keys in committed files

https://claude.ai/code/session_015x5G8w88EJg1ByUVRxf1PY