### PR TITLE
Add SEO upgrade, PDF Processing, and PPTX skills

### DIFF
--- a/.claude/skills/pdf-processing/SKILL.md
+++ b/.claude/skills/pdf-processing/SKILL.md
@@ -1,0 +1,159 @@
+---
+description: "Read, extract, create, merge, split, and manipulate PDF files. Use when the user asks to generate handout packs, extract tables from reports, create PDF exports, merge BookSummary chapters, fill forms, or work with any PDF content."
+---
+
+# PDF Processing Skill
+
+Comprehensive PDF manipulation for ImpactMojo content — handout packs, course exports, report generation, and data extraction.
+
+## Setup
+
+Install required Python libraries (run once):
+```bash
+pip install pdfplumber reportlab pypdf Pillow
+```
+
+## Capabilities
+
+### 1. Extract Text & Tables
+
+Use `pdfplumber` to extract text preserving layout and convert tables to structured data:
+
+```python
+import pdfplumber
+
+with pdfplumber.open("report.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        tables = page.extract_tables()
+        for table in tables:
+            # Each table is a list of rows, each row a list of cells
+            for row in table:
+                print(row)
+```
+
+### 2. Create PDFs from Scratch
+
+Use `reportlab` to generate branded ImpactMojo PDFs:
+
+```python
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table
+from reportlab.lib.units import inch
+from reportlab.lib.colors import HexColor
+
+# ImpactMojo brand colors
+PRIMARY = HexColor('#667eea')
+TEXT = HexColor('#2d3748')
+MUTED = HexColor('#718096')
+
+doc = SimpleDocTemplate("output.pdf", pagesize=A4,
+    leftMargin=1*inch, rightMargin=1*inch,
+    topMargin=1*inch, bottomMargin=1*inch)
+
+styles = getSampleStyleSheet()
+styles.add(ParagraphStyle(
+    'ImpactMojoTitle',
+    parent=styles['Title'],
+    fontName='Helvetica-Bold',
+    fontSize=24,
+    textColor=PRIMARY,
+    spaceAfter=20
+))
+styles.add(ParagraphStyle(
+    'ImpactMojoBody',
+    parent=styles['Normal'],
+    fontName='Helvetica',
+    fontSize=11,
+    textColor=TEXT,
+    leading=16,
+    spaceAfter=8
+))
+```
+
+**Important**: Avoid Unicode subscript/superscript characters in ReportLab — built-in fonts render them as black boxes. Use `<sub>` and `<super>` XML tags instead.
+
+### 3. Merge PDFs
+
+Combine multiple handouts or chapters into a single pack:
+
+```python
+from pypdf import PdfMerger
+
+merger = PdfMerger()
+merger.append("handout-1.pdf")
+merger.append("handout-2.pdf")
+merger.append("handout-3.pdf")
+merger.write("handout-pack.pdf")
+merger.close()
+```
+
+### 4. Split PDFs
+
+Extract specific pages:
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("full-document.pdf")
+writer = PdfWriter()
+
+# Extract pages 3-7
+for page_num in range(2, 7):
+    writer.add_page(reader.pages[page_num])
+
+writer.write("excerpt.pdf")
+```
+
+### 5. HTML to PDF (Handouts)
+
+Convert ImpactMojo HTML handouts to PDF using browser print:
+
+```python
+import subprocess
+
+# Using wkhtmltopdf (if available)
+subprocess.run([
+    'wkhtmltopdf',
+    '--page-size', 'A4',
+    '--margin-top', '15mm',
+    '--margin-bottom', '15mm',
+    '--margin-left', '15mm',
+    '--margin-right', '15mm',
+    'Handouts/MEL/handout-1.html',
+    'output/mel-handout-1.pdf'
+])
+```
+
+Alternative: Use Puppeteer (already in package.json):
+```javascript
+const puppeteer = require('puppeteer');
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+await page.goto('file:///path/to/handout.html');
+await page.pdf({ path: 'output.pdf', format: 'A4', printBackground: true });
+await browser.close();
+```
+
+## ImpactMojo Use Cases
+
+### Handout Packs
+Generate track-specific PDF packs by merging handouts:
+```
+/Handouts/MEL Track/*.html → mel-track-pack.pdf
+/Handouts/Gender Equity Track/*.html → gender-track-pack.pdf
+```
+
+### Course Export
+Generate a complete course as a single PDF — all 13 modules + lexicon.
+
+### BookSummary Chapters
+Extract individual chapters from BookSummaries for offline reading.
+
+### Workshop Materials
+Combine selected handouts + game instructions + lab guides into a workshop-ready pack.
+
+## Output Location
+
+Place generated PDFs in `/exports/` or deliver directly to user. Never commit large PDFs to the repo.

--- a/.claude/skills/pptx/SKILL.md
+++ b/.claude/skills/pptx/SKILL.md
@@ -1,0 +1,164 @@
+---
+description: "Create and edit PowerPoint presentations (.pptx) from course content, workshop plans, or plain language descriptions. Use when the user asks to generate slides, create a presentation, build a deck, or export course content as PPTX. Complements the Gamma API skill for generating 101 Course Decks."
+---
+
+# PPTX Skill — ImpactMojo
+
+Create branded PowerPoint presentations from ImpactMojo course content, workshop outlines, or plain language descriptions.
+
+## Setup
+
+```bash
+pip install python-pptx Pillow
+```
+
+## Design Standards
+
+### Avoid "AI Slop" Slides
+- No walls of bullet points
+- No generic blue/gray color schemes
+- No clip art or stock photo placeholders
+- No identical layouts repeated across all slides
+
+### ImpactMojo Slide Design Principles
+
+**Color strategy**: Match the learning track's folk art color:
+| Track | Primary Color | Art Style |
+|-------|--------------|-----------|
+| MEL & Research | `#3182ce` | Warli |
+| Data & Technology | `#38a169` | Gond |
+| Policy & Economics | `#d69e2e` | Kalamkari |
+| Gender & Equity | `#d53f8c` | Madhubani |
+| Health & Communication | `#e53e3e` | Pattachitra |
+| Philosophy & Governance | `#805ad5` | Pichwai |
+
+**Layout variety**: Rotate between these layouts:
+1. **Title + subtitle** (opening)
+2. **Big stat + context** (data points)
+3. **Two-column** (comparison, before/after)
+4. **Image + text** (case study, example)
+5. **Grid of 3-4 cards** (key concepts)
+6. **Quote + attribution** (key takeaway)
+7. **Timeline / process flow** (sequences)
+
+**Typography**:
+- Title slides: 36-44pt, bold
+- Section headers: 28-32pt
+- Body text: 18-22pt
+- Never below 16pt
+- Use Inter for headings, system fonts for body
+
+**Visual requirement**: Every slide needs at least one visual element — a shape, chart, icon, or colored block. Text-only slides are forgettable.
+
+## Creating Presentations
+
+### From Course Content
+
+```python
+from pptx import Presentation
+from pptx.util import Inches, Pt, Emu
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+
+prs = Presentation()
+prs.slide_width = Inches(13.33)  # 16:9 widescreen
+prs.slide_height = Inches(7.5)
+
+# Title slide
+slide = prs.slides.add_slide(prs.slide_layouts[6])  # Blank layout
+txBox = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(11), Inches(3))
+tf = txBox.text_frame
+p = tf.add_paragraph()
+p.text = "MEL for Development"
+p.font.size = Pt(44)
+p.font.bold = True
+p.font.color.rgb = RGBColor(0x31, 0x82, 0xce)  # Track color
+p.alignment = PP_ALIGN.LEFT
+
+# Subtitle
+p2 = tf.add_paragraph()
+p2.text = "Module 1: What is Monitoring, Evaluation & Learning?"
+p2.font.size = Pt(22)
+p2.font.color.rgb = RGBColor(0x71, 0x80, 0x96)
+
+# Add ImpactMojo footer
+add_footer(slide, "ImpactMojo — impactmojo.in")
+
+prs.save("mel-module-1.pptx")
+```
+
+### Slide Templates
+
+#### Big Stat Slide
+```python
+def add_stat_slide(prs, stat, label, context):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    # Big number
+    txBox = slide.shapes.add_textbox(Inches(1), Inches(1.5), Inches(11), Inches(2.5))
+    p = txBox.text_frame.add_paragraph()
+    p.text = stat  # e.g., "73%"
+    p.font.size = Pt(96)
+    p.font.bold = True
+    p.font.color.rgb = RGBColor(0x66, 0x7e, 0xea)
+    # Label
+    p2 = txBox.text_frame.add_paragraph()
+    p2.text = label  # e.g., "of Indian NGOs lack formal M&E frameworks"
+    p2.font.size = Pt(24)
+    # Context
+    p3 = txBox.text_frame.add_paragraph()
+    p3.text = context
+    p3.font.size = Pt(16)
+    p3.font.color.rgb = RGBColor(0x71, 0x80, 0x96)
+```
+
+#### Two-Column Comparison
+```python
+def add_comparison_slide(prs, title, left_title, left_items, right_title, right_items):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    # Title
+    txBox = slide.shapes.add_textbox(Inches(1), Inches(0.5), Inches(11), Inches(1))
+    p = txBox.text_frame.add_paragraph()
+    p.text = title
+    p.font.size = Pt(32)
+    p.font.bold = True
+    # Left column
+    left = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(5), Inches(4.5))
+    # Right column
+    right = slide.shapes.add_textbox(Inches(7), Inches(2), Inches(5), Inches(4.5))
+    # ... populate columns
+```
+
+## ImpactMojo Use Cases
+
+### 101 Course Decks
+Generate the remaining 16 foundational course decks (complementing Gamma):
+- ~60 slides per deck
+- Indian folk art illustration style matching the track
+- Each slide: concept → example → reflection
+
+### Workshop Slide Packs
+Generate slide decks for the 3-day workshop programme:
+- Day 1: MEL Essentials (20 slides)
+- Day 2: Data & Methods (25 slides)
+- Day 3: Applied Practice (15 slides)
+
+### Pitch Decks
+Generate partnership/funder presentations showing platform impact metrics.
+
+### Course Summary Decks
+Condense a 13-module flagship course into a 15-slide summary deck.
+
+## Quality Checklist
+
+- [ ] No text below 16pt
+- [ ] Every slide has a visual element
+- [ ] No more than 2 consecutive same-layout slides
+- [ ] Track color applied consistently
+- [ ] ImpactMojo footer on every slide
+- [ ] 16:9 aspect ratio
+- [ ] Spelling/grammar checked
+- [ ] South Asian examples used (not Western defaults)
+
+## Output
+
+Save to `/exports/` or deliver to user. Typical output: `{course-slug}-deck.pptx`.

--- a/.claude/skills/seo/SKILL.md
+++ b/.claude/skills/seo/SKILL.md
@@ -1,31 +1,59 @@
 ---
-description: "Optimize ImpactMojo pages for search engines — meta tags, structured data, Open Graph, sitemap, and content strategy. Use when the user asks about SEO, search rankings, meta tags, structured data, or discoverability."
+description: "Optimize ImpactMojo pages for search engines — technical audits, meta tags, structured data, Open Graph, sitemap, Core Web Vitals, E-E-A-T content quality, schema markup, image optimization, AI search optimization, and multilingual SEO. Use when the user asks about SEO, search rankings, meta tags, structured data, discoverability, or site audit."
 ---
 
-# SEO Skill
+# SEO Skill — ImpactMojo
 
-Optimize impactmojo.in for search engine visibility and social sharing.
+Comprehensive SEO optimization for impactmojo.in. Organized into 12 sub-capabilities.
 
-## Core SEO Checklist
+---
 
-### Every HTML Page Must Have
+## 1. Technical SEO Audit
+
+Run a 9-category audit across the site:
+
+```bash
+# Check meta descriptions exist
+grep -rL '<meta name="description"' Games/*.html Labs/*.html courses/*/index.html BookSummaries/*.html
+
+# Check canonical URLs
+grep -rn 'rel="canonical"' Games/*.html Labs/*.html | head -20
+
+# Check viewport meta
+grep -rL 'name="viewport"' Games/*.html Labs/*.html
+
+# Check title tags
+grep -rn '<title>' Games/*.html Labs/*.html | grep -v "ImpactMojo"
+```
+
+**Categories:** Crawlability, Indexing, Metadata, Performance, Mobile, Security (HTTPS), Accessibility, Structured Data, Internal Linking.
+
+---
+
+## 2. Required Meta Tags (Every Page)
+
 ```html
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{Page Title} | ImpactMojo</title>
-<meta name="description" content="{150-160 char description}">
+<meta name="description" content="{150-160 char description with primary keyword}">
 <meta name="keywords" content="development economics, {topic}, South Asia, free education">
-<link rel="canonical" href="https://impactmojo.in/{path}">
+<link rel="canonical" href="https://www.impactmojo.in/{path}">
+<meta name="robots" content="index, follow">
 ```
 
-### Open Graph (Social Sharing)
+---
+
+## 3. Open Graph (Social Sharing)
+
 ```html
 <meta property="og:title" content="{Title}">
 <meta property="og:description" content="{Description}">
-<meta property="og:image" content="https://impactmojo.in/assets/{image}.png">
-<meta property="og:url" content="https://impactmojo.in/{path}">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/{image}.png">
+<meta property="og:url" content="https://www.impactmojo.in/{path}">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ImpactMojo">
+<meta property="og:locale" content="en_IN">
 ```
 
 ### Twitter Card
@@ -33,13 +61,15 @@ Optimize impactmojo.in for search engine visibility and social sharing.
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{Title}">
 <meta name="twitter:description" content="{Description}">
-<meta name="twitter:image" content="https://impactmojo.in/assets/{image}.png">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/{image}.png">
 ```
 
-### Structured Data (JSON-LD)
-For courses:
-```html
-<script type="application/ld+json">
+---
+
+## 4. Structured Data (JSON-LD)
+
+### Course Schema
+```json
 {
   "@context": "https://schema.org",
   "@type": "Course",
@@ -48,51 +78,187 @@ For courses:
   "provider": {
     "@type": "Organization",
     "name": "ImpactMojo",
-    "url": "https://impactmojo.in"
+    "url": "https://www.impactmojo.in",
+    "logo": "https://www.impactmojo.in/assets/images/ImpactMojo Logo.png"
   },
   "isAccessibleForFree": true,
   "educationalLevel": "Introductory",
-  "inLanguage": "en"
+  "inLanguage": ["en", "hi", "ta", "bn", "te", "mr"],
+  "numberOfCredits": 0,
+  "hasCourseInstance": {
+    "@type": "CourseInstance",
+    "courseMode": "online",
+    "courseWorkload": "PT2H"
+  }
 }
-</script>
 ```
 
-For games/interactive content:
-```html
-<script type="application/ld+json">
+### Game / Interactive Resource
+```json
 {
   "@context": "https://schema.org",
   "@type": "LearningResource",
   "name": "{Game Name}",
   "description": "{Description}",
-  "learningResourceType": "interactive",
-  "isAccessibleForFree": true
+  "learningResourceType": "interactive simulation",
+  "isAccessibleForFree": true,
+  "interactivityType": "active",
+  "educationalUse": "workshop, classroom, self-study"
 }
-</script>
 ```
 
-## Sitemap Management
-- File: `sitemap.xml`
-- Add `<url>` entry for every new page
-- Set `<lastmod>` to current date
-- Priority: `1.0` (homepage), `0.8` (courses), `0.7` (games/labs), `0.5` (handouts)
+### Book Summary
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Book",
+  "name": "{Book Title}",
+  "author": {"@type": "Person", "name": "{Author}"},
+  "review": {
+    "@type": "Review",
+    "reviewBody": "{Summary description}",
+    "author": {"@type": "Organization", "name": "ImpactMojo"}
+  }
+}
+```
 
-## Content SEO Strategy
-- **Title tags**: Include primary keyword + "| ImpactMojo"
-- **H1**: One per page, matches search intent
-- **Internal linking**: Cross-link related courses, games, and handouts
-- **Image alt text**: Descriptive, keyword-rich
-- **URL structure**: Clean, lowercase, hyphenated (`/courses/behavioral-economics/`)
+### Organization (homepage)
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "EducationalOrganization",
+  "name": "ImpactMojo",
+  "url": "https://www.impactmojo.in",
+  "description": "Free development education for social impact across South Asia",
+  "areaServed": ["IN", "BD", "NP", "LK"],
+  "availableLanguage": ["en", "hi", "ta", "bn", "te", "mr"]
+}
+```
+
+---
+
+## 5. E-E-A-T Content Quality
+
+Ensure pages demonstrate **Experience, Expertise, Authoritativeness, Trustworthiness**:
+
+- **Author attribution**: Link to Dr. Varna Sri Raman's profile on About page
+- **Citations**: Link to DevDiscourses papers, cite real programme evaluations
+- **Dates**: Show `lastmod` or "Updated: {date}" on content pages
+- **Credentials**: Mention academic background, field experience in South Asia
+- **External validation**: Link to GitHub stars, Netlify status, user testimonials
+
+---
+
+## 6. Image Optimization
+
+- **Alt text**: Descriptive, keyword-rich (`alt="Theory of Change workshop diagram for NGO evaluation"`)
+- **File size**: Compress via ImgBot (already integrated via PR #254)
+- **Format**: Use WebP where possible, PNG for illustrations with transparency
+- **Lazy loading**: Add `loading="lazy"` to below-fold images
+- **Dimensions**: Always set `width` and `height` to prevent CLS
+
+---
+
+## 7. Sitemap Management
+
+File: `sitemap.xml` — must include every public page.
+
+| Content type | Priority | changefreq |
+|---|---|---|
+| Homepage | `1.0` | weekly |
+| Courses | `0.8` | monthly |
+| Games | `0.6` | monthly |
+| Labs | `0.6` | monthly |
+| BookSummaries | `0.7` | monthly |
+| Blog posts | `0.6` | monthly |
+| Legal pages | `0.4` | yearly |
+
+**Validation:**
+```bash
+# Count sitemap URLs vs actual files
+python3 -c "
+import xml.etree.ElementTree as ET
+tree = ET.parse('sitemap.xml')
+ns = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+urls = tree.getroot().findall('s:url', ns)
+print(f'Sitemap URLs: {len(urls)}')
+"
+```
+
+---
+
+## 8. Core Web Vitals
+
+Target scores for Lighthouse:
+- **LCP** (Largest Contentful Paint): < 2.5s
+- **FID** (First Input Delay): < 100ms
+- **CLS** (Cumulative Layout Shift): < 0.1
+
+Key optimizations for static site:
+- Inline critical CSS (already done — no external stylesheets on games/labs)
+- Preload Google Fonts with `<link rel="preload">`
+- Defer non-critical JS with `defer` attribute
+- Set explicit image dimensions to prevent layout shift
+
+---
+
+## 9. AI Search Optimization (GEO)
+
+Optimize for Google AI Overviews and ChatGPT/Perplexity citations:
+
+- **FAQ sections**: Add FAQ schema to key pages (courses, about, pricing)
+- **Definition lists**: Structure content as clear Q&A or definition → explanation
+- **Concise answers**: First paragraph of each section should directly answer the implied question
+- **Cite sources**: Link to authoritative papers and datasets
+- **Unique data**: Highlight platform-specific stats (269 Dataverse entries, 203 BCT techniques, 200 case studies from 117 countries)
+
+---
+
+## 10. Multilingual SEO (hreflang)
+
+ImpactMojo supports 6 languages. Add hreflang tags on pages with translations:
+
+```html
+<link rel="alternate" hreflang="en" href="https://www.impactmojo.in/{path}">
+<link rel="alternate" hreflang="hi" href="https://www.impactmojo.in/{path}?lang=hi">
+<link rel="alternate" hreflang="ta" href="https://www.impactmojo.in/{path}?lang=ta">
+<link rel="alternate" hreflang="x-default" href="https://www.impactmojo.in/{path}">
+```
+
+---
+
+## 11. Internal Linking Strategy
+
+- Every game links to related course modules
+- Every lab links to the course it supports
+- Every course links to relevant handouts, games, and labs
+- BookSummaries link to related DevDiscourses papers
+- Blog posts link to relevant platform content
+
+**Anchor text**: Use descriptive text, not "click here".
+
+---
+
+## 12. ImpactMojo Keyword Clusters
+
+| Cluster | Primary keywords |
+|---------|-----------------|
+| Core platform | free development education, South Asia learning platform, NGO training |
+| MEL | monitoring evaluation learning, theory of change, logframe |
+| Economics | development economics course free, behavioral economics simulation |
+| Gender | gender mainstreaming course, feminist research methods |
+| Games | economics simulation game, public goods game, prisoner's dilemma interactive |
+| Data | development data tools, India datasets, Dataverse |
+| Premium | MEL workshop India, development coaching, research consultation |
+
+---
 
 ## Audit Workflow
-1. Check all pages have required meta tags: `grep -rn '<meta name="description"' *.html courses/**/*.html Games/**/*.html`
-2. Validate sitemap completeness: compare sitemap URLs vs actual files
-3. Check for missing Open Graph tags
-4. Verify canonical URLs resolve correctly
-5. Test structured data with Google Rich Results validator
 
-## ImpactMojo-Specific Keywords
-- development economics, South Asia, free courses
-- behavioral economics games, RCT simulation
-- poverty measurement, microfinance, gender economics
-- interactive learning, development studies
+1. **Technical**: Check meta tags, canonicals, viewport, robots on all pages
+2. **Content**: Verify E-E-A-T signals, keyword coverage, internal links
+3. **Schema**: Validate JSON-LD with Google Rich Results Test
+4. **Sitemap**: Cross-check sitemap vs actual files
+5. **Images**: Check alt text coverage, file sizes, lazy loading
+6. **Performance**: Run Lighthouse on key pages
+7. **Social**: Verify OG/Twitter cards render correctly


### PR DESCRIPTION
## Summary
- **SEO skill upgraded** from basic checklist to 12 sub-capabilities: technical audit, E-E-A-T, schema markup (Course/Book/Org), Core Web Vitals, AI search optimization (GEO), multilingual hreflang, keyword clusters
- **PDF Processing skill** — extract, create, merge, split PDFs. Handout packs, course exports, workshop materials
- **PPTX skill** — generate slide decks with track-specific colors and folk art theming. Complements Gamma for remaining 16 course decks

## New skills
| Skill | Trigger |
|-------|---------|
| `seo` (upgraded) | "SEO audit", "meta tags", "structured data", "sitemap" |
| `pdf-processing` | "generate handout pack", "PDF export", "merge chapters" |
| `pptx` | "create slides", "build a deck", "export as PPTX" |

https://claude.ai/code/session_01NRyWEsHgbfSK4j1cJdf6Qa