### PR TITLE
Fix: gender course big plane SVGs missing CSS

### DIFF
--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1311,9 +1311,27 @@ section, .module, .lexicon-section, .founders-section {
     50% { transform: translateY(-30px) rotate(180deg); opacity: 0.7; }
 }
 
+/* Additional floating planes */
+.v3-big-plane {
+    position: absolute;
+    width: 80px;
+    height: 80px;
+    opacity: 0.22;
+    animation: v3-plane-float 30s ease-in-out infinite;
+}
+.v3-big-plane-1 { top: 30%; left: 5%; animation-delay: 0s; }
+.v3-big-plane-2 { bottom: 20%; right: 10%; animation-delay: -10s; }
+.v3-big-plane-3 { top: 70%; left: 70%; animation-delay: -20s; }
+@keyframes v3-plane-float {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    25% { transform: translate(50px, -30px) rotate(10deg); }
+    50% { transform: translate(80px, 40px) rotate(-5deg); }
+    75% { transform: translate(-20px, 60px) rotate(8deg); }
+}
+
 /* Hide decorative elements on mobile / reduced motion */
 @media (max-width: 768px) {
-    .v3-paper-plane, .v3-floating-elements, .v3-blob { display: none !important; }
+    .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; }
 }
 @media (prefers-reduced-motion: reduce) {
     .v3-paper-plane, .v3-blob, .v3-sparkle { animation: none !important; }


### PR DESCRIPTION
The gender course has 4 plane SVGs total — 1 `.v3-paper-plane` (fixed in PR #306) and 3 `.v3-big-plane` elements that had NO CSS rules, rendering at full size across the page. Added positioning, sizing (80px), and animation CSS matching the reference courses.

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ