### PR TITLE
Add taranga.sriraman@gmail.com as organization-tier user

### DIFF
--- a/supabase/migrations/20260326_add_taranga_user.sql
+++ b/supabase/migrations/20260326_add_taranga_user.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- Add taranga.sriraman@gmail.com as organization-tier user
+-- Date: 2026-03-26
+--
+-- Grants organization (highest) subscription tier without
+-- admin role. User was created via Auth Admin API.
+-- ============================================================
+
+UPDATE public.profiles
+SET
+    subscription_tier   = 'organization',
+    subscription_status = 'active',
+    role                = 'learner',
+    updated_at          = NOW()
+WHERE email = 'taranga.sriraman@gmail.com';


### PR DESCRIPTION
## Summary
- Adds migration to set `taranga.sriraman@gmail.com` to organization tier (highest plan) with learner role (non-admin)
- Auth user already created and profile updated live in Supabase
- Migration file tracked for reproducibility

## Changes
- `supabase/migrations/20260326_add_taranga_user.sql` — UPDATE profile to organization tier

https://claude.ai/code/session_01MFevcdtTodkXiGpsCfU959