### PR TITLE
Fix Gamma embeds: use direct URLs instead of broken proxy

### DIFF
--- a/101-courses/SRHR-basics.html
+++ b/101-courses/SRHR-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Sexual & Reproductive Health Rights 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/pqlgfwhgifv5887" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/pqlgfwhgifv5887" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Sexual & Reproductive Health Rights 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/advocacy-basics.html
+++ b/101-courses/advocacy-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Advocacy Basics 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/7vn84i39w277ccl" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/7vn84i39w277ccl" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Advocacy Basics 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/bcc-comms.html
+++ b/101-courses/bcc-comms.html
@@ -50,7 +50,7 @@
     <span class="header-title">Behaviour Change Communication 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/1fmdryar7yxd46o" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/1fmdryar7yxd46o" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Behaviour Change Communication 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/bi-analysis.html
+++ b/101-courses/bi-analysis.html
@@ -50,7 +50,7 @@
     <span class="header-title">Bivariate Analysis 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/j6e4moalbgaq4ae" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/j6e4moalbgaq4ae" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Bivariate Analysis 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/care-economy-101.html
+++ b/101-courses/care-economy-101.html
@@ -50,7 +50,7 @@
     <span class="header-title">Care Economy 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/s0lvffkv9i4qyko" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/s0lvffkv9i4qyko" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Care Economy 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/climate-essentials.html
+++ b/101-courses/climate-essentials.html
@@ -50,7 +50,7 @@
     <span class="header-title">Climate Essentials 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ot3zjxw8op210lc" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ot3zjxw8op210lc" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Climate Essentials 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/community-dev.html
+++ b/101-courses/community-dev.html
@@ -50,7 +50,7 @@
     <span class="header-title">Community Development 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ah3tx37gr0qtb7t" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ah3tx37gr0qtb7t" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Community Development 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/cost-effectiveness.html
+++ b/101-courses/cost-effectiveness.html
@@ -50,7 +50,7 @@
     <span class="header-title">Cost-Effectiveness Analysis 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/jj79tp52dqlahsi" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/jj79tp52dqlahsi" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Cost-Effectiveness Analysis 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/data-feminism.html
+++ b/101-courses/data-feminism.html
@@ -50,7 +50,7 @@
     <span class="header-title">Data Feminism 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ai5yv7qpxm3m1t7" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ai5yv7qpxm3m1t7" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Data Feminism 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/data-lit.html
+++ b/101-courses/data-lit.html
@@ -50,7 +50,7 @@
     <span class="header-title">Data Literacy 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/2ir4k5iuhh8yif0" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/2ir4k5iuhh8yif0" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Data Literacy 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/decent-work.html
+++ b/101-courses/decent-work.html
@@ -50,7 +50,7 @@
     <span class="header-title">Decent Work 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ku6s6m5ozs1eugf" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ku6s6m5ozs1eugf" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Decent Work 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/decolonize-dev.html
+++ b/101-courses/decolonize-dev.html
@@ -50,7 +50,7 @@
     <span class="header-title">Decolonizing Development 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/l785o2nzxle65vd" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/l785o2nzxle65vd" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Decolonizing Development 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/dev-architecture.html
+++ b/101-courses/dev-architecture.html
@@ -50,7 +50,7 @@
     <span class="header-title">Development Architecture 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ol361y6nd5qfbs4" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ol361y6nd5qfbs4" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Development Architecture 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/dev-economics.html
+++ b/101-courses/dev-economics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Development Economics 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/baib0hhyognvrhg" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/baib0hhyognvrhg" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Development Economics 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/digital-ethics.html
+++ b/101-courses/digital-ethics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Digital Ethics 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/wbsq6m7cbk7fgdb" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/wbsq6m7cbk7fgdb" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Digital Ethics 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/econometrics-101.html
+++ b/101-courses/econometrics-101.html
@@ -50,7 +50,7 @@
     <span class="header-title">Econometrics 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/lfxhwbdfjvh4ckk" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/lfxhwbdfjvh4ckk" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Econometrics 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/eda-hhs.html
+++ b/101-courses/eda-hhs.html
@@ -50,7 +50,7 @@
     <span class="header-title">Exploratory Data Analysis for Household Surveys 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/p0lzef6xgy6k0xd" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/p0lzef6xgy6k0xd" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Exploratory Data Analysis for Household Surveys 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/edu-pedagogy.html
+++ b/101-courses/edu-pedagogy.html
@@ -50,7 +50,7 @@
     <span class="header-title">Education & Pedagogy 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/xor1t3qh6foyxxk" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/xor1t3qh6foyxxk" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Education & Pedagogy 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/eng-dev.html
+++ b/101-courses/eng-dev.html
@@ -50,7 +50,7 @@
     <span class="header-title">English for Development Professionals 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/cuyzkl6i0fomiop" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/cuyzkl6i0fomiop" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="English for Development Professionals 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/env-justice.html
+++ b/101-courses/env-justice.html
@@ -50,7 +50,7 @@
     <span class="header-title">Environmental Justice 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/wvlhodld38hw6jq" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/wvlhodld38hw6jq" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Environmental Justice 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/fundraising-basics.html
+++ b/101-courses/fundraising-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Fundraising Basics 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/m9it78mjr1ysgvq" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/m9it78mjr1ysgvq" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Fundraising Basics 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/ind-constitution.html
+++ b/101-courses/ind-constitution.html
@@ -50,7 +50,7 @@
     <span class="header-title">Indian Constitution 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ce0p18e8x3so9fu" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ce0p18e8x3so9fu" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Indian Constitution 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/inequality-basics.html
+++ b/101-courses/inequality-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Inequality 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/ocmateld5ycg01t" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/ocmateld5ycg01t" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Inequality 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/irt-basics.html
+++ b/101-courses/irt-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Item Response Theory 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/telsxhuhdybfc2z" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/telsxhuhdybfc2z" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Item Response Theory 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/livelihood-basics.html
+++ b/101-courses/livelihood-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Livelihoods 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/fydt8t0isalnhm3" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/fydt8t0isalnhm3" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Livelihoods 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/mel-basics.html
+++ b/101-courses/mel-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Monitoring, Evaluation & Learning 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/5rdiqleyykxl65i" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/5rdiqleyykxl65i" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Monitoring, Evaluation & Learning 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/multivariate-basics.html
+++ b/101-courses/multivariate-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Multivariate Analysis 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/k724n05l8u9wepl" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/k724n05l8u9wepl" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Multivariate Analysis 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/obs2insight.html
+++ b/101-courses/obs2insight.html
@@ -50,7 +50,7 @@
     <span class="header-title">Field Observations to Insights 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/rqgzouwjovw8hm0" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/rqgzouwjovw8hm0" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Field Observations to Insights 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/pol-economy.html
+++ b/101-courses/pol-economy.html
@@ -50,7 +50,7 @@
     <span class="header-title">Political Economy 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/q9qdemkv2m9l98f" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/q9qdemkv2m9l98f" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Political Economy 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/post-truth-101.html
+++ b/101-courses/post-truth-101.html
@@ -50,7 +50,7 @@
     <span class="header-title">Post-Truth 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/n8qfqkpul9mztqo" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/n8qfqkpul9mztqo" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Post-Truth 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/pub-health-basics.html
+++ b/101-courses/pub-health-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Public Health 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/cfgdhshknhl3zmq" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/cfgdhshknhl3zmq" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Public Health 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/qual-methods.html
+++ b/101-courses/qual-methods.html
@@ -50,7 +50,7 @@
     <span class="header-title">Qualitative Research Methods 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/jpzak4ip04ddhz6" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/jpzak4ip04ddhz6" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Qualitative Research Methods 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/research-ethics.html
+++ b/101-courses/research-ethics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Research Ethics 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/o8v0jrsv30e8rhg" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/o8v0jrsv30e8rhg" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Research Ethics 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/sel-basics.html
+++ b/101-courses/sel-basics.html
@@ -50,7 +50,7 @@
     <span class="header-title">Social-Emotional Learning 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/3e5mrovw3jsoonv" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/3e5mrovw3jsoonv" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Social-Emotional Learning 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/social-margins.html
+++ b/101-courses/social-margins.html
@@ -50,7 +50,7 @@
     <span class="header-title">Social Margins 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/an2qeykh381uf18" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/an2qeykh381uf18" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Social Margins 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/toc-workbench.html
+++ b/101-courses/toc-workbench.html
@@ -50,7 +50,7 @@
     <span class="header-title">Theory of Change 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/kdjplyosg3s5667" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/kdjplyosg3s5667" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Theory of Change 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/visual-eth.html
+++ b/101-courses/visual-eth.html
@@ -50,7 +50,7 @@
     <span class="header-title">Visual Ethnography 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/vw5ygsm28tdvove" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/vw5ygsm28tdvove" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Visual Ethnography 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/101-courses/wee-studies.html
+++ b/101-courses/wee-studies.html
@@ -50,7 +50,7 @@
     <span class="header-title">Women's Economic Empowerment 101</span>
     <a href="/catalog.html" class="header-back">Back to Courses</a>
   </header>
-  <iframe class="embed-frame" src="/slides/olmor8092tumwko" 
+  <iframe class="embed-frame" src="https://gamma.app/embed/olmor8092tumwko" 
     allow="fullscreen" allowfullscreen loading="lazy"
     title="Women's Economic Empowerment 101 - ImpactMojo"></iframe>
   <footer class="footer">

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,13 +27,6 @@
   [headers.values]
     Cache-Control = "public, max-age=300, must-revalidate"
 
-# Proxy Gamma slide embeds through our domain (hides gamma.app origin)
-[[redirects]]
-  from = "/slides/*"
-  to = "https://gamma.app/embed/:splat"
-  status = 200
-  force = true
-
 # GitBook documentation — 200 proxy rewrite avoids redirect loops
 [[redirects]]
   from = "/docs"


### PR DESCRIPTION
Netlify proxy triggered Cloudflare challenge. Switch iframes to direct gamma.app/embed/ URLs. Remove unused /slides/* proxy redirect.

https://claude.ai/code/session_01S9T7AeKUooyY51UzrVc4Uy