### PR TITLE
Fix: gender nav bar + pubpol dynamic content CSS

### DIFF
--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1141,6 +1141,42 @@ section, .module, .lexicon-section, .founders-section {
     color: var(--text-primary); font-weight: 700; font-size: 1rem;
 }
 .im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right { display: flex; align-items: center; gap: 0.5rem; }
+.im-premium-btn {
+    background: var(--gradient-primary, linear-gradient(135deg, #7C3AED 0%, #6366F1 100%));
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+    text-decoration: none;
+}
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--bg-sidebar, #150E25);
+    border: 1px solid var(--border-color, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--text-muted, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover { background: var(--hover-bg, #334155); color: var(--text-primary, #F1F5F9); }
+.im-theme-btn.active { background: var(--accent, #7C3AED); color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+@media (max-width: 768px) {
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+}
 /* Reading Progress Bar */
         .reading-progress {
             position: fixed;

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -416,6 +416,61 @@
         body{font-family:'Amaranth',sans-serif!important;}
         h1,h2,h3,h4,h5,h6{font-family:'Inter',sans-serif!important;}
         code,pre,.monospace,kbd,samp{font-family:'JetBrains Mono',monospace!important;}
+
+        /* Module content (dynamically loaded) */
+        .module-header { margin-bottom: 1.5rem; }
+        .module-number { font-size: 0.85rem; font-weight: 600; color: var(--color-accent); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.25rem; }
+        .module-title { font-size: 1.5rem; font-weight: 700; color: var(--color-text); margin: 0 0 0.5rem; }
+        .module-intro { font-size: 0.95rem; color: var(--text-secondary); line-height: 1.7; margin: 0; }
+        .prose { line-height: 1.8; }
+        .prose p { margin-bottom: 1rem; }
+        .prose h3 { font-size: 1.15rem; font-weight: 600; margin: 1.75rem 0 0.75rem; color: var(--color-text); }
+        .prose h4 { font-size: 1rem; font-weight: 600; margin: 1.25rem 0 0.5rem; }
+        .prose ul, .prose ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+        .prose li { margin-bottom: 0.4rem; }
+        .card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+        .card { background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: 12px; padding: 1.25rem; }
+        .card-icon { width: 40px; height: 40px; border-radius: 10px; background: rgba(14,165,233,0.1); display: flex; align-items: center; justify-content: center; margin-bottom: 0.75rem; }
+        .card-icon.indigo { background: rgba(99,102,241,0.1); }
+        .card-icon.green { background: rgba(16,185,129,0.1); }
+        .card-icon.orange { background: rgba(245,158,11,0.1); }
+        .card-title { font-weight: 600; font-size: 0.95rem; margin-bottom: 0.4rem; color: var(--color-text); }
+        .card-text { font-size: 0.85rem; color: var(--text-secondary); line-height: 1.6; }
+        .callout { border-radius: 12px; padding: 1.25rem; margin: 1.5rem 0; border-left: 4px solid var(--color-accent); background: rgba(14,165,233,0.05); }
+        .callout-blue { border-left-color: var(--color-accent); background: rgba(14,165,233,0.05); }
+        .callout-icon { float: left; margin-right: 0.75rem; }
+        .callout-content { overflow: hidden; }
+        .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.5rem 0; }
+        @media (max-width: 768px) { .two-col { grid-template-columns: 1fr; } .card-grid { grid-template-columns: 1fr; } }
+        .coach-callout { display: flex; gap: 1rem; padding: 1.25rem; background: var(--color-bg-secondary); border-radius: 12px; border: 1px solid var(--color-border); margin: 1.5rem 0; }
+        .coach-photo { width: 48px; height: 48px; border-radius: 50%; object-fit: cover; flex-shrink: 0; }
+        .coach-name { font-weight: 600; font-size: 0.9rem; color: var(--color-accent); }
+        .coach-message { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.6; margin: 0.25rem 0; }
+        .coach-links { display: flex; gap: 0.75rem; margin-top: 0.5rem; }
+        .coach-link { font-size: 0.8rem; color: var(--color-accent); text-decoration: none; display: flex; align-items: center; gap: 0.25rem; }
+        .reading-list { list-style: none; padding: 0; margin: 1rem 0; }
+        .reading-list li { padding: 0.5rem 0; border-bottom: 1px solid var(--color-border); font-size: 0.9rem; }
+        .reading-list-title { font-weight: 600; margin-bottom: 0.5rem; }
+        .reflection-box { background: var(--color-bg-secondary); border-radius: 12px; padding: 1.25rem; margin: 1.5rem 0; border: 1px solid var(--color-border); }
+        .reflection-q { font-weight: 600; margin-bottom: 0.5rem; }
+        .reflection-hint { font-size: 0.85rem; color: var(--text-secondary); font-style: italic; }
+        .sources { font-size: 0.8rem; color: var(--text-muted); margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--color-border); }
+        .divider { height: 1px; background: var(--color-border); margin: 2rem 0; }
+
+        /* MCQ Quiz sections */
+        .mcq-section { margin-top: 2rem; padding: 1.5rem; background: var(--color-bg-secondary); border-radius: 12px; border: 1px solid var(--color-border); }
+        .mcq-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; font-weight: 600; color: var(--color-text); }
+        .mcq { margin-bottom: 1.25rem; padding: 1rem; background: var(--color-bg); border-radius: 10px; border: 1px solid var(--color-border); }
+        .mcq-q { font-weight: 500; margin-bottom: 0.75rem; }
+        .mcq-number { font-weight: 600; color: var(--color-accent); margin-right: 0.5rem; }
+        .mcq-type { font-size: 0.75rem; color: var(--text-muted); margin-left: 0.5rem; }
+        .mcq-options { display: flex; flex-direction: column; gap: 0.4rem; }
+        .mcq-option { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.75rem; border-radius: 8px; cursor: pointer; transition: background 0.2s; font-size: 0.9rem; }
+        .mcq-option:hover { background: rgba(14,165,233,0.08); }
+        .mcq-option input[type="radio"] { accent-color: var(--color-accent); }
+        .mcq-check-btn { margin-top: 0.75rem; padding: 0.5rem 1rem; background: var(--color-accent); color: #fff; border: none; border-radius: 8px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
+        .mcq-check-btn:hover { opacity: 0.9; }
+        .mcq-feedback { margin-top: 0.5rem; padding: 0.75rem; border-radius: 8px; font-size: 0.85rem; display: none; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

**Gender course:**
- Added missing CSS for `.im-premium-btn` (the huge star was an unstyled Premium button SVG)
- Added missing CSS for `.im-theme-selector` and `.im-theme-btn` (theme toggle was invisible)
- Added `.im-topbar-right` layout CSS

**Pubpol (governance) course:**
- Added CSS for all dynamically-loaded content classes: `.module-header`, `.module-number`, `.module-title`, `.module-intro`, `.prose`
- Added layout CSS: `.card-grid`, `.card`, `.callout`, `.two-col`, `.coach-callout`, `.reading-list`, `.reflection-box`, `.sources`
- Added MCQ quiz CSS: `.mcq-section`, `.mcq`, `.mcq-option`, `.mcq-check-btn`, `.mcq-feedback`

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ