### PR TITLE
Fix: SEL course content not loading (case mismatch)

### DIFF
--- a/js/course-loader.js
+++ b/js/course-loader.js
@@ -28,9 +28,14 @@
   var EDGE_FN_URL = cfg.SUPABASE_URL + '/functions/v1/serve-course-content';
 
   // ── Detect course ID ────────────────────────────────────────────
+  // Map URL slugs to DB course_ids (handles case mismatches)
+  var COURSE_ID_MAP = { 'sel': 'SEL' };
+
   function detectCourseId() {
     var match = window.location.pathname.match(/\/courses\/([^/]+)/);
-    return match ? match[1] : null;
+    if (!match) return null;
+    var slug = match[1];
+    return COURSE_ID_MAP[slug] || slug;
   }
 
   var courseId = detectCourseId();


### PR DESCRIPTION
## Summary

- SEL course content wasn't loading because URL `/courses/sel/` produces lowercase slug `sel`, but the database stores it as `SEL` (uppercase)
- Added a course ID mapping in `course-loader.js` to handle the case mismatch
- This fixes "Unable to load course content" on the SEL course page

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ