### PR TITLE
Audit fixes: decoratives for 3 courses + HTML tags for 2 courses

### DIFF
--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -2305,7 +2305,39 @@
             transform: translateX(0) !important;
         }
 
-    </style>
+    
+/* V3 FLOATING PAPER PLANE */
+.v3-paper-plane { position: fixed; top: 15%; right: 8%; width: 140px; height: 140px; opacity: 0.35; z-index: 0; pointer-events: none; animation: v3-fly 25s ease-in-out infinite; }
+@keyframes v3-fly { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 20% { transform: translate(60px, -40px) rotate(12deg); } 40% { transform: translate(120px, 30px) rotate(-8deg); } 60% { transform: translate(40px, 60px) rotate(15deg); } 80% { transform: translate(-30px, 20px) rotate(-5deg); } }
+[data-theme="light"] .v3-paper-plane { opacity: 0.25; }
+/* V3 ORGANIC BACKGROUND BLOBS */
+.v3-organic-bg { position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: -2; overflow: hidden; }
+.v3-blob { position: absolute; border-radius: 63% 37% 54% 46% / 55% 48% 52% 45%; animation: v3-morph 20s ease-in-out infinite; }
+.v3-blob-1 { top: -120px; right: -120px; width: 450px; height: 450px; background: radial-gradient(circle, rgba(14, 165, 233, 0.12) 0%, transparent 70%); }
+.v3-blob-2 { bottom: -180px; left: -180px; width: 550px; height: 550px; background: radial-gradient(circle, rgba(99, 102, 241, 0.10) 0%, transparent 70%); border-radius: 41% 59% 38% 62% / 67% 44% 56% 33%; animation-delay: -5s; animation-direction: reverse; }
+.v3-blob-3 { top: 40%; left: 60%; width: 350px; height: 350px; background: radial-gradient(circle, rgba(16, 185, 129, 0.08) 0%, transparent 70%); border-radius: 52% 48% 61% 39% / 43% 58% 42% 57%; animation-delay: -10s; }
+.v3-blob-4 { top: 60%; right: 20%; width: 280px; height: 280px; background: radial-gradient(circle, rgba(245, 158, 11, 0.06) 0%, transparent 70%); border-radius: 38% 62% 45% 55% / 61% 39% 61% 39%; animation-delay: -15s; animation-direction: reverse; }
+@keyframes v3-morph { 0%, 100% { transform: translate(0, 0) rotate(0deg) scale(1); border-radius: 63% 37% 54% 46% / 55% 48% 52% 45%; } 25% { transform: translate(30px, -25px) rotate(5deg) scale(1.05); border-radius: 41% 59% 48% 52% / 47% 53% 47% 53%; } 50% { transform: translate(-20px, 35px) rotate(-3deg) scale(0.95); border-radius: 54% 46% 38% 62% / 62% 38% 62% 38%; } 75% { transform: translate(25px, 15px) rotate(8deg) scale(1.02); border-radius: 48% 52% 59% 41% / 53% 47% 53% 47%; } }
+[data-theme="light"] .v3-blob-1 { background: radial-gradient(circle, rgba(14, 165, 233, 0.08) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-2 { background: radial-gradient(circle, rgba(99, 102, 241, 0.06) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-3 { background: radial-gradient(circle, rgba(16, 185, 129, 0.05) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-4 { background: radial-gradient(circle, rgba(245, 158, 11, 0.04) 0%, transparent 70%); }
+/* FLOATING SPARKLES */
+.v3-floating-elements { position: fixed; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
+.v3-sparkle { position: absolute; font-size: 1.2rem; color: var(--accent-color, #0EA5E9); opacity: 0.4; animation: v3-sparkle-float 15s ease-in-out infinite; }
+.v3-sparkle-1 { top: 20%; left: 10%; }
+.v3-sparkle-2 { top: 60%; right: 15%; animation-delay: -5s; color: var(--secondary-accent, #6366F1); }
+.v3-sparkle-3 { bottom: 30%; left: 20%; animation-delay: -10s; color: var(--success-color, #10B981); }
+@keyframes v3-sparkle-float { 0%, 100% { transform: translateY(0) rotate(0deg); opacity: 0.4; } 50% { transform: translateY(-30px) rotate(180deg); opacity: 0.7; } }
+.v3-big-plane { position: absolute; width: 80px; height: 80px; opacity: 0.22; animation: v3-plane-float 30s ease-in-out infinite; }
+.v3-big-plane-1 { top: 30%; left: 5%; }
+.v3-big-plane-2 { bottom: 20%; right: 10%; animation-delay: -10s; }
+.v3-big-plane-3 { top: 70%; left: 70%; animation-delay: -20s; }
+@keyframes v3-plane-float { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 25% { transform: translate(50px, -30px) rotate(10deg); } 50% { transform: translate(80px, 40px) rotate(-5deg); } 75% { transform: translate(-20px, 60px) rotate(8deg); } }
+@media (max-width: 768px) { .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; } }
+@media (prefers-reduced-motion: reduce) { .v3-paper-plane, .v3-blob, .v3-sparkle, .v3-big-plane { animation: none !important; } }
+
+</style>
 <style>
 /* ===== ImpactMojo Design System ===== */
 :root {
@@ -2686,7 +2718,46 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <!-- Main Content -->
     <main id="main-content" class="main-content">
         <!-- Hero Section -->
-        <section class="hero">
+        
+<!-- V3 FLOATING PAPER PLANE -->
+<svg class="v3-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- V3 ORGANIC BACKGROUND BLOBS -->
+<div class="v3-organic-bg" aria-hidden="true">
+    <div class="v3-blob v3-blob-1"></div>
+    <div class="v3-blob v3-blob-2"></div>
+    <div class="v3-blob v3-blob-3"></div>
+    <div class="v3-blob v3-blob-4"></div>
+</div>
+<!-- V3 FLOATING ELEMENTS -->
+<div class="v3-floating-elements" aria-hidden="true">
+    <div class="v3-sparkle v3-sparkle-1">✦</div>
+    <div class="v3-sparkle v3-sparkle-2">✧</div>
+    <div class="v3-sparkle v3-sparkle-3">✦</div>
+    <svg class="v3-big-plane v3-big-plane-1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#6366F1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#0EA5E9" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#10B981"/>
+    </svg>
+    <svg class="v3-big-plane v3-big-plane-2" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#0EA5E9"/>
+    </svg>
+    <svg class="v3-big-plane v3-big-plane-3" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#F59E0B" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#EF4444" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    </svg>
+</div>
+
+<section class="hero">
             <div class="hero-charts">
                 <!-- Decorative chart elements -->
                 <svg style="top: 20%; right: 10%; width: 120px; height: 80px;">

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -335,7 +335,39 @@
             .coach-actions { justify-content: center; }
             .founders-grid { grid-template-columns: 1fr; }
         }
-    </style>
+    
+/* V3 FLOATING PAPER PLANE */
+.v3-paper-plane { position: fixed; top: 15%; right: 8%; width: 140px; height: 140px; opacity: 0.35; z-index: 0; pointer-events: none; animation: v3-fly 25s ease-in-out infinite; }
+@keyframes v3-fly { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 20% { transform: translate(60px, -40px) rotate(12deg); } 40% { transform: translate(120px, 30px) rotate(-8deg); } 60% { transform: translate(40px, 60px) rotate(15deg); } 80% { transform: translate(-30px, 20px) rotate(-5deg); } }
+[data-theme="light"] .v3-paper-plane { opacity: 0.25; }
+/* V3 ORGANIC BACKGROUND BLOBS */
+.v3-organic-bg { position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: -2; overflow: hidden; }
+.v3-blob { position: absolute; border-radius: 63% 37% 54% 46% / 55% 48% 52% 45%; animation: v3-morph 20s ease-in-out infinite; }
+.v3-blob-1 { top: -120px; right: -120px; width: 450px; height: 450px; background: radial-gradient(circle, rgba(14, 165, 233, 0.12) 0%, transparent 70%); }
+.v3-blob-2 { bottom: -180px; left: -180px; width: 550px; height: 550px; background: radial-gradient(circle, rgba(99, 102, 241, 0.10) 0%, transparent 70%); border-radius: 41% 59% 38% 62% / 67% 44% 56% 33%; animation-delay: -5s; animation-direction: reverse; }
+.v3-blob-3 { top: 40%; left: 60%; width: 350px; height: 350px; background: radial-gradient(circle, rgba(16, 185, 129, 0.08) 0%, transparent 70%); border-radius: 52% 48% 61% 39% / 43% 58% 42% 57%; animation-delay: -10s; }
+.v3-blob-4 { top: 60%; right: 20%; width: 280px; height: 280px; background: radial-gradient(circle, rgba(245, 158, 11, 0.06) 0%, transparent 70%); border-radius: 38% 62% 45% 55% / 61% 39% 61% 39%; animation-delay: -15s; animation-direction: reverse; }
+@keyframes v3-morph { 0%, 100% { transform: translate(0, 0) rotate(0deg) scale(1); border-radius: 63% 37% 54% 46% / 55% 48% 52% 45%; } 25% { transform: translate(30px, -25px) rotate(5deg) scale(1.05); border-radius: 41% 59% 48% 52% / 47% 53% 47% 53%; } 50% { transform: translate(-20px, 35px) rotate(-3deg) scale(0.95); border-radius: 54% 46% 38% 62% / 62% 38% 62% 38%; } 75% { transform: translate(25px, 15px) rotate(8deg) scale(1.02); border-radius: 48% 52% 59% 41% / 53% 47% 53% 47%; } }
+[data-theme="light"] .v3-blob-1 { background: radial-gradient(circle, rgba(14, 165, 233, 0.08) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-2 { background: radial-gradient(circle, rgba(99, 102, 241, 0.06) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-3 { background: radial-gradient(circle, rgba(16, 185, 129, 0.05) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-4 { background: radial-gradient(circle, rgba(245, 158, 11, 0.04) 0%, transparent 70%); }
+/* FLOATING SPARKLES */
+.v3-floating-elements { position: fixed; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
+.v3-sparkle { position: absolute; font-size: 1.2rem; color: var(--accent-color, #0EA5E9); opacity: 0.4; animation: v3-sparkle-float 15s ease-in-out infinite; }
+.v3-sparkle-1 { top: 20%; left: 10%; }
+.v3-sparkle-2 { top: 60%; right: 15%; animation-delay: -5s; color: var(--secondary-accent, #6366F1); }
+.v3-sparkle-3 { bottom: 30%; left: 20%; animation-delay: -10s; color: var(--success-color, #10B981); }
+@keyframes v3-sparkle-float { 0%, 100% { transform: translateY(0) rotate(0deg); opacity: 0.4; } 50% { transform: translateY(-30px) rotate(180deg); opacity: 0.7; } }
+.v3-big-plane { position: absolute; width: 80px; height: 80px; opacity: 0.22; animation: v3-plane-float 30s ease-in-out infinite; }
+.v3-big-plane-1 { top: 30%; left: 5%; }
+.v3-big-plane-2 { bottom: 20%; right: 10%; animation-delay: -10s; }
+.v3-big-plane-3 { top: 70%; left: 70%; animation-delay: -20s; }
+@keyframes v3-plane-float { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 25% { transform: translate(50px, -30px) rotate(10deg); } 50% { transform: translate(80px, 40px) rotate(-5deg); } 75% { transform: translate(-20px, 60px) rotate(8deg); } }
+@media (max-width: 768px) { .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; } }
+@media (prefers-reduced-motion: reduce) { .v3-paper-plane, .v3-blob, .v3-sparkle, .v3-big-plane { animation: none !important; } }
+
+</style>
 <style>
 /* ===== ImpactMojo Design System ===== */
 :root {
@@ -616,7 +648,46 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Open navigation menu" aria-expanded="false" type="button"><span></span><span></span><span></span></button>
             </header>
             
-            <section class="hero" id="hero">
+            
+<!-- V3 FLOATING PAPER PLANE -->
+<svg class="v3-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- V3 ORGANIC BACKGROUND BLOBS -->
+<div class="v3-organic-bg" aria-hidden="true">
+    <div class="v3-blob v3-blob-1"></div>
+    <div class="v3-blob v3-blob-2"></div>
+    <div class="v3-blob v3-blob-3"></div>
+    <div class="v3-blob v3-blob-4"></div>
+</div>
+<!-- V3 FLOATING ELEMENTS -->
+<div class="v3-floating-elements" aria-hidden="true">
+    <div class="v3-sparkle v3-sparkle-1">✦</div>
+    <div class="v3-sparkle v3-sparkle-2">✧</div>
+    <div class="v3-sparkle v3-sparkle-3">✦</div>
+    <svg class="v3-big-plane v3-big-plane-1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#6366F1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#0EA5E9" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#10B981"/>
+    </svg>
+    <svg class="v3-big-plane v3-big-plane-2" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#0EA5E9"/>
+    </svg>
+    <svg class="v3-big-plane v3-big-plane-3" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#F59E0B" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#EF4444" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    </svg>
+</div>
+
+<section class="hero" id="hero">
                 <div class="hero-content">
                     <div class="hero-badge"><span>Flagship Course • Free Forever</span></div>
                     <h1>AI for Impact: Data Monitoring & Evaluation in Development</h1>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -1815,7 +1815,39 @@
             transform: translateX(0) !important;
         }
 
-    </style>
+    
+/* V3 FLOATING PAPER PLANE */
+.v3-paper-plane { position: fixed; top: 15%; right: 8%; width: 140px; height: 140px; opacity: 0.35; z-index: 0; pointer-events: none; animation: v3-fly 25s ease-in-out infinite; }
+@keyframes v3-fly { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 20% { transform: translate(60px, -40px) rotate(12deg); } 40% { transform: translate(120px, 30px) rotate(-8deg); } 60% { transform: translate(40px, 60px) rotate(15deg); } 80% { transform: translate(-30px, 20px) rotate(-5deg); } }
+[data-theme="light"] .v3-paper-plane { opacity: 0.25; }
+/* V3 ORGANIC BACKGROUND BLOBS */
+.v3-organic-bg { position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: -2; overflow: hidden; }
+.v3-blob { position: absolute; border-radius: 63% 37% 54% 46% / 55% 48% 52% 45%; animation: v3-morph 20s ease-in-out infinite; }
+.v3-blob-1 { top: -120px; right: -120px; width: 450px; height: 450px; background: radial-gradient(circle, rgba(14, 165, 233, 0.12) 0%, transparent 70%); }
+.v3-blob-2 { bottom: -180px; left: -180px; width: 550px; height: 550px; background: radial-gradient(circle, rgba(99, 102, 241, 0.10) 0%, transparent 70%); border-radius: 41% 59% 38% 62% / 67% 44% 56% 33%; animation-delay: -5s; animation-direction: reverse; }
+.v3-blob-3 { top: 40%; left: 60%; width: 350px; height: 350px; background: radial-gradient(circle, rgba(16, 185, 129, 0.08) 0%, transparent 70%); border-radius: 52% 48% 61% 39% / 43% 58% 42% 57%; animation-delay: -10s; }
+.v3-blob-4 { top: 60%; right: 20%; width: 280px; height: 280px; background: radial-gradient(circle, rgba(245, 158, 11, 0.06) 0%, transparent 70%); border-radius: 38% 62% 45% 55% / 61% 39% 61% 39%; animation-delay: -15s; animation-direction: reverse; }
+@keyframes v3-morph { 0%, 100% { transform: translate(0, 0) rotate(0deg) scale(1); border-radius: 63% 37% 54% 46% / 55% 48% 52% 45%; } 25% { transform: translate(30px, -25px) rotate(5deg) scale(1.05); border-radius: 41% 59% 48% 52% / 47% 53% 47% 53%; } 50% { transform: translate(-20px, 35px) rotate(-3deg) scale(0.95); border-radius: 54% 46% 38% 62% / 62% 38% 62% 38%; } 75% { transform: translate(25px, 15px) rotate(8deg) scale(1.02); border-radius: 48% 52% 59% 41% / 53% 47% 53% 47%; } }
+[data-theme="light"] .v3-blob-1 { background: radial-gradient(circle, rgba(14, 165, 233, 0.08) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-2 { background: radial-gradient(circle, rgba(99, 102, 241, 0.06) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-3 { background: radial-gradient(circle, rgba(16, 185, 129, 0.05) 0%, transparent 70%); }
+[data-theme="light"] .v3-blob-4 { background: radial-gradient(circle, rgba(245, 158, 11, 0.04) 0%, transparent 70%); }
+/* FLOATING SPARKLES */
+.v3-floating-elements { position: fixed; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
+.v3-sparkle { position: absolute; font-size: 1.2rem; color: var(--accent-color, #0EA5E9); opacity: 0.4; animation: v3-sparkle-float 15s ease-in-out infinite; }
+.v3-sparkle-1 { top: 20%; left: 10%; }
+.v3-sparkle-2 { top: 60%; right: 15%; animation-delay: -5s; color: var(--secondary-accent, #6366F1); }
+.v3-sparkle-3 { bottom: 30%; left: 20%; animation-delay: -10s; color: var(--success-color, #10B981); }
+@keyframes v3-sparkle-float { 0%, 100% { transform: translateY(0) rotate(0deg); opacity: 0.4; } 50% { transform: translateY(-30px) rotate(180deg); opacity: 0.7; } }
+.v3-big-plane { position: absolute; width: 80px; height: 80px; opacity: 0.22; animation: v3-plane-float 30s ease-in-out infinite; }
+.v3-big-plane-1 { top: 30%; left: 5%; }
+.v3-big-plane-2 { bottom: 20%; right: 10%; animation-delay: -10s; }
+.v3-big-plane-3 { top: 70%; left: 70%; animation-delay: -20s; }
+@keyframes v3-plane-float { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 25% { transform: translate(50px, -30px) rotate(10deg); } 50% { transform: translate(80px, 40px) rotate(-5deg); } 75% { transform: translate(-20px, 60px) rotate(8deg); } }
+@media (max-width: 768px) { .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; } }
+@media (prefers-reduced-motion: reduce) { .v3-paper-plane, .v3-blob, .v3-sparkle, .v3-big-plane { animation: none !important; } }
+
+</style>
 <style>
 /* ===== ImpactMojo Design System ===== */
 :root {
@@ -2143,7 +2175,46 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <!-- Main Content -->
     <main class="main-content" id="main-content">
         <!-- Hero Section -->
-        <section id="hero" class="hero">
+        
+<!-- V3 FLOATING PAPER PLANE -->
+<svg class="v3-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- V3 ORGANIC BACKGROUND BLOBS -->
+<div class="v3-organic-bg" aria-hidden="true">
+    <div class="v3-blob v3-blob-1"></div>
+    <div class="v3-blob v3-blob-2"></div>
+    <div class="v3-blob v3-blob-3"></div>
+    <div class="v3-blob v3-blob-4"></div>
+</div>
+<!-- V3 FLOATING ELEMENTS -->
+<div class="v3-floating-elements" aria-hidden="true">
+    <div class="v3-sparkle v3-sparkle-1">✦</div>
+    <div class="v3-sparkle v3-sparkle-2">✧</div>
+    <div class="v3-sparkle v3-sparkle-3">✦</div>
+    <svg class="v3-big-plane v3-big-plane-1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#6366F1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#0EA5E9" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#10B981"/>
+    </svg>
+    <svg class="v3-big-plane v3-big-plane-2" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#0EA5E9"/>
+    </svg>
+    <svg class="v3-big-plane v3-big-plane-3" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#F59E0B" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#EF4444" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    </svg>
+</div>
+
+<section id="hero" class="hero">
             <span class="hero-badge">Flagship Course - Free Forever</span>
             <h1>Gandhi's Political Thought: Philosophy for Praxis</h1>
             <p class="hero-subtitle">From Swaraj to Sarvodaya</p>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -3447,7 +3447,10 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 
                 </section>
 
-    
+            </div><!-- /content-wrapper -->
+        </main><!-- /main-content -->
+    </div><!-- /page-wrapper -->
+
     <!-- FOOTER -->
     <footer class="footer">
         <div class="footer-content">

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3517,7 +3517,10 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 
                 </section>
 
-    
+            </div><!-- /content-wrapper -->
+        </main><!-- /main-content -->
+    </div><!-- /page-wrapper -->
+
     <!-- FOOTER -->
     <footer class="footer">
         <div class="footer-content">


### PR DESCRIPTION
## Summary

Full audit fixes across 5 courses:

**Decorative elements added** (gandhi, dataviz, devai):
- V3 paper plane SVG (140px, animated, fixed position)
- 4 organic background blobs with morphing animation
- 3 floating sparkles
- 3 additional floating planes (80px)
- Mobile hide + reduced-motion support
- Light theme opacity adjustments

**HTML structure fixed** (mel, media):
- Added missing `</div><!-- /content-wrapper -->`, `</main>`, `</div><!-- /page-wrapper -->` closing tags before footer

All 11 courses now pass the full audit checklist.

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ