### PR TITLE
feat: Add 4 new Claude skills + community resources

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -12,6 +12,7 @@ Persistent context that carries across Claude Code sessions. Updated automatical
 ## Recent Decisions
 
 <!-- Append new decisions at the top -->
+- **2026-03-24**: Added 4 new skills (frontend-design, seo, deep-research, debugging) inspired by @zodchiii's curated AI tools roundup. Added community resources section to CLAUDE.md with GitHub repos to watch and notable community skills. Total skills now: 20.
 
 ## Known Issues
 

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,95 @@
+---
+description: "Systematic debugging for ImpactMojo — HTML rendering issues, broken links, JSON errors, layout bugs, JavaScript failures, and cross-reference inconsistencies. Use when the user reports a bug, something looks wrong, or a page isn't working."
+---
+
+# Systematic Debugging Skill
+
+Structured approach to finding and fixing issues on impactmojo.in.
+
+## Debugging Framework
+
+### Step 1 — Reproduce & Classify
+Identify the issue type:
+
+| Type | Symptoms | First Check |
+|------|----------|-------------|
+| **Broken link** | 404, wrong page | `grep -rn 'href="...' *.html` for the path |
+| **Layout bug** | Overlapping, overflow, misaligned | Check CSS media queries, viewport meta |
+| **JS error** | Feature not working, console error | Check inline `<script>` for syntax errors |
+| **Data issue** | Wrong counts, missing items | Validate JSON: `python3 -m json.tool data/*.json` |
+| **Content mismatch** | Counts don't match, stale text | Run content-auditor agent |
+| **Form broken** | Submission fails | Verify Formspree endpoint `xpwdvgzp` |
+| **Stale reference** | Old URL, 101.impactmojo.in | `grep -rn '101.impactmojo.in' *.html courses/` |
+
+### Step 2 — Investigate
+
+**For HTML/CSS issues:**
+```bash
+# Check for malformed HTML (unclosed tags)
+grep -c '<div' file.html  # compare with
+grep -c '</div>' file.html
+
+# Find CSS specificity conflicts
+grep -n 'important' file.html
+
+# Check responsive breakpoints
+grep -n '@media' file.html
+```
+
+**For data issues:**
+```bash
+# Validate all JSON
+for f in data/*.json; do python3 -m json.tool "$f" > /dev/null && echo "OK: $f" || echo "FAIL: $f"; done
+
+# Check search index completeness
+python3 -c "import json; d=json.load(open('data/search-index.json')); print(f'{len(d)} entries'); [print(f'  {e[\"type\"]}: {e[\"id\"]}') for e in sorted(d, key=lambda x: x['id'])]"
+
+# Count consistency
+grep -rn '16 Games\|16 games\|16 Interactive' index.html catalog.html docs/
+```
+
+**For cross-reference issues:**
+```bash
+# Find all internal links
+grep -oP 'href="(/[^"]+)"' index.html | sort -u
+
+# Check each linked file exists
+grep -oP 'href="(/[^"]+)"' index.html | sort -u | while read -r link; do
+  path="${link#href=\"}"; path="${path%\"}";
+  [ -f ".${path}" ] || echo "MISSING: $path"
+done
+```
+
+### Step 3 — Fix
+1. Make the minimal change that fixes the root cause
+2. Don't refactor surrounding code unless it caused the bug
+3. Test the fix in context (check related pages too)
+
+### Step 4 — Verify
+1. Re-run the same check that found the bug
+2. Run the content-auditor agent if cross-references were involved
+3. Validate JSON if data files were touched
+4. Check mobile layout if CSS was changed
+
+### Step 5 — Prevent
+- If the bug was a missing cross-reference, check if `add-files` skill covers that case
+- If it was a count mismatch, verify all count locations are documented
+- Add the pattern to Known Issues in memory.md if it's likely to recur
+
+## Common ImpactMojo-Specific Issues
+
+### The "620KB index.html" Problem
+- Always backup first: `cp index.html Backups/index-backup-$(date +%Y%m%d-%H%M).html`
+- Use targeted edits, never rewrite the whole file
+- Search for exact strings rather than line numbers (they shift frequently)
+
+### Count Drift
+Content counts appear in 4+ locations. When they drift:
+1. `grep -rn 'N Games' index.html catalog.html README.md docs/` (where N is the expected count)
+2. Fix ALL occurrences in one commit
+3. Update memory.md with new counts
+
+### Stale 101.impactmojo.in Links
+Legacy links to the old subdomain:
+1. `grep -rn '101.impactmojo.in' .`
+2. Replace with self-hosted path (usually `/Handouts/` or `/courses/`)

--- a/.claude/skills/deep-research/SKILL.md
+++ b/.claude/skills/deep-research/SKILL.md
@@ -1,0 +1,80 @@
+---
+description: "Conduct deep research on development economics topics using multiple AI providers and web sources. Use when the user asks to research a topic, gather evidence for content, find data for a new course/game, or needs substantive background material."
+---
+
+# Deep Research Skill
+
+Multi-source research workflow for creating evidence-backed ImpactMojo content.
+
+## When to Use
+- Researching a new course topic or game mechanic
+- Gathering data for blog posts or Threads content
+- Finding recent papers, reports, or case studies
+- Cross-validating claims across sources
+- Building reading lists or bibliographies
+
+## Research Workflow
+
+### Step 1 — Define the Research Question
+Clarify with the user:
+- What specific topic or question?
+- What type of content will this feed into? (game, course, blog, handout)
+- What depth is needed? (quick overview vs. comprehensive review)
+- Any specific regions or time periods?
+
+### Step 2 — Multi-Source Search
+Use available tools in this priority order:
+
+1. **Web Search** — Current articles, news, recent publications
+2. **Grok AI** (`grok-ai` skill) — Cross-validate facts, get alternative perspectives
+3. **Gemini AI** (`gemini-ai` skill) — Generate summaries, extract structured data
+4. **DeepSeek AI** (`deepseek-ai` skill) — Chain-of-thought reasoning for complex analysis
+
+### Step 3 — Synthesize Findings
+Structure research output as:
+
+```markdown
+## Research: {Topic}
+
+### Key Findings
+- Finding 1 (source)
+- Finding 2 (source)
+
+### Data Points
+| Metric | Value | Source | Year |
+|--------|-------|--------|------|
+
+### Relevant Frameworks
+- Framework/theory and how it applies
+
+### South Asian Context
+- Region-specific data, case studies, or examples
+
+### Content Opportunities
+- How this could become a game mechanic
+- Course module suggestions
+- Blog post angles
+
+### Sources
+1. [Source 1](url) — brief description
+2. [Source 2](url) — brief description
+```
+
+### Step 4 — Validate
+- Cross-check key claims across at least 2 sources
+- Flag any conflicting data with both versions
+- Note data recency — prefer post-2020 sources
+- Identify gaps where more research is needed
+
+## Quality Standards
+- Always cite sources with URLs when available
+- Distinguish between peer-reviewed research and commentary
+- Note sample sizes and methodological limitations
+- Prefer World Bank, UNDP, J-PAL, NBER, and regional research institutions
+- Flag if data is specific to one country vs. South Asia broadly
+
+## Integration with Other Skills
+- Feed findings into `blog-writer` for evidence-backed posts
+- Use data points in `threads-writer` for social content
+- Inform game design parameters in `add-game`
+- Support course outline development

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,64 @@
+---
+description: "Generate polished, accessible HTML/CSS for ImpactMojo pages — games, labs, landing sections, and interactive components. Use when the user asks to build UI, improve design, create a page layout, or wants frontend help."
+---
+
+# Frontend Design Skill
+
+Generate high-quality, accessible HTML/CSS/JS for ImpactMojo's static site.
+
+## Design System
+
+ImpactMojo uses a consistent visual language across all pages:
+
+### Colors
+- **Primary**: `#667eea` (indigo) → `#764ba2` (purple) gradient
+- **Accent**: `#f093fb` (pink), `#4facfe` (blue)
+- **Text**: `#2d3748` (dark), `#718096` (muted)
+- **Background**: `#f7fafc` (light gray), `#ffffff` (white)
+- **Success**: `#48bb78`, **Warning**: `#ed8936`, **Error**: `#fc8181`
+
+### Typography
+- **Headings**: system font stack, bold, `#2d3748`
+- **Body**: `0.9rem` minimum on mobile, `1rem` on desktop
+- **Line height**: 1.6 for readability
+
+### Layout Patterns
+- **Cards**: `border-radius: 16px`, `box-shadow: 0 4px 6px rgba(0,0,0,0.1)`, white background
+- **Sections**: Max-width `1200px`, centered, `padding: 4rem 2rem`
+- **Grid**: CSS Grid with `auto-fit, minmax(300px, 1fr)` for responsive cards
+- **Spacing**: `gap: 2rem` between cards, `margin-bottom: 3rem` between sections
+
+### Responsive Rules
+- Mobile-first approach
+- Breakpoints: `768px` (tablet), `1024px` (desktop)
+- Tap targets: minimum `48px`
+- `<meta name="viewport" content="width=device-width, initial-scale=1.0">`
+
+### Accessibility (WCAG AA)
+- Color contrast ratio ≥ 4.5:1 for text
+- All images have `alt` text
+- Focus-visible outlines on interactive elements
+- Semantic HTML5 (`<nav>`, `<main>`, `<section>`, `<article>`)
+- `aria-label` on icon-only buttons
+
+### Indian Folk Art Style (Games)
+Games use illustrations inspired by Madhubani, Warli, and Kalamkari art:
+- Bold outlines, flat colors
+- Geometric patterns and nature motifs
+- Inline SVG preferred for illustrations
+- Color palette: earth tones with vibrant accents
+
+## Workflow
+
+1. **Understand**: Clarify what page/component is needed and where it fits
+2. **Reference**: Check existing pages for consistent patterns (`index.html`, recent games)
+3. **Build**: Write semantic HTML with inline CSS (for games) or linked styles
+4. **Validate**: Check responsive behavior, accessibility, dark mode support
+5. **Integrate**: Update cross-references per content-management rules
+
+## Anti-Patterns to Avoid
+- No external CSS frameworks (Bootstrap, Tailwind) — all styles are custom
+- No `!important` unless absolutely necessary
+- No fixed pixel widths on containers
+- No missing viewport meta tags
+- No placeholder images — use inline SVG or CSS gradients

--- a/.claude/skills/seo/SKILL.md
+++ b/.claude/skills/seo/SKILL.md
@@ -1,0 +1,98 @@
+---
+description: "Optimize ImpactMojo pages for search engines — meta tags, structured data, Open Graph, sitemap, and content strategy. Use when the user asks about SEO, search rankings, meta tags, structured data, or discoverability."
+---
+
+# SEO Skill
+
+Optimize impactmojo.in for search engine visibility and social sharing.
+
+## Core SEO Checklist
+
+### Every HTML Page Must Have
+```html
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{Page Title} | ImpactMojo</title>
+<meta name="description" content="{150-160 char description}">
+<meta name="keywords" content="development economics, {topic}, South Asia, free education">
+<link rel="canonical" href="https://impactmojo.in/{path}">
+```
+
+### Open Graph (Social Sharing)
+```html
+<meta property="og:title" content="{Title}">
+<meta property="og:description" content="{Description}">
+<meta property="og:image" content="https://impactmojo.in/assets/{image}.png">
+<meta property="og:url" content="https://impactmojo.in/{path}">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ImpactMojo">
+```
+
+### Twitter Card
+```html
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{Title}">
+<meta name="twitter:description" content="{Description}">
+<meta name="twitter:image" content="https://impactmojo.in/assets/{image}.png">
+```
+
+### Structured Data (JSON-LD)
+For courses:
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Course",
+  "name": "{Course Name}",
+  "description": "{Description}",
+  "provider": {
+    "@type": "Organization",
+    "name": "ImpactMojo",
+    "url": "https://impactmojo.in"
+  },
+  "isAccessibleForFree": true,
+  "educationalLevel": "Introductory",
+  "inLanguage": "en"
+}
+</script>
+```
+
+For games/interactive content:
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "LearningResource",
+  "name": "{Game Name}",
+  "description": "{Description}",
+  "learningResourceType": "interactive",
+  "isAccessibleForFree": true
+}
+</script>
+```
+
+## Sitemap Management
+- File: `sitemap.xml`
+- Add `<url>` entry for every new page
+- Set `<lastmod>` to current date
+- Priority: `1.0` (homepage), `0.8` (courses), `0.7` (games/labs), `0.5` (handouts)
+
+## Content SEO Strategy
+- **Title tags**: Include primary keyword + "| ImpactMojo"
+- **H1**: One per page, matches search intent
+- **Internal linking**: Cross-link related courses, games, and handouts
+- **Image alt text**: Descriptive, keyword-rich
+- **URL structure**: Clean, lowercase, hyphenated (`/courses/behavioral-economics/`)
+
+## Audit Workflow
+1. Check all pages have required meta tags: `grep -rn '<meta name="description"' *.html courses/**/*.html Games/**/*.html`
+2. Validate sitemap completeness: compare sitemap URLs vs actual files
+3. Check for missing Open Graph tags
+4. Verify canonical URLs resolve correctly
+5. Test structured data with Google Rich Results validator
+
+## ImpactMojo-Specific Keywords
+- development economics, South Asia, free courses
+- behavioral economics games, RCT simulation
+- poverty measurement, microfinance, gender economics
+- interactive learning, development studies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,28 @@ Persistent project context lives in `.claude/memory.md` — carries state, decis
 - **memory.md** — persistent context across sessions (project state, decisions, known issues, session log)
 - **rules/** — modular instructions (code-style, content-management, api-conventions, testing)
 - **commands/** — `/project:review`, `/project:fix-issue`, `/project:deploy-check`, `/project:audit`, `/project:add-game`
-- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai, napkin-ai, threads-writer, blog-writer, dojo-ops, book-summaries, memory)
+- **skills/** — auto-invoked workflows (add-files, housekeeping, github-ops, netlify-ops, supabase-ops, gamma-ops, gemini-ai, grok-ai, deepseek-ai, sarvam-ai, napkin-ai, threads-writer, blog-writer, dojo-ops, book-summaries, memory, frontend-design, seo, deep-research, debugging)
 - **agents/** — subagent personas (code-reviewer, content-auditor)
 - **hooks/** — session-start (API key bootstrap), pre-tool-use (destructive command guard), stop (memory sync prompt)
+
+## Community Resources
+
+Curated skills, MCP servers, and repos worth tracking (sourced from [@zodchiii's roundup](https://x.com/i/status/2034924354337714642)):
+
+### GitHub Repos to Watch
+- [anthropics/skills](https://github.com/anthropics/skills) — Official Anthropic skills repository
+- [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) — Curated community skills (22k+ stars)
+- [anthropics/claude-code-security-review](https://github.com/anthropics/claude-code-security-review) — Security review skill
+- [199-biotechnologies/claude-deep-research-skill](https://github.com/199-biotechnologies/claude-deep-research-skill) — Deep research patterns
+- [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo) — Prompt/output testing
+- [mendableai/firecrawl](https://github.com/mendableai/firecrawl) — Web scraping for content research
+- [eyaltoledano/claude-task-master](https://github.com/eyaltoledano/claude-task-master) — AI project management
+- [upstash/context7](https://github.com/upstash/context7) — Library docs injection MCP
+- [tavily-ai/tavily-mcp](https://github.com/tavily-ai/tavily-mcp) — AI-native search MCP
+
+### Notable Community Skills
+- **Frontend Design** (277k+ installs) — UI generation patterns
+- **Claude SEO** (12 sub-skills) — Search optimization
+- **Systematic Debugging** — Structured troubleshooting
+- **Context Optimization** — Better context window usage
+- Browse more at [skillsmp.com](https://skillsmp.com)


### PR DESCRIPTION
## Summary
- Added 4 new Claude Code skills: **frontend-design**, **seo**, **deep-research**, **debugging**
- Added **Community Resources** section to CLAUDE.md with GitHub repos to watch and notable community skills
- Updated memory.md with session decisions

Inspired by [@zodchiii's curated AI tools roundup](https://x.com/i/status/2034924354337714642).

## New Skills

| Skill | Purpose |
|-------|---------|
| `frontend-design` | ImpactMojo design system, accessibility (WCAG AA), responsive patterns, Indian folk art style guide |
| `seo` | Meta tags, structured data (JSON-LD), Open Graph, Twitter Cards, sitemap, content SEO strategy |
| `deep-research` | Multi-source research workflow using Grok/Gemini/DeepSeek for dev econ content |
| `debugging` | Systematic troubleshooting: broken links, layout bugs, JSON errors, count drift, stale references |

## Community Resources Added to CLAUDE.md
- 9 GitHub repos to watch (anthropics/skills, awesome-claude-skills, firecrawl, promptfoo, etc.)
- Notable community skills reference (Frontend Design 277k+ installs, Claude SEO, etc.)
- Link to skillsmp.com for browsing community skills

## Test plan
- [ ] Verify new skills appear in Claude Code skill list
- [ ] Test each skill triggers on expected keywords
- [ ] Confirm CLAUDE.md renders correctly on GitHub

https://claude.ai/code/session_01XqMdzvrv62sddKC32Y5Soe