### PR TITLE
Add auth state persistence to all 279 pages

### DIFF
--- a/101-courses/SRHR-basics.html
+++ b/101-courses/SRHR-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/advocacy-basics.html
+++ b/101-courses/advocacy-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/bcc-comms.html
+++ b/101-courses/bcc-comms.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/bi-analysis.html
+++ b/101-courses/bi-analysis.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/care-economy-101.html
+++ b/101-courses/care-economy-101.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/climate-essentials.html
+++ b/101-courses/climate-essentials.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/community-dev.html
+++ b/101-courses/community-dev.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/cost-effectiveness.html
+++ b/101-courses/cost-effectiveness.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/data-feminism.html
+++ b/101-courses/data-feminism.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/data-lit.html
+++ b/101-courses/data-lit.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/decent-work.html
+++ b/101-courses/decent-work.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/decolonize-dev.html
+++ b/101-courses/decolonize-dev.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/dev-architecture.html
+++ b/101-courses/dev-architecture.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/dev-economics.html
+++ b/101-courses/dev-economics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/digital-ethics.html
+++ b/101-courses/digital-ethics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/econometrics-101.html
+++ b/101-courses/econometrics-101.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/eda-hhs.html
+++ b/101-courses/eda-hhs.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/edu-pedagogy.html
+++ b/101-courses/edu-pedagogy.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/eng-dev.html
+++ b/101-courses/eng-dev.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/env-justice.html
+++ b/101-courses/env-justice.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/fundraising-basics.html
+++ b/101-courses/fundraising-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/ind-constitution.html
+++ b/101-courses/ind-constitution.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/inequality-basics.html
+++ b/101-courses/inequality-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/irt-basics.html
+++ b/101-courses/irt-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/livelihood-basics.html
+++ b/101-courses/livelihood-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/mel-basics.html
+++ b/101-courses/mel-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/multivariate-basics.html
+++ b/101-courses/multivariate-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/obs2insight.html
+++ b/101-courses/obs2insight.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/pol-economy.html
+++ b/101-courses/pol-economy.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/post-truth-101.html
+++ b/101-courses/post-truth-101.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/pub-health-basics.html
+++ b/101-courses/pub-health-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/qual-methods.html
+++ b/101-courses/qual-methods.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/research-ethics.html
+++ b/101-courses/research-ethics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/sel-basics.html
+++ b/101-courses/sel-basics.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/social-margins.html
+++ b/101-courses/social-margins.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/toc-workbench.html
+++ b/101-courses/toc-workbench.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/visual-eth.html
+++ b/101-courses/visual-eth.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/101-courses/wee-studies.html
+++ b/101-courses/wee-studies.html
@@ -58,5 +58,11 @@
     <span>CC BY-NC-SA 4.0</span>
     <span>ImpactMojo 101 Series</span>
   </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -1996,5 +1996,11 @@ document.addEventListener('click', function(e) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookCompanionTools/budget-template-generator.html
+++ b/BookCompanionTools/budget-template-generator.html
@@ -1223,5 +1223,11 @@ function showToast(msg) {
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookCompanionTools/sample-size-calculator.html
+++ b/BookCompanionTools/sample-size-calculator.html
@@ -1175,5 +1175,11 @@ Where:
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/21-laws-leadership-companion.html
+++ b/BookSummaries/21-laws-leadership-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/22-laws-marketing-companion.html
+++ b/BookSummaries/22-laws-marketing-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/atomic-habits-companion.html
+++ b/BookSummaries/atomic-habits-companion.html
@@ -466,5 +466,11 @@
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/basic-econometrics-companion.html
+++ b/BookSummaries/basic-econometrics-companion.html
@@ -268,5 +268,11 @@ The user is a PhD development economist and qualified lawyer with expertise in e
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/damned-lies-companion.html
+++ b/BookSummaries/damned-lies-companion.html
@@ -324,5 +324,11 @@ Question: ${E}`}]}]})}),t=await e.json();N(t?.candidates?.[0]?.content?.parts?.[
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/debraj-ray-companion.html
+++ b/BookSummaries/debraj-ray-companion.html
@@ -349,5 +349,11 @@ function e(e,t,n,r){Object.defineProperty(e,t,{get:n,set:r,enumerable:!0,configu
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/deep-work-companion.html
+++ b/BookSummaries/deep-work-companion.html
@@ -265,5 +265,11 @@
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/dt-companion.html
+++ b/BookSummaries/dt-companion.html
@@ -2767,5 +2767,11 @@ function useStarter(btn) {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/eat-frog-companion.html
+++ b/BookSummaries/eat-frog-companion.html
@@ -265,5 +265,11 @@
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/econometrics-by-example-companion.html
+++ b/BookSummaries/econometrics-by-example-companion.html
@@ -278,5 +278,11 @@ The user is a PhD development economist and qualified lawyer. Give technically p
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/four-hour-workweek-companion.html
+++ b/BookSummaries/four-hour-workweek-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/gog-companion.html
+++ b/BookSummaries/gog-companion.html
@@ -115,5 +115,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/grit-companion.html
+++ b/BookSummaries/grit-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/handbook-social-protection.html
+++ b/BookSummaries/handbook-social-protection.html
@@ -116,5 +116,11 @@ Provide nuanced, evidence-based answers. Clearly signal evidence quality (strong
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/influence-companion.html
+++ b/BookSummaries/influence-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/info-we-trust-companion.html
+++ b/BookSummaries/info-we-trust-companion.html
@@ -326,5 +326,11 @@ Question: ${S}`}]}]})}),t=await e.json();z(t?.candidates?.[0]?.content?.parts?.[
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/ipcc-climate-communication-companion.html
+++ b/BookSummaries/ipcc-climate-communication-companion.html
@@ -325,5 +325,11 @@ Question: ${k}`}]}]})}),t=await e.json();E(t?.candidates?.[0]?.content?.parts?.[
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/naked-stats-companion.html
+++ b/BookSummaries/naked-stats-companion.html
@@ -115,5 +115,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/presuasion-companion.html
+++ b/BookSummaries/presuasion-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/radical-candor-companion.html
+++ b/BookSummaries/radical-candor-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/rsoe-companion.html
+++ b/BookSummaries/rsoe-companion.html
@@ -115,5 +115,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/swd-companion.html
+++ b/BookSummaries/swd-companion.html
@@ -115,5 +115,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/ted-talks-companion.html
+++ b/BookSummaries/ted-talks-companion.html
@@ -265,5 +265,11 @@
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/thinking-in-systems-companion.html
+++ b/BookSummaries/thinking-in-systems-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/to-sell-is-human-companion.html
+++ b/BookSummaries/to-sell-is-human-companion.html
@@ -670,5 +670,11 @@ function switchTab(id) {
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/truthful-art-companion.html
+++ b/BookSummaries/truthful-art-companion.html
@@ -328,5 +328,11 @@ Question: ${z}`}]}]})}),t=await e.json();P(t?.candidates?.[0]?.content?.parts?.[
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/tufte-companion.html
+++ b/BookSummaries/tufte-companion.html
@@ -115,5 +115,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/BookSummaries/ultralearning-companion.html
+++ b/BookSummaries/ultralearning-companion.html
@@ -395,5 +395,11 @@ body{background:var(--bg);font-family:'Source Serif 4','Georgia',serif;color:var
 })();
 </script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/bidding-wars-game.html
+++ b/Games/bidding-wars-game.html
@@ -1997,5 +1997,11 @@ function spawnConfetti(){
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/climate-action-game.html
+++ b/Games/climate-action-game.html
@@ -1845,5 +1845,11 @@ function resetGame() {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/commons-crisis-game.html
+++ b/Games/commons-crisis-game.html
@@ -1899,5 +1899,11 @@ window.addEventListener('resize', function(){
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/cooperation-paradox-game.html
+++ b/Games/cooperation-paradox-game.html
@@ -1919,5 +1919,11 @@ window.restartGame = function() {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/digital-ethics-game.html
+++ b/Games/digital-ethics-game.html
@@ -1487,5 +1487,11 @@ window.restartGame = function() {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/econ-concepts-game.html
+++ b/Games/econ-concepts-game.html
@@ -1596,5 +1596,11 @@ init();
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -1000,5 +1000,11 @@ function resetGame(){
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/gender-equity-game.html
+++ b/Games/gender-equity-game.html
@@ -1494,5 +1494,11 @@ function generateEndArt(score) {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/info-asymmetry-game.html
+++ b/Games/info-asymmetry-game.html
@@ -2052,5 +2052,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/network-effects-game.html
+++ b/Games/network-effects-game.html
@@ -2823,5 +2823,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/opportunity-cost-game.html
+++ b/Games/opportunity-cost-game.html
@@ -2146,5 +2146,11 @@ updateBarVisuals();
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/prisoners-dilemma-game.html
+++ b/Games/prisoners-dilemma-game.html
@@ -2084,5 +2084,11 @@ init();
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/public-good-game.html
+++ b/Games/public-good-game.html
@@ -3239,5 +3239,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/public-health-game.html
+++ b/Games/public-health-game.html
@@ -1904,5 +1904,11 @@ function resetGame() {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/real-middle-india.html
+++ b/Games/real-middle-india.html
@@ -2068,5 +2068,11 @@ window.addEventListener("resize", function() {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Games/risk-reward-game.html
+++ b/Games/risk-reward-game.html
@@ -1617,5 +1617,11 @@ function drawPTCurve(){
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Case Studies/case_study_template.html
+++ b/Handouts/Cross Cutting Resources/Case Studies/case_study_template.html
@@ -763,5 +763,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Case Studies/case_study_worksheets.html
+++ b/Handouts/Cross Cutting Resources/Case Studies/case_study_worksheets.html
@@ -1313,5 +1313,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Communications/communication_guide.html
+++ b/Handouts/Cross Cutting Resources/Communications/communication_guide.html
@@ -1025,5 +1025,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Local Application Worksheet/local_application_worksheet.html
+++ b/Handouts/Cross Cutting Resources/Local Application Worksheet/local_application_worksheet.html
@@ -918,5 +918,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Cross Cutting Resources/Software Tools Guide/software_tools_guide.html
+++ b/Handouts/Cross Cutting Resources/Software Tools Guide/software_tools_guide.html
@@ -1080,5 +1080,11 @@ Examples:<br>
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_guide.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_guide.html
@@ -916,5 +916,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_1.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_1.html
@@ -1167,5 +1167,11 @@ All pairwise comparisons significant at p < 0.001
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_2.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_2.html
@@ -1235,5 +1235,11 @@ With FDR (q = 0.05): 34 remain significant
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_quick_reference.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_quick_reference.html
@@ -810,5 +810,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_workshop_exercises.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_workshop_exercises.html
@@ -792,5 +792,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout.html
@@ -872,5 +872,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_1.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_1.html
@@ -956,5 +956,11 @@ Additional Data:
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_2.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_2.html
@@ -992,5 +992,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/EDA/eda_survey_handout_1.html
+++ b/Handouts/Data and Technology Track/EDA/eda_survey_handout_1.html
@@ -1111,5 +1111,11 @@ outliers <- data$v447a < (Q1 - 1.5*IQR) | data$v447a > (Q3 + 1.5*IQR)
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/EDA/eda_survey_handout_2.html
+++ b/Handouts/Data and Technology Track/EDA/eda_survey_handout_2.html
@@ -1149,5 +1149,11 @@ change_data <- data %>%
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/common_mistakes_guide.html
+++ b/Handouts/Data and Technology Track/Econometrics/common_mistakes_guide.html
@@ -1228,5 +1228,11 @@ stargazer(model1, model2,
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_formula_sheet.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_formula_sheet.html
@@ -970,5 +970,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_handout_1.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_handout_1.html
@@ -1106,5 +1106,11 @@ N = 8,543    R² = 0.42    F-statistic = 524.3
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_handout_2.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_handout_2.html
@@ -1254,5 +1254,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_problem_sets.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_problem_sets.html
@@ -1501,5 +1501,11 @@ dynamic_fe <- feols(log_output ~ trained + trained_lag1 + trained_lag2 +
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_1.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_1.html
@@ -888,5 +888,11 @@ Where:
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_2.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_2.html
@@ -1058,5 +1058,11 @@ model = smf.ols('test_score ~ teacher_training + infrastructure +
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_template.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_template.html
@@ -866,5 +866,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_problem_sets.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_problem_sets.html
@@ -1131,5 +1131,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_quick_reference.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_quick_reference.html
@@ -882,5 +882,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Education and Pedagogy/education_pedagogy_handout.html
+++ b/Handouts/Education and Pedagogy/education_pedagogy_handout.html
@@ -969,5 +969,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Education and Pedagogy/education_pedagogy_handout_2.html
+++ b/Handouts/Education and Pedagogy/education_pedagogy_handout_2.html
@@ -1420,5 +1420,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_1.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_1.html
@@ -846,5 +846,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_2.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_2.html
@@ -883,5 +883,11 @@ enrollment_rates <- data %>%
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_south_asia.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_south_asia.html
@@ -778,5 +778,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_handout.html
+++ b/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_handout.html
@@ -971,5 +971,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_quick_reference.html
+++ b/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_quick_reference.html
@@ -888,5 +888,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_1.html
+++ b/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_1.html
@@ -905,5 +905,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_2.html
+++ b/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_2.html
@@ -1028,5 +1028,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_1.html
+++ b/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_1.html
@@ -963,5 +963,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_2.html
+++ b/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_2.html
@@ -999,5 +999,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/Assumptions Checklist/assumptions_checklist.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Assumptions Checklist/assumptions_checklist.html
@@ -1067,5 +1067,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_1.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_1.html
@@ -1182,5 +1182,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_2.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_2.html
@@ -1436,5 +1436,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/Qualitative Research/qualitative_research_handout.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Qualitative Research/qualitative_research_handout.html
@@ -1222,5 +1222,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Monitoring Evaluation and Learning Track/Research Design Worksheet/research_design_worksheet.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Research Design Worksheet/research_design_worksheet.html
@@ -1235,5 +1235,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_1.html
+++ b/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_1.html
@@ -1010,5 +1010,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_2.html
+++ b/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_2.html
@@ -1158,5 +1158,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Development Economics/development_economics_handout.html
+++ b/Handouts/Policy and Economics Track/Development Economics/development_economics_handout.html
@@ -1091,5 +1091,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Development Economics/development_economics_problem_sets.html
+++ b/Handouts/Policy and Economics Track/Development Economics/development_economics_problem_sets.html
@@ -982,5 +982,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Livelihoods/livelihood_assessment_toolkit.html
+++ b/Handouts/Policy and Economics Track/Livelihoods/livelihood_assessment_toolkit.html
@@ -1720,5 +1720,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Livelihoods/livelihoods_handout.html
+++ b/Handouts/Policy and Economics Track/Livelihoods/livelihoods_handout.html
@@ -1306,5 +1306,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Policy Tracking/policy_tracking_sheet.html
+++ b/Handouts/Policy and Economics Track/Policy Tracking/policy_tracking_sheet.html
@@ -905,5 +905,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_1.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_1.html
@@ -1087,5 +1087,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_2.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_2.html
@@ -1246,5 +1246,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_1.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_1.html
@@ -960,5 +960,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_2.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_2.html
@@ -1216,5 +1216,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_1.html
+++ b/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_1.html
@@ -1226,5 +1226,11 @@ Interpretation:
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_2.html
+++ b/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_2.html
@@ -1194,5 +1194,11 @@ Method C (Self-Targeting):
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/safety_nets_south_asia.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/safety_nets_south_asia.html
@@ -871,5 +871,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_1.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_1.html
@@ -973,5 +973,11 @@ Program Data:
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_2.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_2.html
@@ -961,5 +961,11 @@ Proposed Digital System:
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Quick Reference Cards/quick_reference_cards.html
+++ b/Handouts/Quick Reference Cards/quick_reference_cards.html
@@ -916,5 +916,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout.html
@@ -1082,5 +1082,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_1.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_1.html
@@ -880,5 +880,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_2.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_2.html
@@ -985,5 +985,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_dashboard_south_asia.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_dashboard_south_asia.html
@@ -1053,5 +1053,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_1.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_1.html
@@ -1196,5 +1196,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_2.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_2.html
@@ -1583,5 +1583,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_1.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_1.html
@@ -954,5 +954,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_2.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_2.html
@@ -1009,5 +1009,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_1.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_1.html
@@ -1021,5 +1021,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_2.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_2.html
@@ -1174,5 +1174,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_practical_skills.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_practical_skills.html
@@ -1249,5 +1249,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/AI Bias and Algorithmic Justice/handout_3_ai_bias.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/AI Bias and Algorithmic Justice/handout_3_ai_bias.html
@@ -668,5 +668,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Digital Justice and Data Consent/handout_4_consent.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Digital Justice and Data Consent/handout_4_consent.html
@@ -727,5 +727,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Digital Surveillance and State Power/handout_1_surveillance.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Digital Surveillance and State Power/handout_1_surveillance.html
@@ -559,5 +559,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_1.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_1.html
@@ -939,5 +939,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_2.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_2.html
@@ -1178,5 +1178,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Platform Labour and Digital Governance/handout_2_platforms.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Platform Labour and Digital Governance/handout_2_platforms.html
@@ -634,5 +634,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_assessment_framework.html
+++ b/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_assessment_framework.html
@@ -1297,5 +1297,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_handout.html
+++ b/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_handout.html
@@ -1173,5 +1173,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_1.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_1.html
@@ -1111,5 +1111,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_2.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_2.html
@@ -1416,5 +1416,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_1.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_1.html
@@ -1008,5 +1008,11 @@ MGNREGA Performance Data (2022-23):
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_2.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_2.html
@@ -1016,5 +1016,11 @@ e-Shram Performance Data (as of 2024):
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_south_asia.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_south_asia.html
@@ -1034,5 +1034,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/South Aisa Region/South Asia Historical - Modern Policy Timeline/historical_timeline.html
+++ b/Handouts/Thematic Areas/South Aisa Region/South Asia Historical - Modern Policy Timeline/historical_timeline.html
@@ -917,5 +917,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/Thematic Areas/South Aisa Region/South Asia Regional Dashboard/regional_dashboard.html
+++ b/Handouts/Thematic Areas/South Aisa Region/South Asia Regional Dashboard/regional_dashboard.html
@@ -702,5 +702,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Handouts/index.html
+++ b/Handouts/index.html
@@ -796,5 +796,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </div>
 </div>
 </footer>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/ImpactMojo_PressKit.html
+++ b/ImpactMojo_PressKit.html
@@ -999,5 +999,11 @@ function cp(btn){
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/community-lab.html
+++ b/Labs/community-lab.html
@@ -1470,5 +1470,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/design-thinking-lab.html
+++ b/Labs/design-thinking-lab.html
@@ -1548,5 +1548,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/gender-studies-lab.html
+++ b/Labs/gender-studies-lab.html
@@ -998,5 +998,11 @@ loadState(); renderRoles(); renderAccess(); renderMargGroups(); renderInterventi
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/impact-partnerships-lab.html
+++ b/Labs/impact-partnerships-lab.html
@@ -1492,5 +1492,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/mel-design-lab.html
+++ b/Labs/mel-design-lab.html
@@ -922,5 +922,11 @@ loadState(); renderKEQs(); renderIndicators(); renderTimeline(); renderReports()
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/mel-plan-lab.html
+++ b/Labs/mel-plan-lab.html
@@ -920,5 +920,11 @@ loadState(); renderObjectives(); renderMatrix(); renderCalendar(); renderReports
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/policy-advocacy-lab.html
+++ b/Labs/policy-advocacy-lab.html
@@ -889,5 +889,11 @@ renderDecisionMakers(); renderEvidence(); renderStakeholders(); renderObjectives
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/resource-sustainability-lab.html
+++ b/Labs/resource-sustainability-lab.html
@@ -1509,5 +1509,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/risk-mitigation-lab.html
+++ b/Labs/risk-mitigation-lab.html
@@ -1398,5 +1398,11 @@ renderRiskList();
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/storytelling-lab.html
+++ b/Labs/storytelling-lab.html
@@ -1304,5 +1304,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/Labs/toc-lab.html
+++ b/Labs/toc-lab.html
@@ -1463,5 +1463,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/PAGE-TEMPLATE.html
+++ b/PAGE-TEMPLATE.html
@@ -1600,5 +1600,11 @@ document.addEventListener('click', function(e) {
 <!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
 <script defer src="js/translate.js"></script>
 
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/SupportGifts/thankyou.html
+++ b/SupportGifts/thankyou.html
@@ -774,5 +774,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -2733,5 +2733,11 @@ document.addEventListener('click', function(e) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/admin/analytics.html
+++ b/admin/analytics.html
@@ -1636,5 +1636,11 @@ render();
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/ai-policy.html
+++ b/ai-policy.html
@@ -1356,5 +1356,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -2497,5 +2497,11 @@ window.addEventListener('hashchange', handleHash);
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -2908,5 +2908,11 @@ document.addEventListener('click', function(e) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/adaptive-management-toc.html
+++ b/blog/adaptive-management-toc.html
@@ -496,5 +496,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/assumption-testing.html
+++ b/blog/assumption-testing.html
@@ -498,5 +498,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/building-mel-culture.html
+++ b/blog/building-mel-culture.html
@@ -466,5 +466,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/community-feedback-loops.html
+++ b/blog/community-feedback-loops.html
@@ -466,5 +466,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/data-driven-decisions.html
+++ b/blog/data-driven-decisions.html
@@ -467,5 +467,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/data-quality-field.html
+++ b/blog/data-quality-field.html
@@ -501,5 +501,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/ethical-research-south-asia.html
+++ b/blog/ethical-research-south-asia.html
@@ -470,5 +470,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/from-learner-to-leader.html
+++ b/blog/from-learner-to-leader.html
@@ -833,5 +833,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/github-open-dev-ecosystem.html
+++ b/blog/github-open-dev-ecosystem.html
@@ -605,5 +605,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/history-of-mel.html
+++ b/blog/history-of-mel.html
@@ -505,5 +505,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/indicators-that-matter.html
+++ b/blog/indicators-that-matter.html
@@ -475,5 +475,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/learning-by-doing.html
+++ b/blog/learning-by-doing.html
@@ -740,5 +740,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/meal-demystified.html
+++ b/blog/meal-demystified.html
@@ -1123,5 +1123,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/mixed-methods-evaluation.html
+++ b/blog/mixed-methods-evaluation.html
@@ -469,5 +469,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/multilingual-learning.html
+++ b/blog/multilingual-learning.html
@@ -468,5 +468,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/open-education-matters.html
+++ b/blog/open-education-matters.html
@@ -464,5 +464,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/participatory-mel.html
+++ b/blog/participatory-mel.html
@@ -497,5 +497,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/quasi-experimental-designs.html
+++ b/blog/quasi-experimental-designs.html
@@ -470,5 +470,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/sample-size-matters.html
+++ b/blog/sample-size-matters.html
@@ -784,5 +784,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/south-asia-development-landscape.html
+++ b/blog/south-asia-development-landscape.html
@@ -468,5 +468,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/theory-of-change-pitfalls.html
+++ b/blog/theory-of-change-pitfalls.html
@@ -1024,5 +1024,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/toc-for-complex-programmes.html
+++ b/blog/toc-for-complex-programmes.html
@@ -491,5 +491,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/toc-vs-logframe.html
+++ b/blog/toc-vs-logframe.html
@@ -496,5 +496,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/tools-we-use.html
+++ b/blog/tools-we-use.html
@@ -467,5 +467,11 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/whats-coming-in-2026.html
+++ b/blog/whats-coming-in-2026.html
@@ -944,5 +944,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/blog/why-impactmojo-exists.html
+++ b/blog/why-impactmojo-exists.html
@@ -1019,5 +1019,11 @@ function updateThemeIcons() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/catalog.html
+++ b/catalog.html
@@ -2630,5 +2630,11 @@ document.addEventListener('click', function(e) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/challenges.html
+++ b/challenges.html
@@ -941,5 +941,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/climate-trace-india.html
+++ b/climate-trace-india.html
@@ -1189,5 +1189,11 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/community/index.html
+++ b/community/index.html
@@ -1637,5 +1637,11 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1780,5 +1780,11 @@ document.addEventListener('DOMContentLoaded', function() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/content-marketing-kit.html
+++ b/content-marketing-kit.html
@@ -1602,5 +1602,11 @@ function gt(id,i){gcs(id).cur=i;upd(id);}
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -3419,5 +3419,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="/js/pwa.js" defer></script>
 <script src="/js/offline.js" defer></script>
 <script defer src="../../js/auto-refresh.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/SEL/lexicon.html
+++ b/courses/SEL/lexicon.html
@@ -602,5 +602,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -4117,5 +4117,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/dataviz/lexicon.html
+++ b/courses/dataviz/lexicon.html
@@ -837,5 +837,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -1553,5 +1553,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/devai/lexicon.html
+++ b/courses/devai/lexicon.html
@@ -649,5 +649,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -3678,5 +3678,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/devecon/lexicon.html
+++ b/courses/devecon/lexicon.html
@@ -1341,5 +1341,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -3578,5 +3578,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/gandhi/lexicon.html
+++ b/courses/gandhi/lexicon.html
@@ -2179,5 +2179,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -2003,5 +2003,11 @@ sections.forEach(section => {
         });
 
     </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/gender/lexicon.html
+++ b/courses/gender/lexicon.html
@@ -663,5 +663,11 @@ renderLexicon();
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -3652,5 +3652,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/law/lexicon.html
+++ b/courses/law/lexicon.html
@@ -602,5 +602,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -3840,5 +3840,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/media/media-lexicon.html
+++ b/courses/media/media-lexicon.html
@@ -598,5 +598,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3909,5 +3909,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/mel/lexicon.html
+++ b/courses/mel/lexicon.html
@@ -602,5 +602,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -3772,5 +3772,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/poa/lexicon.html
+++ b/courses/poa/lexicon.html
@@ -888,5 +888,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -1204,5 +1204,11 @@
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/courses/pubpol/lexicon.html
+++ b/courses/pubpol/lexicon.html
@@ -455,5 +455,11 @@ document.addEventListener('DOMContentLoaded', renderTerms);
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/data-protection.html
+++ b/data-protection.html
@@ -2038,5 +2038,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/dataverse.html
+++ b/dataverse.html
@@ -2204,5 +2204,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1494,5 +1494,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/dojos.html
+++ b/dojos.html
@@ -2061,5 +2061,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -2283,5 +2283,11 @@ function searchFAQ() {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/grievance.html
+++ b/grievance.html
@@ -1895,5 +1895,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/handouts.html
+++ b/handouts.html
@@ -1892,5 +1892,11 @@ loadHandouts();
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/live-projects.html
+++ b/live-projects.html
@@ -1311,5 +1311,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 </svg>
 
 <script defer src="js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -505,5 +505,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/podcast.html
+++ b/podcast.html
@@ -2086,5 +2086,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/premium-tools/code-converter-pro.html
+++ b/premium-tools/code-converter-pro.html
@@ -921,5 +921,11 @@ function loadSnippet(idx) {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/premium-tools/qual-insights-lab.html
+++ b/premium-tools/qual-insights-lab.html
@@ -942,5 +942,11 @@ renderMemos();
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/premium-tools/rq-builder.html
+++ b/premium-tools/rq-builder.html
@@ -884,5 +884,11 @@ function copyOutput() {
 </footer>
 
 <script defer src="../js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1430,5 +1430,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1581,5 +1581,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -1341,5 +1341,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1530,5 +1530,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -913,5 +913,11 @@ function filterLang(lang) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/toc-builder.html
+++ b/toc-builder.html
@@ -1350,5 +1350,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change',func
 </footer>
 
 <script defer src="js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/toc-workbench.html
+++ b/toc-workbench.html
@@ -1407,5 +1407,11 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change',func
 </svg>
 
 <script defer src="js/translate.js"></script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/transparency.html
+++ b/transparency.html
@@ -1417,5 +1417,11 @@ window.addEventListener('resize', function() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/updates.html
+++ b/updates.html
@@ -956,5 +956,11 @@ function toggleCard(card) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/verify-certificate.html
+++ b/verify-certificate.html
@@ -1074,5 +1074,11 @@ document.addEventListener('DOMContentLoaded', function() {
     <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
     <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>

--- a/workshops.html
+++ b/workshops.html
@@ -1871,5 +1871,11 @@ function addBotMessage(text) {
     });
 })();
 </script>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Added Supabase auth stack (supabase-js, state-manager.js, config.js, auth.js) to **all 279 HTML pages**
- Previously only 12 pages had auth — users lost login state when navigating anywhere else
- 267 files changed, 1602 insertions

## What this fixes
Login now persists across every page on the platform — courses, games, labs, handouts, BookSummaries, blog posts, tools, legal pages. No more logouts on navigation.

https://claude.ai/code/session_01NRyWEsHgbfSK4j1cJdf6Qa