### PR TITLE
Fix: coach callout styling for gender + pubpol

### DIFF
--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -728,7 +728,7 @@ a:hover { text-decoration: underline; }
   color: #fff;
 }
 
-.coach-body {}
+.coach-body { flex: 1; }
 
 .coach-name {
   font-family: 'Inter', sans-serif;

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -442,12 +442,37 @@
         .callout-content { overflow: hidden; }
         .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.5rem 0; }
         @media (max-width: 768px) { .two-col { grid-template-columns: 1fr; } .card-grid { grid-template-columns: 1fr; } }
-        .coach-callout { display: flex; gap: 1rem; padding: 1.25rem; background: var(--color-bg-secondary); border-radius: 12px; border: 1px solid var(--color-border); margin: 1.5rem 0; }
-        .coach-photo { width: 48px; height: 48px; border-radius: 50%; object-fit: cover; flex-shrink: 0; }
-        .coach-name { font-weight: 600; font-size: 0.9rem; color: var(--color-accent); }
-        .coach-message { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.6; margin: 0.25rem 0; }
-        .coach-links { display: flex; gap: 0.75rem; margin-top: 0.5rem; }
-        .coach-link { font-size: 0.8rem; color: var(--color-accent); text-decoration: none; display: flex; align-items: center; gap: 0.25rem; }
+        .coach-callout {
+            display: flex; gap: 1rem; align-items: flex-start;
+            padding: 1.25rem;
+            background: linear-gradient(135deg, rgba(14,165,233,0.08) 0%, rgba(99,102,241,0.08) 100%);
+            border: 1px solid rgba(14,165,233,0.25);
+            border-radius: 16px;
+            margin: 2rem 0;
+            position: relative;
+        }
+        .coach-callout::before {
+            content: ''; position: absolute; left: 48px; top: -8px;
+            width: 16px; height: 16px;
+            background: linear-gradient(135deg, rgba(14,165,233,0.08) 0%, rgba(99,102,241,0.08) 100%);
+            border-left: 1px solid rgba(14,165,233,0.25);
+            border-top: 1px solid rgba(14,165,233,0.25);
+            transform: rotate(45deg);
+        }
+        .coach-photo { width: 56px; height: 56px; border-radius: 50%; object-fit: cover; border: 3px solid var(--color-accent); flex-shrink: 0; }
+        .coach-name { font-family: 'Inter', sans-serif; font-weight: 600; font-size: 0.95rem; color: var(--color-accent); margin-bottom: 0.25rem; }
+        .coach-message { color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; margin-bottom: 0.75rem; }
+        .coach-links { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+        .coach-link {
+            display: inline-flex; align-items: center; gap: 0.35rem;
+            padding: 0.4rem 0.75rem; background: var(--color-accent); color: white;
+            text-decoration: none; border-radius: 6px; font-size: 0.8rem; font-weight: 500;
+            transition: all 0.2s ease;
+        }
+        .coach-link:hover { opacity: 0.9; transform: translateY(-1px); }
+        .coach-link.secondary { background: transparent; border: 1px solid var(--color-accent); color: var(--color-accent); }
+        .coach-link img { width: 14px; height: 14px; filter: brightness(0) invert(1); }
+        .coach-link.secondary img { filter: brightness(0) saturate(100%) invert(48%) sepia(95%) saturate(1012%) hue-rotate(178deg); }
         .reading-list { list-style: none; padding: 0; margin: 1rem 0; }
         .reading-list li { padding: 0.5rem 0; border-bottom: 1px solid var(--color-border); font-size: 0.9rem; }
         .reading-list-title { font-weight: 600; margin-bottom: 0.5rem; }


### PR DESCRIPTION
## Summary

- **Gender**: Fixed `.coach-body { flex: 1 }` — content wasn't expanding to fill available space  
- **Pubpol**: Upgraded coach callout CSS to match gandhi reference — gradient background, speech bubble arrow (::before), proper photo border, styled coaching links with hover effects

Both courses now render coach callouts with the same visual treatment as gandhi/devecon.

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ