### PR TITLE
Fix: logged-in users locked out of course modules

### DIFF
--- a/js/course-loader.js
+++ b/js/course-loader.js
@@ -44,7 +44,13 @@
   // ── Get auth token if user is logged in ─────────────────────────
   function getAccessToken() {
     try {
-      // Try Supabase session from localStorage
+      // Check custom storage key used by auth.js
+      var customSession = localStorage.getItem('impactmojo-auth');
+      if (customSession) {
+        var parsed = JSON.parse(customSession);
+        if (parsed && parsed.access_token) return parsed.access_token;
+      }
+      // Fallback: try default Supabase session keys
       var keys = Object.keys(localStorage);
       for (var i = 0; i < keys.length; i++) {
         if (keys[i].indexOf('sb-') === 0 && keys[i].indexOf('-auth-token') > -1) {


### PR DESCRIPTION
course-loader.js was looking for auth token under sb-*-auth-token but auth.js stores it under impactmojo-auth. Logged-in users were always treated as anonymous.

https://claude.ai/code/session_016HLTBM8tMdem6YWsahVAnZ