### PR TITLE
Add alive-docs steps to content skills

### DIFF
--- a/.claude/rules/content-management.md
+++ b/.claude/rules/content-management.md
@@ -17,6 +17,9 @@ When adding or modifying content:
 7. **Update catalog**: `catalog.html` / `catalog_data.json` for courses
 8. **Check stale links**: `grep -rn "101.impactmojo.in" index.html courses/` for refs that should be self-hosted
 9. **Validate forms**: all forms submit to Formspree endpoint `xpwdvgzp`
+10. **GitHub Wiki**: clone `Varnasr/ImpactMojo.wiki.git`, update affected pages (Content-Guide, Changelog, type-specific pages), push
+11. **GitHub Discussion**: create Announcements post for significant new content (games, courses, book summaries)
+12. **GitHub Issues**: close related tracking issues with commit/PR links
 
 ## Related
 

--- a/.claude/skills/add-files/SKILL.md
+++ b/.claude/skills/add-files/SKILL.md
@@ -98,6 +98,14 @@ Run these checks after adding content:
 3. **Search index**: Validate `data/search-index.json` is valid JSON
 4. **No stale refs**: Check new content doesn't link to `101.impactmojo.in` when it should be self-hosted
 
+## Step 6 — GitHub "Alive Docs" Updates
+
+After verifying the content:
+
+1. **GitHub Wiki** — clone `Varnasr/ImpactMojo.wiki.git`, update relevant pages (Content-Guide, Changelog, and type-specific pages like Book-Summaries or 101-Course-Decks), push
+2. **GitHub Discussion** — create an Announcements discussion for significant new content (games, courses, book summaries)
+3. **GitHub Issues** — close related tracking issues with links to the commit/PR
+
 ## Quick Reference — Minimum Updates Per Type
 
 | Update Location | Game | Lab | Course | Handout |
@@ -114,3 +122,5 @@ Run these checks after adding content:
 | CHANGELOG.md | Y | Y | Y | Y |
 | sitemap.xml | Y | Y | Y | — |
 | Backup index.html | Y | Y | Y | — |
+| GitHub Wiki | Y | — | Y | — |
+| GitHub Discussion | Y | — | Y | — |

--- a/.claude/skills/book-summaries/SKILL.md
+++ b/.claude/skills/book-summaries/SKILL.md
@@ -85,6 +85,26 @@ After creating the companion:
 5. **Update changelog** — `docs/changelog.md`
 6. **Link from related courses** — if the book maps to an existing course, add a link in the course page
 
+### 5. GitBook Documentation Updates
+
+7. **Update `docs/book-summaries-guide.md`** — add the new book to the "Available Books" table
+8. **Update `docs/content-catalog.md`** — add row to the BookSummaries table, update count in heading
+9. **Update `docs/platform-overview.md`** — update BookSummaries entry with new book count and title
+10. **Update `docs/content-guide.md`** — update BookSummaries count in the content types table
+11. **Update `docs/roadmap.md`** — if this was a roadmap item, mark it complete
+
+### 6. GitHub "Alive Docs" Updates
+
+12. **Create GitHub Discussion** (Announcements category) — announce the new book companion with title, author, chapter count, features, and link. Use GraphQL API:
+    ```bash
+    curl -s -X POST "https://api.github.com/graphql" \
+      -H "Authorization: bearer $GITHUB_PAT" \
+      -d '{"query": "mutation { createDiscussion(input: {repositoryId: \"...\", categoryId: \"...\", title: \"...\", body: \"...\"}) { discussion { url } } }"}'
+    ```
+13. **Update GitHub Issue #272** — check off the new book in the BookSummaries expansion tracking issue
+14. **Update GitHub Wiki** — clone `Varnasr/ImpactMojo.wiki.git`, update `Book-Summaries.md` and `Content-Guide.md` with the new entry, push
+15. **Comment on related discussions** — if Discussion #276 ("Which books should we summarise next?") listed this book, comment confirming it's now live
+
 ## Writing Guidelines
 
 - **Practitioner-first**: explain why each concept matters for fieldwork

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -54,3 +54,15 @@ Run through this checklist after completing major work on ImpactMojo.
     - Verify no broken navigation links
     - Check text contrast on new UI elements (WCAG AA)
     - Test all forms submit to correct Formspree endpoint
+
+11. **GitHub "Alive Docs" sync**
+    - **Wiki**: Clone `Varnasr/ImpactMojo.wiki.git`, update affected pages (Home, Content-Guide, Changelog, Roadmap, Architecture, Book-Summaries, 101-Course-Decks), push
+    - **Discussions**: Post announcement in Announcements category for user-facing additions
+    - **Issues**: Close resolved issues with commit/PR links; update tracking issues (#272 BookSummaries, etc.)
+    - **Milestones**: Update milestone progress if applicable
+
+12. **GitBook cross-check**
+    - Verify `docs/changelog.md` has entries for all changes made
+    - Verify `docs/platform-overview.md` counts match `index.html` counts
+    - Verify `docs/content-catalog.md` tables include all new content
+    - Verify `docs/roadmap.md` completed items match what was shipped


### PR DESCRIPTION
## Summary
- Updated `book-summaries`, `add-files`, `housekeeping` skills and `content-management` rule to include GitHub Wiki, Discussions, and Issues sync as standard post-content steps
- Ensures documentation stays "alive" across all surfaces (GitBook, Wiki, Discussions, Issues) whenever content is added

## Test plan
- [x] Verified skill files are valid markdown
- [x] No breaking changes to existing workflows — only additive steps

https://claude.ai/code/session_016mfcLvMvje3kESJNd7sdxx