### PR TITLE
Add blog-writer, dojo-ops, book-summaries skills + github-ops auto-labeling

### DIFF
--- a/.claude/skills/blog-writer/SKILL.md
+++ b/.claude/skills/blog-writer/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: blog-writer
+description: Create new blog posts for impactmojo.in/blog with proper HTML template, napkin illustrations, blog.html card, and cross-references. Use when the user asks to write a blog post, add a blog entry, or create content for the blog.
+---
+
+# Blog Writer Skill
+
+Create fully-formatted blog posts for ImpactMojo following the established template, illustration conventions, and cross-referencing requirements.
+
+## When to Use
+
+- User says "write a blog post about...", "new blog post", "add to the blog"
+- User wants dev econ / education content published on impactmojo.in/blog
+
+## Blog Post Template
+
+Every post follows this structure:
+
+### 1. File Creation
+
+Create `blog/{slug}.html` using kebab-case naming.
+
+### 2. HTML Structure
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{Title} — ImpactMojo Blog</title>
+    <meta property="og:title" content="{Title}">
+    <meta property="og:description" content="{Excerpt}">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://www.impactmojo.in/blog/{slug}.html">
+    <meta property="article:author" content="The ImpactMojo Team">
+    <meta property="article:published_time" content="{YYYY-MM-DD}">
+    <meta property="article:section" content="{Category}">
+    <meta property="article:tag" content="{Tag1}">
+    <meta property="article:tag" content="{Tag2}">
+    <!-- Copy CSS from an existing blog post (e.g., why-impactmojo-exists.html) -->
+</head>
+<body>
+    <!-- Header nav (copy from existing post) -->
+    <article>
+        <header>
+            <span class="category-badge {category}">{CATEGORY}</span>
+            <h1>{Title}</h1>
+            <div class="article-meta">
+                <span class="article-date">{Month DD, YYYY}</span>
+                <span class="article-readtime">{N} min</span>
+            </div>
+            <div class="article-tags">
+                <span class="article-tag">{tag1}</span>
+                <span class="article-tag">{tag2}</span>
+            </div>
+        </header>
+        <div class="article-content">
+            <!-- Blog content here -->
+
+            <!-- Illustration 1 (after ~30% of content) -->
+            <figure class="article-illustration">
+                <img src="../assets/images/blog/{slug}/illustration-1.png"
+                     alt="{Description}"
+                     onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                <div style="display:none; padding: 3rem; background: var(--secondary-bg); border-radius: 12px;">
+                    [Illustration 1: {Description}]
+                </div>
+                <figcaption>{Caption}</figcaption>
+            </figure>
+
+            <!-- More content -->
+
+            <!-- Illustration 2 (after ~70% of content) -->
+            <figure class="article-illustration">
+                <img src="../assets/images/blog/{slug}/illustration-2.png"
+                     alt="{Description}"
+                     onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                <div style="display:none; padding: 3rem; background: var(--secondary-bg); border-radius: 12px;">
+                    [Illustration 2: {Description}]
+                </div>
+                <figcaption>{Caption}</figcaption>
+            </figure>
+        </div>
+        <!-- Share + Newsletter CTA + Related posts (copy from existing) -->
+    </article>
+    <!-- Footer (copy from existing) -->
+</body>
+</html>
+```
+
+### 3. Blog Categories & Colors
+
+| Category | Code | Color |
+|----------|------|-------|
+| MEAL | `meal` | Green (#10B981) |
+| Theory of Change | `toc` | Indigo (#6366F1) |
+| Methods | `methods` | Sky Blue (#0EA5E9) |
+| Stories | `stories` | Amber (#F59E0B) |
+| Platform | `platform` | Pink (#EC4899) |
+
+## Cross-Reference Checklist
+
+After creating the blog post file:
+
+1. **Add card to `blog.html`** — insert `<article class="blog-card">` with correct `data-category` and `data-tags`
+2. **Create illustration directory** — `mkdir -p assets/images/blog/{slug}/`
+3. **Generate napkin illustrations** — use napkin-ai skill to create 2 illustrations, save as `illustration-1.png` and `illustration-2.png`
+4. **Add to search index** — add entry to `data/search-index.json`:
+   ```json
+   {"id": "BLOG{NNN}", "title": "...", "description": "...", "type": "blog", "category": "...", "url": "/blog/{slug}.html", "tags": [...]}
+   ```
+5. **Update sitemap.xml** — add `<url>` entry
+6. **Update changelog** — add entry to `docs/changelog.md`
+
+## Writing Guidelines
+
+- **Evidence-backed**: cite specific studies, datasets, or frameworks
+- **South Asian framing**: use examples from India, Bangladesh, Nepal, Sri Lanka
+- **Practitioner voice**: write for NGO staff and researchers, not academics
+- **Length**: 1,200–2,000 words (8–12 min read)
+- **Structure**: Hook → Context → Core argument (with evidence) → Practical implications → Call to reflection
+- **Author**: Always "The ImpactMojo Team"
+
+## Best Practices
+
+- Copy CSS and structural elements from the most recent blog post to ensure consistency
+- Always include the onerror fallback for illustrations
+- Set 2 related posts at the bottom linking to thematically relevant existing posts
+- Date format in meta: `YYYY-MM-DD`, display format: `Month DD, YYYY`

--- a/.claude/skills/book-summaries/SKILL.md
+++ b/.claude/skills/book-summaries/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: book-summaries
+description: Create interactive book companion pages for BookSummaries/. Use when the user asks to add a book summary, create a book companion, or summarize a development economics text.
+---
+
+# Book Summaries Skill
+
+Create interactive book companion pages for key texts in development economics, social protection, and public policy.
+
+## When to Use
+
+- User says "add a book summary", "create a book companion", "summarize this book"
+- User wants to create an interactive guide for a development economics text
+- User provides a book title or PDF to summarize
+
+## Directory Structure
+
+```
+BookSummaries/
+├── index.html                        # Listing page for all companions
+├── handbook-social-protection.html   # Social protection handbook
+├── debraj-ray-companion.html         # Debraj Ray's Development Economics
+├── dt-companion.html                 # Development as Freedom (Sen)
+└── {new-companion}.html              # New companions go here
+```
+
+## Creating a New Book Companion
+
+### 1. File Naming
+
+Use kebab-case: `{author-or-short-title}-companion.html`
+
+Examples:
+- `banerjee-duflo-companion.html` (Poor Economics)
+- `easterly-companion.html` (The Elusive Quest for Growth)
+- `dreze-sen-companion.html` (An Uncertain Glory)
+
+### 2. HTML Template
+
+Follow the existing companion structure:
+- Same CSS variables as the main site (see `BookSummaries/index.html` for reference)
+- Google Analytics tag (`G-JRCMEB9TBW`)
+- Responsive viewport meta
+- Dark/light mode support
+- Favicon links
+
+### 3. Content Structure
+
+Each companion should include:
+
+```
+1. Book Overview
+   - Title, author(s), publication year
+   - Why this book matters for practitioners
+   - Key themes (3-5 bullet points)
+
+2. Chapter-by-Chapter Summaries
+   - Chapter title and core argument
+   - Key concepts defined
+   - Evidence and examples cited
+   - Practitioner takeaways
+
+3. Interactive Elements
+   - Expandable/collapsible sections per chapter
+   - Key term definitions (hover or click)
+   - Cross-references to ImpactMojo courses/labs where relevant
+
+4. Quick Reference
+   - Key frameworks or models from the book
+   - Important data points or statistics
+   - Recommended reading order (if non-linear reading is useful)
+```
+
+### 4. Cross-Reference Checklist
+
+After creating the companion:
+
+1. **Add card to `BookSummaries/index.html`** — add a companion card following existing pattern
+2. **Add to search index** — `data/search-index.json`:
+   ```json
+   {"id": "BOOK{NNN}", "title": "...", "description": "...", "type": "book-summary", "category": "...", "url": "/BookSummaries/{slug}.html", "tags": [...]}
+   ```
+3. **Update sitemap.xml** — add `<url>` entry
+4. **Update content counts** — grep for book summary counts in `index.html`, `catalog.html`
+5. **Update changelog** — `docs/changelog.md`
+6. **Link from related courses** — if the book maps to an existing course, add a link in the course page
+
+## Writing Guidelines
+
+- **Practitioner-first**: explain why each concept matters for fieldwork
+- **Evidence-focused**: highlight the empirical evidence, not just theory
+- **South Asian lens**: connect to Indian/South Asian development context where possible
+- **Accessible language**: avoid jargon; define technical terms inline
+- **Length**: aim for comprehensive coverage — companions can be 5,000–15,000 words
+- **Attribution**: always cite the original author; these are companions, not replacements
+
+## Quality Checks
+
+- Validate HTML structure matches existing companions
+- Ensure dark mode works (test CSS variables)
+- Check all expandable/collapsible sections function correctly
+- Verify responsive layout on mobile widths
+- Run `python3 -m json.tool data/search-index.json > /dev/null` after updating search index

--- a/.claude/skills/dojo-ops/SKILL.md
+++ b/.claude/skills/dojo-ops/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dojo-ops
+description: Manage dojo practice sessions — add new sessions, update series, modify schedules, and maintain dojos.html. Use when the user asks to add a dojo session, update dojo content, or manage the 56-session practice program.
+---
+
+# Dojo Operations Skill
+
+Manage the ImpactMojo Dojos — 56 practice-based skill sessions across 6 series for development practitioners.
+
+## When to Use
+
+- User says "add a dojo session", "update the dojos", "new dojo series"
+- User wants to modify session content, schedules, or series structure
+- User asks about dojo logistics (pricing, locations, cohort format)
+
+## Dojo Structure
+
+### The 6 Series
+
+| Code | Series | Sessions | Focus |
+|------|--------|----------|-------|
+| S01 | Thinking Clearly in Development | 8 | Calibrating confidence, cognitive biases, probabilistic thinking |
+| S02 | Evidence Reasoning | 9 | Statistical thinking, hypothesis testing, research design, cost-effectiveness |
+| S03 | Political Economy & Implementation | 16 | Stakeholder mapping, implementation diagnosis, scaling, adaptive management |
+| S04 | Methods That Actually Work | 9 | Field research methodologies, data collection techniques |
+| S05 | Epistemic Hygiene | 8 | Intellectual honesty, Fermi estimation, honest writing |
+| S06 | Gender, Power & Data | 6 | GESI principles, power analysis, gender-responsive data |
+
+### Session Format
+- **Duration**: 90 minutes per session
+- **Locations**: Delhi, Bangalore, Online
+- **Cost**: ₹1,500 per session, no long-term commitment
+- **Cohort size**: Small groups for practice-based learning
+
+## Key File
+
+`dojos.html` — main page listing all 6 series with session details.
+
+## Adding a New Session
+
+1. Open `dojos.html`
+2. Find the appropriate series section (e.g., `S01`)
+3. Add the session card following the existing HTML pattern in that series
+4. Update the session count in the stats bar at the top
+5. Update `data/search-index.json` if the session is significant enough to be searchable
+6. Update `docs/dojos-guide.md` with the new session details
+
+## Adding a New Series
+
+1. Create a new series section in `dojos.html` following the existing pattern
+2. Assign the next series code (e.g., `S07`)
+3. Add all sessions within the series
+4. Update the stats bar (total sessions count, series count)
+5. Update content counts across: `index.html`, `catalog.html`, `docs/platform-overview.md`
+6. Add entries to `data/search-index.json`
+7. Update `docs/dojos-guide.md`
+8. Update `docs/changelog.md`
+
+## Content Guidelines
+
+- Sessions should be **practice-based** — participants do, not just listen
+- Each session needs a clear **skill outcome** (what can you do after this?)
+- Use South Asian development context for examples and case studies
+- Frame around **practitioner challenges**, not academic theory
+- Session titles should be action-oriented (e.g., "Calibrating Your Confidence" not "Confidence Calibration Theory")
+
+## Cross-Reference Updates
+
+When modifying dojos, check these files:
+- `dojos.html` — main page
+- `index.html` — dojo mention in hero/features section
+- `docs/dojos-guide.md` — documentation
+- `data/search-index.json` — search entries
+- `docs/changelog.md` — if user-facing change

--- a/.claude/skills/github-ops/SKILL.md
+++ b/.claude/skills/github-ops/SKILL.md
@@ -51,9 +51,36 @@ curl -s -H "Authorization: token $GITHUB_PAT" \
 
 For POST/PATCH/PUT, add `-X METHOD -d '{"key": "value"}'`.
 
+### Labels
+- List labels: `GET /repos/{owner}/{repo}/labels`
+- Create label: `POST /repos/{owner}/{repo}/labels` with `{"name": "...", "color": "...", "description": "..."}`
+- Add labels to issue/PR: `POST /repos/{owner}/{repo}/issues/{number}/labels` with `{"labels": ["label1", "label2"]}`
+
+### Auto-Labeling PRs
+
+When creating PRs, automatically apply labels based on changed files:
+
+| Path Pattern | Label | Color |
+|-------------|-------|-------|
+| `Games/*` | `games` | `10B981` |
+| `courses/*` | `courses` | `6366F1` |
+| `blog/*` | `blog` | `EC4899` |
+| `BookSummaries/*` | `book-summaries` | `D97706` |
+| `Handouts/*` | `handouts` | `F59E0B` |
+| `dojos*` | `dojos` | `0EA5E9` |
+| `.claude/*` | `claude-setup` | `94A3B8` |
+| `data/*` | `data` | `64748B` |
+| `docs/*` | `documentation` | `0284C7` |
+
+**Workflow:**
+1. Before labeling, check if label exists: `GET /repos/{owner}/{repo}/labels/{name}`
+2. If 404, create it with the color above
+3. Then apply to the PR/issue
+
 ## Best Practices
 - Always check if a PR/issue exists before creating duplicates
 - Include meaningful titles and descriptions
 - Link PRs to issues with "Closes #N" in the body
 - Never force-push to main/master
+- Auto-label PRs based on changed file paths (see table above)
 - Prefer the API over `gh` CLI for reliability in remote environments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,6 @@ See `.claude/rules/api-conventions.md` for endpoints and auth patterns.
 
 - **rules/** — modular instructions (code-style, content-management, api-conventions, testing)
 - **commands/** — `/project:review`, `/project:fix-issue`, `/project:deploy-check`, `/project:audit`, `/project:add-game`
-- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai, napkin-ai, threads-writer)
+- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai, napkin-ai, threads-writer, blog-writer, dojo-ops, book-summaries)
 - **agents/** — subagent personas (code-reviewer, content-auditor)
 - **hooks/** — session-start (API key bootstrap), pre-tool-use (destructive command guard)


### PR DESCRIPTION
## Summary
- **blog-writer skill**: Full blog post creation workflow with HTML template, napkin illustrations, and cross-references
- **dojo-ops skill**: Manage 56 practice sessions across 6 series
- **book-summaries skill**: Create interactive book companion pages for dev econ texts
- **github-ops enhancement**: Auto-label PRs based on changed file paths (9 path patterns)
- **CLAUDE.md**: Updated skills list

## Test plan
- [ ] Verify skills trigger on matching prompts
- [ ] Confirm CLAUDE.md matches .claude/skills/ directory

https://claude.ai/code/session_015x5G8w88EJg1ByUVRxf1PY