### PR TITLE
Fix: pubpol content crashing into sidebar (unclosed page-wrapper)

### DIFF
--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -373,7 +373,7 @@
         .resource-quick-link:hover{border-color:var(--accent-color);color:var(--accent-color);text-decoration:none;}
         .resource-quick-link img{width:13px;height:13px;}
         /* Footer */
-        .footer{background:var(--color-bg-secondary);border-top:1px solid var(--color-border);padding:2.5rem 2rem 1.5rem;margin-top:3rem;}
+        .footer{background:var(--color-bg-secondary);border-top:1px solid var(--color-border);padding:2.5rem 2rem 1.5rem;margin-top:3rem;margin-left:var(--sidebar-width);}
         .footer-content{max-width:var(--content-max-width);margin:0 auto;display:grid;grid-template-columns:1fr 2fr;gap:2rem;margin-bottom:1.5rem;}
         .footer-logo img{height:32px;margin-bottom:0.75rem;}
         .footer-logo p{font-size:0.85rem;color:var(--text-muted);}
@@ -391,6 +391,7 @@
             .sidebar{transform:translateX(-100%);transition:transform 0.3s ease;top:0;height:100vh;height:100dvh;}
             .sidebar.active{transform:translateX(0);}
             .main-content{margin-left:0!important;width:100%;}
+            .footer{margin-left:0!important;}
             .mobile-header{display:flex!important;}
             .content-wrapper{padding:var(--spacing-lg);padding-top:calc(56px + var(--spacing-xl));}
             .v3-paper-plane,.v3-blob{display:none!important;}
@@ -880,6 +881,7 @@
 
 </div><!-- /content-wrapper -->
 </main><!-- /main-content -->
+</div><!-- /page-wrapper -->
 
 <!-- V3 Paper Plane -->
 <svg class="v3-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">


### PR DESCRIPTION
The `page-wrapper` flex container (`display: flex`) was never closed — footer, paper plane SVG, and scripts were all flex children alongside the sidebar, causing the main content to collide with the sidebar.

Fix: close `</div><!-- /page-wrapper -->` after main-content, and add `margin-left: var(--sidebar-width)` to footer (with mobile reset).

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ