### PR TITLE
Add napkin-ai skill, fix skill mappings across docs

### DIFF
--- a/.claude/rules/api-conventions.md
+++ b/.claude/rules/api-conventions.md
@@ -9,10 +9,10 @@ All external API calls use environment variables for authentication (loaded by `
 | Netlify | `$NETLIFY_PAT` | `Authorization: Bearer $NETLIFY_PAT` | `netlify-ops` |
 | Gamma | `$GAMMA_API_KEY` | `Authorization: Bearer $GAMMA_API_KEY` | `gamma-ops` |
 | Gemini | `$GEMINI_API_KEY` | Query param `?key=$GEMINI_API_KEY` | `gemini-ai` |
-| Napkin.ai | `$NAPKIN_API_KEY` | `Authorization: Bearer $NAPKIN_API_KEY` | — |
-| Grok | `$GROK_API_KEY` | `Authorization: Bearer $GROK_API_KEY` | — |
-| DeepSeek | `$DEEPSEEK_API_KEY` | `Authorization: Bearer $DEEPSEEK_API_KEY` | — |
-| Sarvam AI | `$SARVAM_API_KEY` | `Authorization: Bearer $SARVAM_API_KEY` | — |
+| Napkin.ai | `$NAPKIN_API_KEY` | `Authorization: Bearer $NAPKIN_API_KEY` | `napkin-ai` |
+| Grok | `$GROK_API_KEY` | `Authorization: Bearer $GROK_API_KEY` | `grok-ai` |
+| DeepSeek | `$DEEPSEEK_API_KEY` | `Authorization: Bearer $DEEPSEEK_API_KEY` | `deepseek-ai` |
+| Sarvam AI | `$SARVAM_API_KEY` | `Authorization: Bearer $SARVAM_API_KEY` | `sarvam-ai` |
 
 ## Rules
 

--- a/.claude/skills/napkin-ai/SKILL.md
+++ b/.claude/skills/napkin-ai/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: napkin-ai
+description: Napkin.ai API operations — generate visual infographics and diagrams from text using $NAPKIN_API_KEY. Use when the user asks to create visuals, infographics, illustrations for blog posts, or napkin-style diagrams.
+---
+
+# Napkin.ai Skill
+
+Use the Napkin.ai API via `$NAPKIN_API_KEY` to generate visual infographics and diagrams from text descriptions.
+
+## Authentication
+
+```
+Authorization: Bearer $NAPKIN_API_KEY
+```
+
+Base URL: `https://api.napkin.ai/v1`
+
+## Capabilities
+
+### Generate Visual from Text
+```bash
+curl -s -X POST "https://api.napkin.ai/v1/generate" \
+  -H "Authorization: Bearer $NAPKIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Description of the visual you want",
+    "style": "infographic"
+  }'
+```
+
+### Available Styles
+- `infographic` — Data-driven visual layouts
+- `diagram` — Flowcharts, process diagrams
+- `concept` — Concept maps, mind maps
+- `comparison` — Side-by-side comparisons
+- `timeline` — Chronological visualizations
+
+## ImpactMojo Use Cases
+- **Blog illustrations**: Generate 2 napkin.ai visuals per blog post (established pattern)
+- **Course diagrams**: Visualize frameworks (Theory of Change, logframes, causal chains)
+- **Handout graphics**: Create visual summaries for printable handouts
+- **Social media**: Generate shareable infographics for Threads/LinkedIn posts
+- **Workshop materials**: Visual aids for facilitation
+
+## Existing Integration
+
+Blog posts use napkin.ai illustrations stored at:
+```
+blog/images/{post-slug}/napkin-{n}.png
+```
+
+Each blog post gets 2 illustrations (established in v10.8.1 — see changelog).
+
+## Best Practices
+- Generate 2 visuals per blog post (platform convention)
+- Save outputs to `blog/images/{slug}/` directory
+- Use `infographic` style for data-heavy content, `diagram` for process flows
+- Reference the visual in the blog HTML with proper alt text
+- Never commit `$NAPKIN_API_KEY` to the repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,6 @@ See `.claude/rules/api-conventions.md` for endpoints and auth patterns.
 
 - **rules/** — modular instructions (code-style, content-management, api-conventions, testing)
 - **commands/** — `/project:review`, `/project:fix-issue`, `/project:deploy-check`, `/project:audit`, `/project:add-game`
-- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai)
+- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai, napkin-ai, threads-writer)
 - **agents/** — subagent personas (code-reviewer, content-auditor)
 - **hooks/** — session-start (API key bootstrap), pre-tool-use (destructive command guard)


### PR DESCRIPTION
## Summary
- New `napkin-ai` skill for blog illustrations and infographics
- Fixed `api-conventions.md`: all 9 API services now correctly map to their skill names
- `CLAUDE.md` now lists all 12 skills

## Test plan
- [x] All skills detected by Claude Code
- [x] api-conventions table has no orphan dashes
- [x] CLAUDE.md skill list matches .claude/skills/ directory

https://claude.ai/code/session_015x5G8w88EJg1ByUVRxf1PY