### PR TITLE
Fix auth persistence: add state-manager.js to 7 pages

### DIFF
--- a/BookSummaries/index.html
+++ b/BookSummaries/index.html
@@ -1782,6 +1782,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 </script>
+<script defer src="/js/state-manager.js"></script>
 <script defer src="/js/config.js"></script>
 <script defer src="/js/auth.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->

--- a/admin/cms.html
+++ b/admin/cms.html
@@ -664,6 +664,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 
 <!-- Scripts -->
+<script src="/js/state-manager.js"></script>
 <script src="/js/config.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="/js/auth.js"></script>

--- a/admin/index.html
+++ b/admin/index.html
@@ -1395,6 +1395,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
 <!-- Scripts -->
 <script src="https://accounts.google.com/gsi/client" async defer></script>
+<script src="/js/state-manager.js"></script>
 <script src="/js/config.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="/js/auth.js"></script>

--- a/coaching.html
+++ b/coaching.html
@@ -1510,6 +1510,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
 <!-- Supabase & Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="js/state-manager.js"></script>
 <script src="js/config.js"></script>
 <script src="js/auth.js"></script>
 

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -2190,6 +2190,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
 <!-- Supabase JS -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="js/state-manager.js"></script>
 <script src="js/config.js"></script>
 <script src="js/auth.js"></script>
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -886,6 +886,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <!-- Auth & Premium Scripts -->
+<script src="js/state-manager.js"></script>
 <script src="js/config.js"></script>
 <script src="js/auth.js"></script>
 <script>

--- a/premium.html
+++ b/premium.html
@@ -2112,6 +2112,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+<script defer src="js/state-manager.js"></script>
 <script defer src="js/config.js"></script>
 <script defer src="js/auth.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- **Root cause found**: 7 pages loaded `auth.js` without `state-manager.js`, causing `window.IMState` to be undefined
- This broke the cached profile system — users' login state appeared lost when navigating to these pages
- Profile fetch failures caused tier-gating race conditions (users redirected to login or shown wrong tier)

## Pages fixed
| Page | Issue |
|------|-------|
| `premium.html` | Missing state-manager.js (deferred) |
| `admin/index.html` | Missing state-manager.js |
| `admin/cms.html` | Missing state-manager.js |
| `coaching.html` | Missing state-manager.js |
| `portfolio.html` | Missing state-manager.js |
| `forgot-password.html` | Missing state-manager.js |
| `BookSummaries/index.html` | Missing state-manager.js (deferred) |

## How it works
`state-manager.js` initializes `window.IMState` which provides:
- Cached profile in localStorage (`impactmojo_cached_profile`)
- Instant UI updates on page load while fresh profile fetches in background
- Profile deduplication preventing race conditions

Without it, `auth.js` falls back to direct localStorage but the cached profile system breaks, causing auth gates to see no profile during the fetch window.

https://claude.ai/code/session_01NRyWEsHgbfSK4j1cJdf6Qa