### PR TITLE
Update GitBook docs to reflect v10.5–v10.8 features

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the ImpactMojo knowledge base — for educators, practitioners, contributors, and developers.
 
-**Live site:** [impactmojo.in](https://www.impactmojo.in) | **Version:** 10.1.0
+**Live site:** [impactmojo.in](https://www.impactmojo.in) | **Version:** 10.8.3
 
 ## What is ImpactMojo?
 
@@ -17,7 +17,7 @@ Everything on the platform is free to use. No login required, no paywall, no tri
 - [Getting Started](getting-started.md) — How to use the platform, step by step
 - [Workshops & Facilitation](workshops-and-facilitation.md) — Run workshops using ImpactMojo content
 - [Handouts Guide](handouts-guide.md) — How to find, use, and print 400+ handouts
-- [Dataverse Guide](dataverse-guide.md) — 215+ data tools and datasets, explained
+- [Dataverse Guide](dataverse-guide.md) — 247 data tools and datasets, explained
 - [FAQ](faq.md) — Common questions answered
 
 **If you want to contribute:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,21 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/Varnasr/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.8.4 — March 22, 2026
+
+**What changed for you:** Major GitBook documentation catch-up — all docs now reflect features shipped in v10.5–v10.8.
+
+### GitBook Documentation Updates
+- Updated docs version from 10.1.0 to 10.8.3
+- Fixed stale Dataverse counts (215→247) in README, welcome, and roadmap docs
+- Fixed stale game counts (12→16) and lab counts (10→19) in welcome.md
+- Added 4 missing games (Climate Action, Care Economy, Epidemic Response, Digital Ethics) to content catalog and games guide
+- Added Gender Studies Lab to labs guide and content catalog
+- Fixed all 101.impactmojo.in stale links in labs guide and content catalog → self-hosted /courses/ paths
+- Updated BookSummaries from 1 to 3 in content catalog and platform overview
+- Updated roadmap: moved completed features (cohorts, notifications) to "Recently Completed", added v10.5–v10.8 releases
+- Labs guide now documents all 11 self-hosted labs with correct links
+
 ## v10.8.3 — March 22, 2026
 
 **What changed for you:** Documentation consistency sweep — fixed stale content counts across all GitBook docs and added API key management template.

--- a/docs/content-catalog.md
+++ b/docs/content-catalog.md
@@ -22,13 +22,15 @@ Deep, multi-module courses with 12–13 modules each, interactive lexicons, Sout
 
 ---
 
-## BookSummaries (1)
+## BookSummaries (3)
 
 Interactive book companions under Specials — deep, chapter-by-chapter explorations with data tools and AI-powered Q&A.
 
 | # | Book | Features | Link |
 |---|------|----------|------|
 | 1 | The Handbook of Social Protection (Hanna & Olken, MIT Press 2026) | 24 chapters, evidence explorer, data playground, programme compare, glossary, South Asia lens, AI Q&A | [Open](/BookSummaries/handbook-social-protection.html) |
+| 2 | Development Economics (Debraj Ray) | Chapter-by-chapter companion with interactive data tools | [Open](/BookSummaries/debraj-ray-companion.html) |
+| 3 | Design Thinking for Development | Design thinking companion with practice exercises | [Open](/BookSummaries/dt-companion.html) |
 
 ---
 
@@ -113,16 +115,17 @@ Hands-on workbenches where you build, design, and practice real skills.
 
 | # | Lab | Track | Link |
 |---|-----|-------|------|
-| 1 | Theory of Change Lab | MEL | [Open](https://101.impactmojo.in/toc-workbench) |
-| 2 | MLE Design Lab | MEL | [Open](https://101.impactmojo.in/mel-design-lab) |
-| 3 | MEL Plan Lab | MEL | [Open](https://101.impactmojo.in/mel-plan-lab) |
-| 4 | Storytelling Lab | Health & Communication | [Open](https://101.impactmojo.in/storytelling-lab) |
-| 5 | Design Thinking Lab | MEL | [Open](https://101.impactmojo.in/design-thinking-lab) |
-| 6 | Community Development Lab | MEL | [Open](https://101.impactmojo.in/community-lab) |
-| 7 | Policy & Advocacy Lab | Philosophy & Governance | [Open](https://101.impactmojo.in/policy-advocacy-lab) |
-| 8 | Risk and Mitigation Lab | MEL | [Open](https://101.impactmojo.in/risk-mitigation-lab) |
-| 9 | Resource and Sustainability Lab | MEL | [Open](https://101.impactmojo.in/resource-sustainability-lab) |
-| 10 | Impact and Partnerships Lab | MEL | [Open](https://101.impactmojo.in/impact-partnerships) |
+| 1 | Theory of Change Lab | MEL | [Open](/courses/toc-lab.html) |
+| 2 | MLE Design Lab | MEL | [Open](/courses/mel-design-lab.html) |
+| 3 | MEL Plan Lab | MEL | [Open](/courses/mel-plan-lab.html) |
+| 4 | Storytelling Lab | Health & Communication | [Open](/courses/storytelling-lab.html) |
+| 5 | Design Thinking Lab | MEL | [Open](/courses/design-thinking-lab.html) |
+| 6 | Community Development Lab | MEL | [Open](/courses/community-lab.html) |
+| 7 | Policy & Advocacy Lab | Philosophy & Governance | [Open](/courses/policy-advocacy-lab.html) |
+| 8 | Risk and Mitigation Lab | MEL | [Open](/courses/risk-mitigation-lab.html) |
+| 9 | Resource and Sustainability Lab | MEL | [Open](/courses/resource-sustainability-lab.html) |
+| 10 | Impact and Partnerships Lab | MEL | [Open](/courses/impact-partnerships-lab.html) |
+| 11 | Gender Studies Lab | Gender & Equity | [Open](/courses/gender-studies-lab.html) |
 
 ---
 
@@ -146,6 +149,10 @@ All games now feature **MiroFish AI agents** powered by Groq/Gemini/DeepSeek wit
 | 10 | Externality Game | Pigouvian tax and market failure | Ashok, Nalini, Bina | [Play](/Games/externality-game.html) |
 | 11 | The Real Middle | Income inequality dynamics in India | 5 simulated households | [Play](/Games/real-middle-india.html) |
 | 12 | Econ Concepts Puzzle | 12 economics brain-teasers | — | [Play](/Games/econ-concepts-game.html) |
+| 13 | Climate Action Challenge | Climate resource allocation across decades | — | [Play](/Games/climate-action-game.html) |
+| 14 | Care Economy Challenge | Invisible burden of unpaid care work and equity | — | [Play](/Games/gender-equity-game.html) |
+| 15 | Epidemic Response | Public health outbreak management simulation | — | [Play](/Games/public-health-game.html) |
+| 16 | Digital Ethics Challenge | AI bias, data consent, and digital surveillance | — | [Play](/Games/digital-ethics-game.html) |
 
 ---
 
@@ -270,7 +277,7 @@ Advanced tools for researchers and practitioners. Requires a paid membership.
 | Foundational courses | 39 |
 | Interactive labs | 19 |
 | Learning games | 16 |
-| BookSummaries | 1 |
+| BookSummaries | 3 |
 | Premium tools | 9 |
 | Handout pages | 80+ |
 | Dataverse entries | 247 |

--- a/docs/games-guide.md
+++ b/docs/games-guide.md
@@ -74,6 +74,7 @@ The art grounds each game in South Asian visual culture while making abstract co
 | **Climate Action Challenge** | Climate science | Allocate resources between mitigation and adaptation across decades — the lesson that both are needed together | — |
 | **Care Economy Challenge** | Gender equity | Experience the invisible burden of unpaid care work and how policy choices affect equity outcomes | — |
 | **Epidemic Response** | Public health | Manage a disease outbreak across surveillance, treatment, prevention, community health workers, and communication | — |
+| **Digital Ethics Challenge** | Digital ethics | Navigate AI bias, data consent, platform accountability, and surveillance — the ethical dilemmas of digital development | — |
 
 ---
 

--- a/docs/labs-guide.md
+++ b/docs/labs-guide.md
@@ -2,33 +2,34 @@
 
 ## What Are the ImpactMojo Labs?
 
-ImpactMojo offers **10 interactive labs** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), labs produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
+ImpactMojo offers **19 interactive labs** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), labs produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
 
 All labs are **free, browser-based, and require no login**.
 
 ---
 
-## The 10 Labs
+## The Labs
 
 ### MEL & Research Labs
 
 | Lab | What You Build | Link |
 |-----|---------------|------|
-| **Theory of Change Lab** | A structured ToC with assumptions, indicators, and causal pathways | [Open](https://101.impactmojo.in/toc-workbench) |
-| **MLE Design Lab** | A monitoring, learning, and evaluation framework for your programme | [Open](https://101.impactmojo.in/mel-design-lab) |
-| **MEL Plan Lab** | A complete MEL plan with data collection schedule, tools, and responsibilities | [Open](https://101.impactmojo.in/mel-plan-lab) |
-| **Design Thinking Lab** | A human-centred design process from empathy mapping to prototyping | [Open](https://101.impactmojo.in/design-thinking-lab) |
-| **Community Development Lab** | A participatory community assessment and action plan | [Open](https://101.impactmojo.in/community-lab) |
-| **Risk and Mitigation Lab** | A risk register with likelihood, impact, and mitigation strategies | [Open](https://101.impactmojo.in/risk-mitigation-lab) |
-| **Resource and Sustainability Lab** | A resource mobilisation and sustainability plan | [Open](https://101.impactmojo.in/resource-sustainability-lab) |
-| **Impact and Partnerships Lab** | A partnership mapping and impact measurement framework | [Open](https://101.impactmojo.in/impact-partnerships) |
+| **Theory of Change Lab** | A structured ToC with assumptions, indicators, and causal pathways | [Open](/courses/toc-lab.html) |
+| **MLE Design Lab** | A monitoring, learning, and evaluation framework for your programme | [Open](/courses/mel-design-lab.html) |
+| **MEL Plan Lab** | A complete MEL plan with data collection schedule, tools, and responsibilities | [Open](/courses/mel-plan-lab.html) |
+| **Design Thinking Lab** | A human-centred design process from empathy mapping to prototyping | [Open](/courses/design-thinking-lab.html) |
+| **Community Development Lab** | A participatory community assessment and action plan | [Open](/courses/community-lab.html) |
+| **Risk and Mitigation Lab** | A risk register with likelihood, impact, and mitigation strategies | [Open](/courses/risk-mitigation-lab.html) |
+| **Resource and Sustainability Lab** | A resource mobilisation and sustainability plan | [Open](/courses/resource-sustainability-lab.html) |
+| **Impact and Partnerships Lab** | A partnership mapping and impact measurement framework | [Open](/courses/impact-partnerships-lab.html) |
 
 ### Communication & Governance Labs
 
 | Lab | What You Build | Link |
 |-----|---------------|------|
-| **Storytelling Lab** | A structured impact story with narrative arc and evidence integration | [Open](https://101.impactmojo.in/storytelling-lab) |
-| **Policy & Advocacy Lab** | A policy brief and advocacy strategy with stakeholder mapping | [Open](https://101.impactmojo.in/policy-advocacy-lab) |
+| **Storytelling Lab** | A structured impact story with narrative arc and evidence integration | [Open](/courses/storytelling-lab.html) |
+| **Policy & Advocacy Lab** | A policy brief and advocacy strategy with stakeholder mapping | [Open](/courses/policy-advocacy-lab.html) |
+| **Gender Studies Lab** | A gender analysis framework with intersectional assessment and action planning | [Open](/courses/gender-studies-lab.html) |
 
 ---
 

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -162,6 +162,8 @@ Interactive book companions that go far beyond a summary. Each BookSummary offer
 
 **Current entries:**
 - *The Handbook of Social Protection* (Hanna & Olken, MIT Press 2026) — 24 chapters, 17 evidence findings, 5 learning pathways, 40+ glossary concepts
+- *Development Economics* (Debraj Ray) — chapter-by-chapter companion with interactive data tools
+- *Design Thinking for Development* — design thinking companion with practice exercises
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,15 +9,10 @@ Professional translations of courses in Hindi, Tamil, Bengali, and Marathi. ([#2
 
 **What this means for you:** If you work with teams who are more comfortable in regional languages, full course translations (not just Google Translate) will be available soon. We're starting with the most-used flagship courses.
 
-### Cohort-Based Learning
-Scheduled cohorts with deadlines, discussion threads, and group progression. ([#144](https://github.com/Varnasr/ImpactMojo/issues/144))
+### Additional BookSummaries
+Expanding the interactive book companion library beyond the current 3 titles. More development economics and social policy texts planned.
 
-**What this means for you:** Instead of self-paced learning only, you'll be able to enrol your team in a cohort that progresses through a course together on a set schedule — like an online class, but built into the platform.
-
-### Notification System
-Email digests for course updates, streak reminders, and community activity. ([#145](https://github.com/Varnasr/ImpactMojo/issues/145))
-
-**What this means for you:** You'll get gentle reminders to keep learning, plus notifications when new courses, handouts, or tools are added.
+**What this means for you:** Deep, interactive companions for essential development texts — with data tools, glossaries, and AI-powered Q&A — so you can engage with key literature more effectively.
 
 ## Planned — Q2 2026 (April–June)
 
@@ -56,7 +51,22 @@ Email digests for course updates, streak reminders, and community activity. ([#1
 
 ## Recently Completed
 
+### v10.8.x — March 2026
+- **Cohort-based learning** — organization admins can create training cohorts with deadlines, progress tracking, and discussion threads (#144)
+- **Notification system** — in-app and email notifications for streaks, cohort deadlines, assignments, and certificates (#145)
+- **BookSummaries** — 3 interactive book companions (Social Protection, Development Economics, Design Thinking) with data tools and AI Q&A
+- **Blog illustrations** — all 25 blog posts now have napkin.ai illustrations
+- **7 new interactive labs** (Design Thinking, Impact Partnerships, Resource Sustainability, Policy Advocacy, MEL Design, MEL Plan Builder, Gender Studies) — 19 labs total
+- **4 new games** (Climate Action, Care Economy, Epidemic Response, Digital Ethics) — 16 games total
+- **Dataverse expanded** from 215 to 247 resources
+- **Premium tools** secured with server-side JWT auth-gate on Netlify Edge Functions
+- **7 interactive workshop templates** added to premium listing
+- **Field Notes Pro** — 70 curated development economics field notes
+- **Gamma API integration** — 23 of 38 course decks synced as Gamma presentations
+- Documentation consistency sweeps across all GitBook docs
+
 ### v10.1.0 — March 2026
+- Educator-friendly documentation overhaul (Welcome, Platform Overview, Getting Started, etc.)
 - Git best-practice standards across all 29 repos
 - GitBook docs sidebar link fix
 
@@ -75,9 +85,9 @@ Email digests for course updates, streak reminders, and community activity. ([#1
 - Interactive assessments for flagship courses
 - Full-text search (Ctrl+K)
 - Offline PWA support
-- ImpactMojo Dataverse (215+ tools and datasets)
+- ImpactMojo Dataverse (247 tools and datasets)
 - BCT Repository (203 behaviour change techniques)
-- 12 learning games, 10 interactive labs
+- 16 learning games, 19 interactive labs
 - Dark mode and high-contrast theme
 - Multilingual support (6 languages)
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -13,7 +13,7 @@ If you work at an NGO, a think tank, or a university department focused on devel
 ImpactMojo was built to close that gap. Everything here is:
 
 - **Rooted in South Asian realities** — examples from India, Bangladesh, Nepal, and Sri Lanka, not textbook cases from other contexts
-- **Free at the core** — all 48 courses, 12 simulation games, 10 interactive labs, and hundreds of handouts are available without paying a rupee
+- **Free at the core** — all 48 courses, 16 simulation games, 19 interactive labs, and hundreds of handouts are available without paying a rupee
 - **Designed for practitioners** — not abstract theory, but content you can use in your next workshop, field visit, or strategy meeting
 - **Available offline** — because we know internet connections in the field aren't always reliable
 - **Multilingual** — available in English, Hindi, Tamil, Bengali, Telugu, and Marathi
@@ -44,7 +44,7 @@ ImpactMojo is much more than a course library. Here's what's available:
 **16 interactive games** that let you experience economic and development concepts by making decisions — budget allocations, market dynamics, policy trade-offs, and more. Ideal for workshops and classrooms.
 
 ### Interactive Labs
-**10 browser-based workbenches** where you can build frameworks, analyse data, and produce real outputs (like a theory of change diagram or a research question) step by step.
+**19 browser-based workbenches** where you can build frameworks, analyse data, and produce real outputs (like a theory of change diagram or a research question) step by step.
 
 ### Handouts
 **400+ downloadable pages** organized by track — ready to print, share in a training, or assign as pre-reading.
@@ -59,7 +59,7 @@ A **dictionary of 500+ development terms** — from "attribution" to "zero-based
 **500+ curated academic papers, books, and reports** — the essential reading list for development professionals, organized so you can actually find what you need.
 
 ### Dataverse
-**215+ datasets, APIs, tools, and MCP servers** for development research. If you need data on poverty, health outcomes, governance indicators, or climate — start here.
+**247 datasets, APIs, tools, and MCP servers** for development research. If you need data on poverty, health outcomes, governance indicators, or climate — start here.
 
 ### Blog & Podcast
 Regular writing and audio on development practice, new platform features, and sector trends.


### PR DESCRIPTION
Superseded by housekeeping in PR #323 (merged March 26). All doc updates from this PR were included and extended in the v10.9.1 housekeeping sweep. Closing.