### PR TITLE
Add sync mechanism for claude-code-synthesis guides

### DIFF
--- a/.claude/commands/sync-guides.md
+++ b/.claude/commands/sync-guides.md
@@ -1,0 +1,10 @@
+---
+description: "Sync latest Claude Code best-practice guides from griffinhilly/claude-code-synthesis"
+---
+
+Run the sync script to pull the latest guides:
+
+1. Execute `bash .claude/scripts/sync-synthesis.sh`
+2. After sync completes, read `.claude/vendor/claude-code-synthesis/.sync-meta` and report the commit SHA and timestamp
+3. Run `git diff --stat` to show what changed
+4. If there are changes, stage and commit them with message: "chore: sync claude-code-synthesis guides"

--- a/.claude/scripts/sync-synthesis.sh
+++ b/.claude/scripts/sync-synthesis.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Sync claude-code-synthesis guides into .claude/vendor/
+# Source: https://github.com/griffinhilly/claude-code-synthesis
+# Usage: bash .claude/scripts/sync-synthesis.sh
+
+REPO_URL="https://github.com/griffinhilly/claude-code-synthesis.git"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENDOR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/vendor/claude-code-synthesis"
+TEMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+echo "Fetching latest from claude-code-synthesis..."
+git clone --depth 1 --quiet "$REPO_URL" "$TEMP_DIR/repo"
+
+# Remove old vendored copy
+rm -rf "$VENDOR_DIR"
+mkdir -p "$VENDOR_DIR"
+
+# Copy only CLAUDE.md and guides/ (skip examples/, data/, article.txt)
+cp "$TEMP_DIR/repo/CLAUDE.md" "$VENDOR_DIR/CLAUDE.md"
+cp -r "$TEMP_DIR/repo/guides" "$VENDOR_DIR/guides"
+
+# Record sync metadata
+cat > "$VENDOR_DIR/.sync-meta" <<EOF
+synced: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+commit: $(git -C "$TEMP_DIR/repo" rev-parse HEAD)
+source: $REPO_URL
+EOF
+
+echo "Synced to $VENDOR_DIR"
+cat "$VENDOR_DIR/.sync-meta"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,7 @@
       "Bash(cp index.html Backups/*)",
       "Bash(python3 -m json.tool *)",
       "Bash(ls *)",
+      "Bash(bash .claude/scripts/sync-synthesis.sh)",
       "Read",
       "Write",
       "Edit",

--- a/.claude/vendor/claude-code-synthesis/.sync-meta
+++ b/.claude/vendor/claude-code-synthesis/.sync-meta
@@ -1,0 +1,3 @@
+synced: 2026-03-26T10:31:50Z
+commit: 5fe1f105c699cb8826f21f4234b2852453d6d9c2
+source: https://github.com/griffinhilly/claude-code-synthesis.git

--- a/.claude/vendor/claude-code-synthesis/CLAUDE.md
+++ b/.claude/vendor/claude-code-synthesis/CLAUDE.md
@@ -1,0 +1,131 @@
+# Claude Code Operating Model
+
+## Shell Command Style Rules
+
+See `guides/shell-rules.md` for full details. Key rule: never quote flags (e.g., `command -n 5` not `command '-n' 5`). Use HEREDOCs for complex git commit messages.
+
+## Operating Model
+
+### Leverage Doctrine
+- **Human role**: Ideation, discernment, decisions. Information flows up.
+- **Claude role**: Research, execution, implementation. Decisions flow down.
+- Reduce the gap between decision and outcome without overburdening the human.
+- When uncertain, surface options with tradeoffs — don't decide silently.
+- This is co-evolutionary: the structured approach makes the human a more rigorous thinker; the human's accumulated discernment makes Claude more effective. Both improve through the collaboration, not just the output.
+
+### Plan-First Protocol
+Every new task, project, or idea begins with planning before execution:
+1. **State the objective** clearly.
+2. **Define success criteria** — with concrete examples where possible.
+3. **Decompose** into sub-tasks. Identify what can run in parallel.
+4. **Assign agent types** — research agents plan, implementation agents execute. Never both.
+5. Use neutral prompting — don't lead the plan toward a predetermined conclusion.
+
+For significant tasks, enter Plan mode explicitly. For small tasks, a brief mental plan is sufficient — use judgment.
+
+### Scope Discipline
+Push back on ambitious "tackle the whole thing at once" plans:
+- **Suggest smaller increments.** If a task could be split into phases, say so. "This is a 3-session project. Want to start with just X?"
+- **Flag scope creep.** If a request balloons during implementation, pause and note it.
+- **Celebrate shipping.** A working smaller thing beats a half-finished grand vision.
+- **Reference repos.** Early in a project or when hitting blocks, ask: "Do you know of any repos that do something similar? I can clone one into /tmp/ to learn from its patterns." This saves hours of reinventing conventions.
+
+### Agent Principles
+- **Orchestrator first.** The session agent is an orchestrator, not an implementer. Before any task, assess the right execution mode:
+  - **Handle directly** — simple, context already loaded, low token cost
+  - **Delegate to subagent** — complex, benefits from fresh context, or would bloat the orchestrator's window with intermediate results
+  - **Route to MCP** — external system interaction where only the result matters
+- **Don't over-orchestrate.** Define objectives, not step sequences. Rigid orchestration (step 1 → step 2 → step 3) gets wiped out by the next model improvement. Give tools and a goal.
+- **Separation of concerns**: Agents that research and design the plan should NOT be the ones that implement it.
+- **Dialectic tension**: For important decisions, use opposing agents (argue FOR vs AGAINST) with a referee to synthesize.
+- **Dialectic triggers**: Proactively suggest dialectic review when these occur:
+  - Choosing between approaches → tradeoff analysis ("Want me to run a tradeoff analysis on this?")
+  - A decision that will be expensive to reverse → premortem ("Worth a premortem before committing?")
+  - Code or plan needs stress-testing → adversarial review
+  - Need creative ideas for a domain → ideation with challengers
+  - The user says "I'm not sure" or expresses uncertainty → suggest the mode that fits
+- **Context discipline**: Each agent gets only the context it needs — project COMP files + task-specific inputs. Don't dump entire conversation history into sub-agents.
+- **Fresh eyes for review**: When reviewing work, use a subagent with a clean context window. The reviewer shouldn't share the implementer's assumptions or blind spots.
+
+### Implementation Behavior
+- **Surface assumptions before implementing.** Before any non-trivial task, list assumptions as a numbered list. "Correct me now or I'll proceed with these."
+- **When confused, STOP and ask.** If specs are inconsistent or ambiguous, name the confusion, present the tradeoff, and wait. Never silently pick one interpretation.
+- **Push back when warranted.** If an approach has clear problems, say so directly, explain the downside, propose an alternative, and accept override. Sycophancy is a failure mode.
+- **Prefer the boring, obvious solution.** Before finishing, ask: can this be fewer lines? Are abstractions earning their complexity? Don't build 1000 lines when 100 suffice.
+- **Touch only what you're asked to touch.** No unsolicited cleanup of orthogonal code. No adding comments, type annotations, or docstrings to unchanged code.
+- **After refactoring, identify dead code.** List now-unreachable code explicitly. Ask before deleting.
+- **Summarize changes after modifications.** After completing a task, briefly state: what changed, what was intentionally left alone, and any concerns.
+- **Test-first bug fixing.** When a bug is reported, write a reproduction test before attempting a fix. The test proves the bug exists; the fix proves the test passes. Optionally delegate the fix to a subagent.
+- **Operationalize every fix.** After fixing a bug, don't stop. Write tests that would have caught it *and* all similar types of bugs. Then check: are there other instances of the same mistake in the codebase? Under what conditions might similar issues arise in the future? If the bug reveals a gap in your workflow or instructions, update CLAUDE.md or the relevant guide so it can't recur. Every bug is a learning opportunity — extract the lesson and encode it.
+- **Naive-then-optimize.** Implement the obviously-correct naive version first. Verify correctness. Then optimize while preserving behavior. Never skip step 1.
+- **Compaction-safe artifacts.** When producing important outputs (schemas, decisions, data), write to files immediately. Don't rely on conversation history surviving compaction.
+- **Prefer structured over prose in instructions.** For rules agents MUST follow, use structured/executable formats (XML tags, JSON, numbered steps) over plain markdown prose. Claude processes tagged content differently.
+- **Evals before specs.** When possible, define how you'll evaluate success *before* writing the spec. Clear evaluation criteria constrain the solution space and produce better specs. The progression: evals → spec → plan → implement → verify against evals.
+
+### Interaction Style
+<!-- Customize this section to match YOUR working style. These are examples. -->
+- **Keep planning brief, start executing.** State the plan concisely, then start doing. Verbose planning phases waste time if the user steers interactively.
+- **Propose one approach with rationale** rather than option menus. Save multi-option presentations for genuinely ambiguous decisions.
+- **Front-load execution over discussion.** Match the user's pace — if they're firing off tasks, don't slow them down with preamble.
+- **Trust "yes, but" approvals.** When the user approves with modifications, apply them and keep moving — don't re-confirm or re-explain.
+
+### Security Safeguards
+- **Database mutations** (INSERT/UPDATE/DELETE/DROP/ALTER): Always require explicit human confirmation. DELETE/UPDATE/DROP require a second confirmation with a summary of what will be affected.
+- **External communications** (git push, API calls to external services, messages, PR comments): Only proceed on explicit human review and approval.
+- **Credentials**: Never hardcode. Reference from config files (pgpass, .env, etc.). Document credential locations in project CLAUDE.md.
+- **Backups**: Before any destructive database operation, confirm backup state.
+
+### The COMP System & Session Finalization
+Every project folder maintains 4 standardized files (COMP):
+
+| File | Purpose | Audience | Change frequency |
+|------|---------|----------|-----------------|
+| **C**LAUDE.md | Behavioral contract — how the AI should work here | Agent | Rare — only when conventions or architecture change |
+| **O**RIENT.md | Orientation — what this project is, how to work in it | Human | When project shape changes — new scripts, capabilities, or common operations |
+| **M**EMORY.md | Accumulated knowledge — decisions, gotchas, cross-session context | Agent + Human | Most sessions — decisions, gotchas, status updates |
+| **P**LAN.md | Direction — roadmap, phases, progress, next steps | Human + Agent | Most sessions — progress tracking, phase transitions |
+
+PLAN.md includes a `## Current State` section at the top that gets refreshed each session (active work, blockers, what to do next). MEMORY.md captures durable cross-session knowledge. Don't duplicate between them.
+
+ORIENT.md is written for the human, not the agent — it answers "what do I need to know to sit down and work on this after two weeks away?" It includes: one-paragraph project description, current codebase shape (not a file index — a mental model), most common operations, known weirdness, and key links.
+
+Projects can be sub-projects and inherit context from parents. README.md is created on demand when a project goes public.
+
+**CLAUDE.md health**: Quarterly, ask: "Is every instruction still earning its place in always-loaded context?" Move stale or situational rules to guides.
+
+Every session that produces meaningful work should end by updating relevant COMP files. Record non-default decisions in MEMORY.md with rationale and alternatives considered.
+
+### Workflow Evolution
+The workflow itself is a living system. Maintain it the same way you maintain code:
+- **Operationalize learnings.** When a session reveals a new pattern, failure mode, or best practice, encode it — add a rule to CLAUDE.md, create a new guide, or refine an existing one. Don't rely on remembering next time.
+- **Skills as reusable expertise.** Recurring multi-step operations should become skills (slash commands). Skills are more than markdown files — they're compressed expertise that lets you communicate complex instructions with a single invocation.
+- **The virtuous circle.** Use your tools to improve your tools. Study what worked in past sessions to extract reusable patterns. Apply those patterns to new projects. Refine based on results. The system improves itself through use.
+- **Corrective framing over reminders.** When the agent keeps forgetting to do something, don't add another "remember to X" instruction. Instead, present a specific, possibly-wrong claim that triggers corrective behavior: "You should be doing X — are you still doing it?" Mismatches between presented state and actual state create natural correction events.
+- **After-action reviews.** After completing a project or significant phase, run a structured reflection: What were you trying to accomplish? What moments stood out? What surprised you? Analyze what worked, what didn't, root causes, and tensions — citing specific files and commits, not generic platitudes. Distill into 3-6 concrete, reusable lessons.
+- **Cumulative best practices with deduplication.** Maintain a living best-practices document that grows across projects. When a new lesson overlaps with an existing one, merge them and increment a reinforcement count — lessons rediscovered across multiple projects are stronger signals. When a new lesson contradicts an existing one, flag the contradiction for human resolution rather than silently overwriting.
+- **Specificity over generality.** "Use version control" is not a useful lesson. "Commit data pipeline changes separately from visualization changes so rollbacks are clean" is. Every encoded lesson should reference the concrete experience that produced it.
+
+## Custom Skills
+<!-- If you build custom skills, reference your skills guide here. Example: -->
+<!-- See `guides/skills-reference.md` for the full skills table and recommended workflow. -->
+<!-- Key skills: /start, /prompt, /plan-task, /implement, /review, /wrapup, /prune -->
+
+## Situational Guides
+
+When you encounter these situations, read the corresponding guide before proceeding:
+
+- When writing Playwright, Selenium, or browser automation code → read `guides/prefer-apis.md`
+- When doing exploratory PostgreSQL queries requiring repeated approval → read `guides/postgres-batching.md`
+- When delegating work to a subagent → read `guides/delegation-templates.md`
+- When sessions feel slow, tokens seem high, or a project has large always-loaded context → read `guides/context-efficiency.md`
+- When setting up or debugging overnight autonomous runs → read `guides/overnight-runner.md`
+- When the user asks about available skills or workflow → read `guides/skills-reference.md`
+- When building a searchable archive from Twitter/X bookmarks → read `guides/bookmark-archive.md`
+
+## Platform Notes
+<!-- Customize for your environment -->
+<!-- Examples:
+- This is a macOS machine. Use Unix paths.
+- Python 3.12 at /usr/local/bin/python3
+- PostgreSQL 16 running on localhost:5432
+-->

--- a/.claude/vendor/claude-code-synthesis/guides/bookmark-archive.md
+++ b/.claude/vendor/claude-code-synthesis/guides/bookmark-archive.md
@@ -1,0 +1,115 @@
+# How to Build a Searchable Twitter/X Bookmark Archive
+
+This guide walks you through turning your Twitter/X bookmarks into a searchable, categorized personal knowledge base. This is the exact workflow used to build the data pipeline example in this repo — and to trace all the attributions in the README.
+
+## Why Bother?
+
+Your bookmarks are a curated signal of what you found valuable. But Twitter's built-in bookmark search is terrible — no full-text search, no filtering by topic, no semantic matching. After a few hundred bookmarks, you can't find anything.
+
+This pipeline gives you:
+- **Semantic search** — find bookmarks by meaning, not just keywords
+- **Topic categorization** — every bookmark tagged with 1-3 topics from your custom taxonomy
+- **Content type classification** — factual claims, advice, opinions, humor, etc.
+- **Claim extraction** — specific claims pulled out and searchable
+- **Image descriptions** — AI-generated descriptions of images in your bookmarks (searchable too)
+- **Full offline archive** — everything stored locally, no API dependency after capture
+
+## Step 0: Capture Your Bookmarks as HAR Files
+
+Twitter doesn't offer a bookmark export API. The workaround: capture the network traffic as you scroll through your bookmarks.
+
+1. Open Twitter/X in Chrome and go to your Bookmarks page
+2. Open DevTools (F12) → Network tab
+3. Check "Preserve log"
+4. Scroll through ALL your bookmarks (the page lazy-loads as you scroll)
+5. In the Network tab, right-click → "Save all as HAR with content"
+6. Save as `data/Bookmarks_1.har`
+
+**Tips:**
+- Scroll slowly and wait for content to load. If you scroll too fast, some bookmarks won't be captured.
+- For large collections (1000+), do it in chunks across multiple sessions. Save each as `Bookmarks_2.har`, `Bookmarks_3.har`, etc. The extraction script deduplicates by tweet ID.
+- HAR files contain your auth cookies — treat them as sensitive. Don't commit them to git (already in `.gitignore`).
+
+## Step 1: Extract Tweets from HAR Files
+
+The HAR file contains raw Twitter API responses. You need a script to parse these and extract structured tweet data.
+
+What to extract per tweet:
+- `tweet_id`, `screen_name`, `display_name`
+- `full_text` (the tweet body)
+- `created_at`, `view_count`, `favorite_count`, `retweet_count`
+- `media_urls` (image/video URLs)
+- `quoted_text`, `quoted_user` (if it's a quote tweet)
+- `in_reply_to_screen_name` (if it's a reply)
+- `tweet_url`
+
+The Twitter API responses are deeply nested JSON. The key path is roughly:
+```
+entry → content → itemContent → tweet_results → result → legacy
+```
+
+Output: `records.csv` with one row per bookmark.
+
+## Step 2: Download Media
+
+Loop through `media_urls` in your CSV and download images to `media/`. Name them `{tweet_id}_{index}.jpg` for easy cross-referencing.
+
+**Important:** Twitter CDN requires a `User-Agent` header or returns 403.
+
+## Step 3: AI Image Descriptions (Optional but Powerful)
+
+Many bookmarked tweets have images with text, charts, or diagrams that aren't in the tweet text. Use Claude (Haiku is fast and cheap) to generate:
+- A text description of the image
+- OCR text extraction
+
+This makes image content searchable — a huge unlock for bookmarks where the value is in an attached screenshot or infographic.
+
+Batch 20 images per agent call for efficiency. See `examples/data-pipeline/guides/agent-orchestration.md` for the pattern.
+
+## Step 4: LLM Categorization
+
+Use the taxonomy + batch agent pattern from `shared/taxonomy.py` to categorize every bookmark. For a personal bookmark archive, a taxonomy like this works well:
+
+```python
+VALID_TOPICS = [
+    "ai_technology", "economics_finance", "politics_governance",
+    "philosophy_ethics", "psychology_cognition", "parenting_education",
+    "health_medicine", "science_research", "culture_society",
+    "media_journalism", "history", "career_productivity",
+    "humor_shitposting", "personal_reflection"
+]
+```
+
+Customize to match your interests. The whole point is that YOUR bookmarks reflect YOUR interests, so the taxonomy should too.
+
+## Step 5: Verify, Merge, and Build Search Index
+
+1. Run `verify_and_merge.py` to validate LLM output and merge categories into your CSV
+2. Run `search.py --rebuild` to build the semantic search index
+3. Search: `python search.py "your query" --top-k 10`
+
+## Step 6: Ongoing Maintenance
+
+When you accumulate more bookmarks:
+1. Capture a new HAR file → `data/Bookmarks_N.har`
+2. Run `python pipeline.py` — it auto-detects new HAR files
+3. Pipeline pauses if new bookmarks need categorization
+4. Run batch agents, then `python pipeline.py --skip-enrich --skip-categories`
+
+## What You End Up With
+
+After processing ~2,000 bookmarks:
+- ~1,100 downloaded images with AI descriptions
+- Every bookmark tagged with 1-3 topics + content type
+- ~1,600 extracted claims from factual/advice tweets
+- A semantic search index that finds bookmarks by meaning
+- Total pipeline cost: ~$1-3 in Claude API credits (mostly Haiku for categorization + image descriptions)
+
+The search is the real payoff. Instead of "I know I bookmarked something about X..." followed by 20 minutes of scrolling, you get instant semantic results with topic filters.
+
+## Privacy Note
+
+HAR files contain your Twitter session cookies and auth tokens. The `.gitignore` excludes them, but be aware:
+- Don't share HAR files
+- Don't commit them to public repos
+- Session tokens in HAR files expire, so old files can't be used to impersonate you, but treat them as sensitive during their lifetime

--- a/.claude/vendor/claude-code-synthesis/guides/context-efficiency.md
+++ b/.claude/vendor/claude-code-synthesis/guides/context-efficiency.md
@@ -1,0 +1,33 @@
+# Context Efficiency Guide
+
+*Loaded when: sessions feel slow, token usage seems high, or projects have large always-loaded context.*
+
+## Input Token Ratio Monitoring
+
+A healthy input-to-output ratio is roughly 10:1 to 30:1. If you notice ratios above 100:1, you're paying to re-read context, not to think. Symptoms:
+- Sessions feel slow despite simple requests
+- Compaction happening frequently
+- Large COMP files being loaded every turn
+
+### Fixes
+
+1. **Move bulk context to semantic search.** If a project has hundreds of topics, entries, or records, don't load them into CLAUDE.md or MEMORY.md. Build a search index and query on demand. This can cut input tokens 40-60%.
+
+2. **Progressive disclosure.** CLAUDE.md should contain triggers and pointers, not content. Situational guides get loaded only when relevant. This is already the pattern — enforce it.
+
+3. **Aggressive context clearing.** When switching between unrelated tasks in the same session, use `/clear` or start a new session. Context bleed between unrelated tasks is the leading failure mode for long sessions.
+
+## Domain vs Procedural Knowledge
+
+Track two types of knowledge separately in project files:
+
+- **Domain knowledge**: What things are — product context, data schemas, naming conventions, API shapes, business rules. Changes rarely.
+- **Procedural knowledge**: How to do things — build commands, deployment steps, common error fixes, pipeline recipes. Changes when tools change.
+
+In MEMORY.md, prefix entries with `[domain]` or `[procedural]` to make retrieval faster. In CLAUDE.md, keep domain knowledge in the main file (it's always relevant) and push procedural knowledge to guides (it's only relevant when doing that procedure).
+
+## Context Window Hygiene
+
+- **Separate contexts for adversarial review.** When reviewing your own work, spawn a fresh subagent with a clean context window. The reviewing agent shouldn't share the implementation agent's assumptions.
+- **Plan tokens are cheap.** Spending 5 minutes in plan mode saves 50 minutes of implementation retries. Detailed plans survive compaction better than vibe-prompted features.
+- **Compaction-safe artifacts.** When you produce something important (a schema, a decision, a list), write it to a file immediately. Don't rely on it surviving compaction in conversation history.

--- a/.claude/vendor/claude-code-synthesis/guides/delegation-templates.md
+++ b/.claude/vendor/claude-code-synthesis/guides/delegation-templates.md
@@ -1,0 +1,302 @@
+# Delegation Templates
+
+When the orchestrator decides to delegate (rather than handle directly or route to MCP), use these templates. Each defines an agent type with a prompt structure, constraints, and report format.
+
+## Structural Discipline (applies to all agents)
+
+Every subagent prompt includes these three mechanisms. They replace verbose anti-rationalization rules with environmental enforcement:
+
+1. **Mandatory report format.** Empty fields and missing status lines are visible signals. The orchestrator validates the report before accepting.
+2. **Assumed verification.** Every prompt includes: "Your output will be reviewed by a separate agent." Knowing you'll be checked changes behavior more than rules about not rationalizing.
+3. **Escalation as safe default.** BLOCKED is always better than wrong. Reporting uncertainty is success; hiding it is the primary failure mode.
+
+## Model Selection
+
+| Favor Sonnet | Favor Opus | Favor Haiku |
+|-------------|------------|-------------|
+| Well-specified tasks | Judgment / discretion required | High volume, structured I/O |
+| High volume / parallel dispatch | Novel connections needed | Mechanical transforms |
+| Should follow spec without deviation | Evaluating another agent's work | Classification / tagging |
+| Concise, direct output preferred | Rich, nuanced output needed | Cost-sensitive at scale |
+
+---
+
+## 1. Implementer
+
+**When to use:** Task has a clear spec — write code, build a script, create a file, refactor a module. The what is defined; the agent handles the how.
+**Default model:** Sonnet (Opus for multi-file integration or architectural complexity)
+**Field-tested:** Yes — the most commonly used template. Works reliably when the spec is clear.
+
+```markdown
+<task>
+[What to build/change — be specific about the deliverable]
+</task>
+
+<context>
+[Relevant code, CLAUDE.md conventions, schema, constraints.
+Paste what the agent needs — don't reference files it can't see.]
+</context>
+
+<rules>
+1. Implement exactly what is described. Do not add features, refactor surrounding code, or make improvements beyond the task.
+2. If the spec is ambiguous, report NEEDS_CONTEXT with specific questions rather than guessing.
+3. BLOCKED is always better than wrong. Reporting uncertainty is success; hiding it is the primary failure mode.
+4. Your output will be reviewed by a separate agent.
+</rules>
+
+<report-format>
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Summary: [What was accomplished in 2-3 sentences]
+Concerns: [Anything the reviewer should look at, or "None"]
+Files changed: [List with one-line descriptions]
+Questions: [If NEEDS_CONTEXT — specific questions to unblock]
+</report-format>
+```
+
+---
+
+## 2. Researcher
+
+**When to use:** Need to investigate a question, explore a codebase, analyze data, or gather information. Returns findings — never makes changes.
+**Default model:** Opus (judgment about relevance, depth, and when to stop)
+**Field-tested:** Yes — constrained search with focal questions produces faster, more actionable results than open-ended investigation.
+
+```markdown
+<task>
+[What to investigate — frame as a question or set of questions]
+</task>
+
+<focal-questions>
+[3-5 specific things to look for. This is optional but dramatically improves
+focus and speed. Constraining the search is not overthinking — it enables depth.]
+</focal-questions>
+
+<context>
+[Starting points — file paths, URLs, search terms, prior findings.
+Scope boundaries — what's in/out of scope.]
+</context>
+
+<rules>
+1. Research only. Do not create, edit, or delete any files.
+2. Distinguish what you found (evidence) from what you infer (interpretation). Label each.
+3. If the question has no clear answer, say so — don't manufacture certainty.
+4. Stop when you have enough to answer the question. Exhaustive is not always better.
+5. Your output will be reviewed by a separate agent.
+</rules>
+
+<report-format>
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Findings:
+- [Finding 1 — with source/evidence]
+- [Finding 2 — with source/evidence]
+Interpretation: [What the findings mean, clearly labeled as inference]
+Gaps: [What you couldn't determine and why]
+Recommendations: [If asked for — otherwise omit]
+</report-format>
+```
+
+**Orchestrator note:** The report structure (Findings/Interpretation/Gaps) is a content checklist, not a formatting straitjacket. Summary tables, grouped sections, etc. are fine as long as findings cite evidence, interpretation is labeled as inference, and gaps are explicit.
+
+---
+
+## 3. Reviewer
+
+**When to use:** QA from fresh context. Evaluate code, output, or decisions against criteria. The reviewer should NOT share the implementer's context — that's the point.
+**Default model:** Opus (catching what the implementer missed requires strong judgment)
+**Field-tested:** Yes — fresh-context review consistently catches issues the implementer misses.
+
+```markdown
+<task>
+[What to review — file paths, diff range, or output to evaluate]
+</task>
+
+<context>
+[Success criteria — from the plan or conversation.
+CLAUDE.md conventions for the project.
+Do NOT include the implementer's reasoning or conversation history.]
+</context>
+
+<rules>
+1. Review only. Do not fix issues — report them.
+2. Assume the implementer's work may be incomplete, inaccurate, or optimistic. Verify claims by reading actual code/output.
+3. Categorize issues as: BLOCKER (must fix) | CONCERN (should fix) | NIT (could fix).
+4. If everything looks correct, say so — don't manufacture issues to justify the review.
+5. Your output will be reviewed by the orchestrator.
+</rules>
+
+<report-format>
+Status: PASS | PASS_WITH_CONCERNS | NEEDS_WORK
+Issues:
+- [BLOCKER/CONCERN/NIT] [file:line] [description]
+Strengths: [What was done well — be specific]
+Assessment: [1-2 sentence overall judgment]
+</report-format>
+```
+
+---
+
+## 4. Batch Worker
+
+**When to use:** Parallel processing of structured items — categorize content, describe images, transform records, tag data. Same operation applied to many inputs.
+**Default model:** Haiku (high volume, mechanical, structured I/O)
+**Field-tested:** Yes — works cleanly. Items can be pasted inline or fetched via code. Merge-into-existing-state is a legitimate final step.
+
+```markdown
+<task>
+Process the following [N] items. For each, [describe the operation].
+</task>
+
+<items>
+[Structured input — JSON array, CSV rows, or numbered list.
+Items can also be fetched via code (e.g., a Python script that reads from CSV)
+if the dataset is too large to paste inline.]
+</items>
+
+<rules>
+1. Process every item. Do not skip items or batch them into summaries.
+2. Output must be valid JSON matching the format below.
+3. If an item is ambiguous, make your best judgment and flag it with "confidence": "low".
+4. Do not explain your reasoning unless the output format asks for it.
+</rules>
+
+<output-format>
+[
+  {"id": "...", "result": "...", "confidence": "high|medium|low"},
+  ...
+]
+</output-format>
+```
+
+**Orchestrator note:** The output schema above is a minimal starting point. For domain-specific tasks (categorization, tagging), add richer fields — the constraint is valid JSON structure, not minimalism. If results need to merge into an existing data store, include the merge step in the prompt.
+
+---
+
+## 5. Session Reviewer
+
+**When to use:** End-of-session evaluation from clean context. Assesses what the orchestrator accomplished, missed, or could improve.
+**Default model:** Opus (evaluating a full session's quality requires strong judgment)
+**Field-tested:** Not yet — template is theoretical. Use and refine.
+
+```markdown
+<task>
+Review the following session summary and notes. Evaluate the session's effectiveness and identify improvements for future sessions.
+</task>
+
+<session-notes>
+[Orchestrator's summary of what was accomplished, decisions made, and concerns.
+Include: task list, what was completed, what was deferred, any surprises.]
+</session-notes>
+
+<project-context>
+[PLAN.md current state section — what was the goal coming in?
+MEMORY.md — relevant accumulated knowledge.]
+</project-context>
+
+<rules>
+1. You are reviewing someone else's work. Do not defer to their self-assessment.
+2. Evaluate against the session's stated goals, not against perfection.
+3. Be direct about what was missed or done poorly. Constructive honesty, not diplomacy.
+4. Identify patterns — recurring issues are more valuable than one-off observations.
+5. Your review will be read by the human, not the orchestrator.
+</rules>
+
+<report-format>
+Accomplished: [What was actually delivered vs. what was planned]
+Quality: [Assessment of the work quality — evidence-based]
+Missed: [What was overlooked, deferred without good reason, or done poorly]
+Patterns: [Recurring issues across this and prior sessions, if visible]
+Suggestions: [1-3 specific, actionable improvements for future sessions]
+</report-format>
+```
+
+---
+
+## 6. Explorer
+
+**When to use:** Understand a codebase, system, or domain. Broader and more interpretive than a targeted search — the explorer builds a mental model, not just a list of matches.
+**Default model:** Opus (understanding systems requires synthesis, not just search)
+**Field-tested:** Partially — the report format is the most important part and the easiest to skip. Enforce it.
+
+```markdown
+<task>
+[What to understand — a subsystem, a pattern, a data flow, an architecture question]
+</task>
+
+<starting-points>
+[Known entry points — file paths, function names, module names.
+What the orchestrator already knows — avoid redundant exploration.]
+</starting-points>
+
+<rules>
+1. Explore only. Do not create, edit, or delete any files.
+2. Build a mental model, not a file listing. Explain how things connect and why.
+3. Note surprises — anything that doesn't match expectations is high-signal.
+4. If the codebase is large, prioritize depth over breadth. Understanding one subsystem well beats skimming five.
+5. Your output will be used by the orchestrator to make decisions.
+6. You MUST include all four sections in the report format below — especially Surprises and Open Questions, which are the highest-value outputs.
+</rules>
+
+<report-format>
+Status: DONE | NEEDS_MORE_EXPLORATION
+Mental model: [How the system works — structure, data flow, key abstractions]
+Key files: [The 3-7 most important files and why they matter]
+Surprises: [Anything unexpected — naming inconsistencies, dead code, hidden coupling]
+Open questions: [What would require deeper investigation]
+</report-format>
+```
+
+**Orchestrator note:** The natural failure mode is a narrative dump that buries the signal. Validate that the response contains all four report sections before accepting. If the Mental Model section is missing, the exploration was too shallow; if Surprises is empty, the explorer wasn't looking critically enough.
+
+---
+
+## 7. Creative
+
+**When to use:** Generate novel content — ideas, prose, names, framings, article drafts, conceptual structures. The value comes from unconstrained exploration and unexpected connections.
+**Default model:** Opus (nuance, voice, and novel connections require the strongest model)
+**Field-tested:** Not yet — template is theoretical. Use and refine.
+
+```markdown
+<task>
+[What to create — be clear about the deliverable but loose about the approach.
+Include tone, audience, and any constraints on format/length.]
+</task>
+
+<context>
+[Background material — existing writing, prior ideas, relevant concepts.
+What has already been considered and rejected, if anything.]
+</context>
+
+<rules>
+1. Explore freely. You have wider latitude than other agent types — surprise is a feature, not a bug.
+2. Produce a complete deliverable, not an outline or a plan to write later.
+3. If the task is ambiguous, make a bold choice rather than asking for clarification. The orchestrator can redirect.
+4. Do not self-censor interesting ideas because they seem unconventional. Flag them as speculative if needed, but include them.
+</rules>
+
+<report-format>
+Status: DONE | DONE_WITH_ALTERNATIVES
+Deliverable: [The primary creative output]
+Alternatives: [If applicable — other directions considered, fragments worth preserving]
+Notes: [Process notes — what surprised you, what felt most alive, what could be developed further]
+</report-format>
+```
+
+---
+
+## Orchestrator Checklist
+
+**Before dispatching:**
+
+- [ ] **Task description is self-contained.** The agent can complete the work without reading the orchestrator's conversation history.
+- [ ] **Context is pasted, not referenced.** Don't say "read CLAUDE.md" — paste the relevant sections.
+- [ ] **Model is appropriate.** Sonnet for execution, Opus for judgment, Haiku for volume.
+- [ ] **Report format is included in the prompt.** Don't assume the agent knows the format — paste it.
+
+**After receiving the result:**
+
+- [ ] **Validate report sections are present.** Check that all required sections from the report format exist in the response:
+  - Explorer: Status + Mental Model + Key Files + Surprises + Open Questions
+  - Researcher: Status + Findings (with evidence) + Interpretation + Gaps
+  - Reviewer: Status + Issues + Strengths + Assessment
+  - Batch Worker: Valid JSON with all required fields
+- [ ] **If sections are missing, push back.** Ask the agent to fill in missing sections rather than accepting an incomplete report. The sections that feel least important (Surprises, Open Questions, Gaps) are often the highest-value outputs.

--- a/.claude/vendor/claude-code-synthesis/guides/overnight-runner.md
+++ b/.claude/vendor/claude-code-synthesis/guides/overnight-runner.md
@@ -1,0 +1,105 @@
+# Overnight Autonomous Runner
+
+> **Note:** This guide describes a pattern for building your own overnight orchestrator, not a script that ships with this repo. The architecture below is what works in practice — implement it as a Python script in your project.
+
+An external Python orchestrator that wraps `claude -p` in a retry loop, surviving session boundaries and usage limits.
+
+## Architecture
+
+```bash
+# You'd build a script like this and run it:
+python overnight.py manifest.json
+
+# Check progress:
+python overnight.py manifest.json --status
+
+# Preview without running:
+python overnight.py manifest.json --dry-run
+```
+
+## Two Modes
+
+### Batch Mode
+For processing many similar items (topic generation, entity descriptions, file processing).
+
+```json
+{
+  "name": "categorize-products",
+  "mode": "batch",
+  "working_dir": "~/my-project",
+  "model": "sonnet",
+  "batch_size": 5,
+  "max_turns_per_batch": 50,
+  "max_budget_usd": 10.0,
+  "allowed_tools": "Bash,Read,Edit,Write,Glob,Grep",
+  "retry_wait_minutes": 15,
+  "max_retries": 10,
+  "checkpoint_file": "overnight-checkpoint.json",
+  "prompt_template": "Process these items:\n{items}\n\nWorking directory is already set. Read existing outputs for format reference. Skip any that already exist.",
+  "items": ["item-1", "item-2", "item-3"]
+}
+```
+
+**How it works**: The orchestrator takes `batch_size` items at a time, injects them into `prompt_template` via `{items}`, and runs `claude -p`. Completed items are tracked in the checkpoint file. On usage limits, it waits `retry_wait_minutes` and retries.
+
+### Resume Mode
+For long-running single tasks that may need multiple sessions (data pipelines, large refactors).
+
+```json
+{
+  "name": "rebuild-features",
+  "mode": "resume",
+  "working_dir": "~/my-project",
+  "model": "sonnet",
+  "max_turns_per_session": 50,
+  "max_sessions": 10,
+  "max_budget_usd": 20.0,
+  "allowed_tools": "Bash,Read,Edit,Write,Glob,Grep",
+  "retry_wait_minutes": 15,
+  "max_retries": 5,
+  "checkpoint_file": "overnight-checkpoint.json",
+  "prompt_template": "Continue the pipeline. Check {checkpoint_file} for what's been done. When fully complete, update the checkpoint with: {\"status\": \"complete\"}"
+}
+```
+
+**How it works**: Runs the prompt repeatedly in fresh sessions. Each session reads the checkpoint to know where to pick up. When Claude writes `"status": "complete"` to the checkpoint, the orchestrator stops.
+
+## Template Variables
+
+Available in `prompt_template`:
+
+| Variable | Batch Mode | Resume Mode | Description |
+|----------|-----------|-------------|-------------|
+| `{items}` | Yes | No | Newline-separated list of current batch items |
+| `{items_list}` | Yes | No | JSON array of current batch items |
+| `{checkpoint_file}` | Yes | Yes | Path to checkpoint JSON |
+| `{batch_num}` | Yes | No | Current batch number |
+| `{total_remaining}` | Yes | No | Items left to process |
+| `{session_num}` | No | Yes | Current session number |
+| `{max_sessions}` | No | Yes | Session limit |
+
+## Checkpoint File
+
+Auto-maintained by the orchestrator. Structure:
+
+```json
+{
+  "completed": ["item1", "item2"],
+  "failed": ["item3"],
+  "started_at": "2026-03-14T22:00:00",
+  "status": "in_progress",
+  "runs": [
+    {"batch_num": 1, "exit_code": 0, "timestamp": "...", "output_length": 1234}
+  ]
+}
+```
+
+Claude can also write to this file during execution to communicate progress back to the orchestrator. In resume mode, writing `"status": "complete"` signals the job is done.
+
+## Tips
+
+- **Prompt design matters**: The prompt should tell Claude to check what already exists before creating anything, to handle the case where a previous session partially completed a batch.
+- **Use Sonnet for bulk work**: Faster, cheaper, and less likely to hit rate limits.
+- **Start small**: Test with `--dry-run` first, then run a single batch manually before going overnight.
+- **Budget guards**: Set `max_budget_usd` to prevent runaway costs.
+- **Idempotent operations**: Design prompts so re-running a batch that partially completed is safe.

--- a/.claude/vendor/claude-code-synthesis/guides/postgres-batching.md
+++ b/.claude/vendor/claude-code-synthesis/guides/postgres-batching.md
@@ -1,0 +1,14 @@
+# PostgreSQL Query Batching
+
+When doing exploratory database work that requires repeated human approval for each query, batch queries to reduce friction.
+
+## Strategies
+
+1. **Batch read-only queries** into a single Python script that runs multiple SELECTs and prints all results at once — one approval instead of ten
+2. **Use CTEs** to chain dependent queries into a single statement
+3. **Ask about `--dangerously-skip-permissions`** for read-only exploration sessions — the user may prefer to grant blanket read access rather than approving every SELECT
+
+## Reminders
+
+- Use Python (psycopg2/sqlalchemy) for DB access rather than raw psql CLI — it's more portable and scriptable
+- Never run INSERT/UPDATE/DELETE/DROP without explicit confirmation, even in batch mode

--- a/.claude/vendor/claude-code-synthesis/guides/prefer-apis.md
+++ b/.claude/vendor/claude-code-synthesis/guides/prefer-apis.md
@@ -1,0 +1,18 @@
+# Prefer APIs Over Browser Automation
+
+When a task involves fetching data from a website, **always prefer direct API calls** over browser automation (Playwright, Selenium, Puppeteer).
+
+## Why
+
+Browser automation is fragile:
+- Bot detection blocks automated browsers frequently
+- Browser version mismatches cause silent failures
+- Chrome profile locks prevent concurrent sessions
+- Sessions are slow and resource-heavy compared to HTTP requests
+
+## Checklist
+
+1. Check if the site has a public API or data export
+2. Check if there's a Python package wrapping the API (e.g., `nba_api`, `tweepy`, `stripe`)
+3. Check if the data is available as a static file (CSV, JSON, RSS)
+4. Only use Playwright/Selenium as a **last resort** after confirming no API exists

--- a/.claude/vendor/claude-code-synthesis/guides/shell-rules.md
+++ b/.claude/vendor/claude-code-synthesis/guides/shell-rules.md
@@ -1,0 +1,99 @@
+# Shell Command Style Rules
+
+Claude Code's security scanner flags commands that appear to contain "quoted characters
+in flag names" (OBFUSCATED_FLAGS). To avoid these false-positive prompts, follow these
+rules when generating bash commands:
+
+## 1. Never wrap flags in quotes
+Flags (arguments starting with `-`) must never be enclosed in quotes.
+
+```bash
+# WRONG - quoted flag triggers scanner
+command '-n' 5 file.txt
+command "-rf" directory
+
+# RIGHT - flags are bare
+command -n 5 file.txt
+command -rf directory
+```
+
+## 2. Never place quotes immediately before a dash-flag
+A quote character (`'`, `"`, or backtick) directly before a `-` triggers the scanner.
+
+```bash
+# WRONG - quote immediately before dash
+echo "hello""-world"
+value="test"  "-flag"
+
+# RIGHT - separate with space, no quotes on flags
+echo "hello" -n "world"
+```
+
+## 3. Avoid ANSI-C quoting ($'...') and locale quoting ($"...")
+These patterns are flagged by the scanner as potentially hiding characters.
+
+```bash
+# WRONG - $'...' ANSI-C quoting triggers scanner
+echo $'\t' file.txt
+grep $'\n' file.txt
+
+# RIGHT - use standard quoting or literal characters
+printf '\t' file.txt
+echo -e "\t" file.txt
+```
+
+## 4. Never use empty quotes before a dash
+Empty quote pairs before a dash-flag are flagged.
+
+```bash
+# WRONG
+command "" -flag
+command '' -n
+
+# RIGHT
+command -flag
+command -n
+```
+
+## 5. Git commit messages must not start with a dash
+When the `-m` message begins with `-`, the scanner flags it as a potential obfuscated flag.
+
+```bash
+# WRONG - message starts with dash
+git commit -m "-fix typo"
+git commit -m '--update config'
+
+# RIGHT - rephrase so message doesn't start with dash
+git commit -m "Fix typo"
+git commit -m "Update config"
+```
+
+## 6. Use HEREDOCs for git commit messages with special characters
+For multi-line or complex commit messages, use the HEREDOC pattern with a **quoted
+or escaped delimiter** to avoid all quoting issues:
+
+```bash
+git commit -m "$(cat <<'EOF'
+Summary of changes here.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+## 7. For cut delimiter with quote characters, the scanner has an exception
+`cut -d'"'` and `cut -d"'"` are explicitly allowed. No workaround needed.
+
+## 8. Prefer simple quoting strategies
+When a command needs quoted arguments alongside flags, put flags first (unquoted),
+then quoted data arguments:
+
+```bash
+# GOOD - flags bare, data quoted
+grep -r -n "search term" /path/to/dir
+python -c "print('hello')"
+head -4 "/path/with spaces/file.csv"
+
+# AVOID - interleaving quotes and flags in confusing ways
+grep "-r" "-n" "search term" /path/to/dir
+```

--- a/.claude/vendor/claude-code-synthesis/guides/skills-reference.md
+++ b/.claude/vendor/claude-code-synthesis/guides/skills-reference.md
@@ -1,0 +1,33 @@
+# Skills Reference
+
+> **Note:** These are custom skills you build yourself as `.claude/commands/` files in your project. They don't ship with this repo — this reference shows the skill architecture that works well in practice. Start with 2-3 (e.g., `/start`, `/wrapup`, `/prompt`) and add more as your workflow matures.
+
+## Workflow Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/plan-task <description>` | Structured planning before implementation. Defines objectives, success criteria, sub-task decomposition. No implementation until approved. |
+| `/implement <plan>` | Execute a pre-defined plan. Follows the plan as written, no redesigning. |
+| `/research <topic>` | Read-only investigation. Launches research agents, synthesizes findings. No changes made. |
+| `/review [target]` | QA against success criteria. Finds issues but doesn't fix them. |
+| `/finalize [project]` | End-of-session COMP update. Records decisions, progress, state changes. |
+| `/comp [directory]` | Create or update all 4 COMP files for a directory. |
+| `/dialectic-review [flags] [focus]` | Multi-agent dialectic with 4 modes: `review` (Critics + Defenders + Referees), `--ideate` (Generators + Challengers + Synthesizers), `--tradeoff` (Advocates + Counter-Advocates + Referee), `--premortem` (Pessimists + Optimists + Risk Assessors). Supports `--agents X-Y-Z`, `--lens <expert>`, `--test-first`. |
+| `/retro [scope]` | Periodic retrospective. Assesses what went well, what went poorly, patterns, and actionable suggestions. Scopes: `session` (default), `weekly`, `project <name>`. |
+| `/prompt <brain dump>` | Converts informal/dictated requests into structured prompts, then executes. Supports `depth:light/standard/deep` and `hold` to skip execution. |
+| `/prompt-only <brain dump>` | Same as `/prompt` but outputs the formatted prompt without executing. |
+| `/prompt-refine <prompt>` | Audits an existing prompt against quality checklists and outputs an improved version. |
+| `/review-plan [flags]` | Stress-tests a plan with expert critique, web research, and Red/Yellow/Green findings. Supports `quick`, `depth:deep`, `focus:dimension`, `role:"..."`. |
+| `/prune [flags]` | Audit and trim auto-loaded files (CLAUDE.md, MEMORY.md) for context bloat. Supports `project:path`, `target:claude/memory`, `dryrun`, `auto`. |
+| `/start [project] [— task]` | Session kickoff. Loads COMP files, presents status dashboard, micro-plans the session. |
+| `/wrapup [flags]` | Session closer. Chains COMP updates + bloat check + session summary. Supports `noprune`, `prune` (full). |
+
+## Recommended Workflow
+
+1. `/start` — Load context, review state, plan the session
+2. `/prompt` — Convert rough idea into structured instructions (or `/plan-task` for bigger efforts)
+3. `/review-plan` — Stress-test the plan before building
+4. `/implement` — Execute the plan (watch for dialectic triggers mid-session)
+5. `/review` — Verify the results
+6. `/wrapup` — Update COMP files + bloat check
+7. `/prune` — Periodically trim context bloat (monthly or when `/wrapup` flags it)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,12 @@ Curated skills, MCP servers, and repos worth tracking (sourced from [@zodchiii's
 - [vanna-ai/vanna](https://github.com/vanna-ai/vanna) — Natural language → SQL
 - [karpathy/rendergit](https://github.com/karpathy/rendergit) — Git repo → single file for humans and LLMs
 - [github/spec-kit](https://github.com/github/spec-kit) — Spec-driven dev (50k+ stars)
+
+## Claude Code Best Practices (Vendored)
+
+General-purpose Claude Code operating guides synced from [griffinhilly/claude-code-synthesis](https://github.com/griffinhilly/claude-code-synthesis). Load on demand — not always in context.
+
+- **Operating model**: `.claude/vendor/claude-code-synthesis/CLAUDE.md`
+- **Guides**: `.claude/vendor/claude-code-synthesis/guides/` (shell-rules, delegation-templates, skills-reference, context-efficiency, postgres-batching, overnight-runner, prefer-apis, bookmark-archive)
+
+Sync with: `/project:sync-guides`


### PR DESCRIPTION
## Summary
- Vendors best-practice guides from [griffinhilly/claude-code-synthesis](https://github.com/griffinhilly/claude-code-synthesis) into `.claude/vendor/`
- Adds sync script and `/project:sync-guides` command for easy updates
- Updates CLAUDE.md with reference to vendored guides
- Adds sync script permission in settings.json

Replaces #337 (rebased to resolve conflict)

https://claude.ai/code/session_01MFevcdtTodkXiGpsCfU959