### PR TITLE
Add notebooklm-py setup for AI Study Companion management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Free development education platform for South Asia. Static HTML/CSS/JS, Supabase
 - **Handouts**: 400+ in `/Handouts/{Track}/`
 - **Data**: JSON in `/data/` (search-index, dataverse, BCT repository)
 - **Docs**: GitBook in `/docs/`
+- **NotebookLM**: 11 AI Study Companion notebooks managed via `notebooklm-py`. Registry: `data/notebooklm-registry.json`. Script: `scripts/notebooklm-manage.py`
 
 ## Conventions
 

--- a/data/notebooklm-registry.json
+++ b/data/notebooklm-registry.json
@@ -1,0 +1,59 @@
+{
+  "notebooks": {
+    "sel": {
+      "id": "e11569c6-2dcd-4750-b627-a84378f90d0b",
+      "title": "Social and Emotional Learning 101",
+      "url": "https://notebooklm.google.com/notebook/e11569c6-2dcd-4750-b627-a84378f90d0b"
+    },
+    "dataviz": {
+      "id": "34f17e04-5443-4fdc-a962-38da194b98f9",
+      "title": "Data Visualization 101",
+      "url": "https://notebooklm.google.com/notebook/34f17e04-5443-4fdc-a962-38da194b98f9"
+    },
+    "devai": {
+      "id": "900b111d-043f-408c-b97b-3caf65d8367d",
+      "title": "Development & AI 101",
+      "url": "https://notebooklm.google.com/notebook/900b111d-043f-408c-b97b-3caf65d8367d"
+    },
+    "devecon": {
+      "id": "959c243c-7fcf-4a1b-b9e4-30ec00fe5b3c",
+      "title": "Development Economics 101",
+      "url": "https://notebooklm.google.com/notebook/959c243c-7fcf-4a1b-b9e4-30ec00fe5b3c"
+    },
+    "gandhi": {
+      "id": "bf866beb-e84d-4aff-86cd-fea0401628bc",
+      "title": "Gandhi & Nonviolence 101",
+      "url": "https://notebooklm.google.com/notebook/bf866beb-e84d-4aff-86cd-fea0401628bc"
+    },
+    "gender": {
+      "id": "9d5909fa-269b-47fe-8c76-99ffe8ac88fc",
+      "title": "Gender & Equity 101",
+      "url": "https://notebooklm.google.com/notebook/9d5909fa-269b-47fe-8c76-99ffe8ac88fc"
+    },
+    "law": {
+      "id": "c0eba78d-1527-46cd-ba85-71e3dfaf2d32",
+      "title": "Law & Justice 101",
+      "url": "https://notebooklm.google.com/notebook/c0eba78d-1527-46cd-ba85-71e3dfaf2d32"
+    },
+    "media": {
+      "id": "5a0b44f0-6ec0-4838-81b5-b9c6e964a507",
+      "title": "Media & Information 101",
+      "url": "https://notebooklm.google.com/notebook/5a0b44f0-6ec0-4838-81b5-b9c6e964a507"
+    },
+    "mel": {
+      "id": "cc450613-e857-4889-9406-a85638f42966",
+      "title": "MEAL 101",
+      "url": "https://notebooklm.google.com/notebook/cc450613-e857-4889-9406-a85638f42966"
+    },
+    "poa": {
+      "id": "1e5a60e9-03b6-4ebb-89cb-869b9f5d0c62",
+      "title": "Policy & Advocacy 101",
+      "url": "https://notebooklm.google.com/notebook/1e5a60e9-03b6-4ebb-89cb-869b9f5d0c62"
+    },
+    "pubpol": {
+      "id": "1f3d2eef-38d1-4fa6-b202-fc65ad8b7db4",
+      "title": "Public Policy 101",
+      "url": "https://notebooklm.google.com/notebook/1f3d2eef-38d1-4fa6-b202-fc65ad8b7db4"
+    }
+  }
+}

--- a/docs/notebooklm-setup.md
+++ b/docs/notebooklm-setup.md
@@ -1,0 +1,83 @@
+# NotebookLM Setup
+
+Programmatic management of ImpactMojo's 11 AI Study Companion notebooks using [notebooklm-py](https://github.com/teng-lin/notebooklm-py).
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+playwright install chromium
+```
+
+## Authentication
+
+One-time setup — opens a browser for Google OAuth:
+
+```bash
+notebooklm login
+```
+
+Use the Google account that owns the 11 course notebooks. Credentials are stored locally and never committed.
+
+Verify with:
+
+```bash
+notebooklm status
+```
+
+## Usage
+
+### Management script
+
+```bash
+# Check auth status
+python3 scripts/notebooklm-manage.py status
+
+# List all notebooks with registry cross-reference
+python3 scripts/notebooklm-manage.py list
+
+# Sync registry titles from live API
+python3 scripts/notebooklm-manage.py sync-registry
+
+# Add a reading/URL to a course notebook
+python3 scripts/notebooklm-manage.py add-source devecon https://example.com/paper.pdf
+
+# Generate audio overview for a course
+python3 scripts/notebooklm-manage.py generate-audio gandhi
+```
+
+### CLI (notebooklm-py built-in)
+
+```bash
+notebooklm list                          # List all notebooks
+notebooklm sources list <notebook-id>    # List sources in a notebook
+notebooklm ask <notebook-id> "question"  # Ask a question
+notebooklm audio <notebook-id>           # Generate audio overview
+```
+
+## Registry
+
+`data/notebooklm-registry.json` maps course slugs to notebook IDs. This is the single source of truth for automation — notebook IDs are also embedded in course HTML pages but the registry is what scripts read.
+
+## Course notebooks
+
+| Slug | Course |
+|------|--------|
+| sel | Social and Emotional Learning 101 |
+| dataviz | Data Visualization 101 |
+| devai | Development & AI 101 |
+| devecon | Development Economics 101 |
+| gandhi | Gandhi & Nonviolence 101 |
+| gender | Gender & Equity 101 |
+| law | Law & Justice 101 |
+| media | Media & Information 101 |
+| mel | MEAL 101 |
+| poa | Policy & Advocacy 101 |
+| pubpol | Public Policy 101 |
+
+## Limitations
+
+- **Unofficial API** — uses undocumented Google APIs that may break without notice
+- **Interactive auth** — `notebooklm login` requires a browser, cannot run in CI/headless
+- **Per-machine credentials** — auth tokens are stored locally, not in the repo
+- **Rate limits** — Google may throttle requests; avoid rapid-fire operations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Python tooling for content management (not used by the static site)
+# Install: pip install -r requirements.txt && playwright install chromium
+notebooklm-py[browser]==0.3.4

--- a/scripts/notebooklm-manage.py
+++ b/scripts/notebooklm-manage.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+notebooklm-manage.py — Manage ImpactMojo NotebookLM study companions.
+
+Programmatic access to the 11 AI Study Companion notebooks linked from
+flagship course pages. Uses notebooklm-py (unofficial Google NotebookLM API).
+
+Usage:
+  python3 scripts/notebooklm-manage.py status
+  python3 scripts/notebooklm-manage.py list
+  python3 scripts/notebooklm-manage.py sync-registry
+  python3 scripts/notebooklm-manage.py add-source <slug> <url-or-file>
+  python3 scripts/notebooklm-manage.py generate-audio <slug>
+
+Prerequisites:
+  pip install -r requirements.txt && playwright install chromium
+  notebooklm login   # one-time Google OAuth
+"""
+
+import asyncio, json, os, sys
+
+# ─── Config ─────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.join(SCRIPT_DIR, "..")
+REGISTRY_PATH = os.path.join(ROOT_DIR, "data", "notebooklm-registry.json")
+
+
+# ─── Registry helpers ────────────────────────────────────────────────────────
+
+def load_registry():
+    """Load the notebook registry from data/notebooklm-registry.json."""
+    with open(REGISTRY_PATH, "r") as f:
+        return json.load(f)
+
+
+def save_registry(data):
+    """Write the notebook registry back to disk."""
+    with open(REGISTRY_PATH, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def get_notebook_id(slug):
+    """Look up a notebook ID by course slug. Exits on unknown slug."""
+    registry = load_registry()
+    entry = registry["notebooks"].get(slug)
+    if not entry:
+        slugs = ", ".join(sorted(registry["notebooks"].keys()))
+        print(f"Error: unknown course slug '{slug}'")
+        print(f"Available: {slugs}")
+        sys.exit(1)
+    return entry["id"]
+
+
+# ─── Commands ────────────────────────────────────────────────────────────────
+
+async def cmd_status():
+    """Check authentication status."""
+    from notebooklm import NotebookLMClient
+    try:
+        async with NotebookLMClient.from_storage() as client:
+            notebooks = await client.notebooks.list()
+            print(f"Authenticated. {len(notebooks)} notebooks accessible.")
+    except Exception as e:
+        print(f"Not authenticated: {e}")
+        print("Run: notebooklm login")
+        sys.exit(1)
+
+
+async def cmd_list():
+    """List all notebooks, cross-referenced with the registry."""
+    from notebooklm import NotebookLMClient
+
+    registry = load_registry()
+    registered_ids = {v["id"]: k for k, v in registry["notebooks"].items()}
+
+    async with NotebookLMClient.from_storage() as client:
+        notebooks = await client.notebooks.list()
+
+        print(f"{'Slug':<12} {'Title':<45} {'Sources':>7}")
+        print("─" * 66)
+        for nb in notebooks:
+            nb_id = nb.id if hasattr(nb, "id") else str(nb)
+            title = nb.title if hasattr(nb, "title") else "—"
+            sources = nb.source_count if hasattr(nb, "source_count") else "?"
+            slug = registered_ids.get(nb_id, "—")
+            print(f"{slug:<12} {title:<45} {sources:>7}")
+
+        # Show registered notebooks not found in the API response
+        api_ids = {nb.id if hasattr(nb, "id") else str(nb) for nb in notebooks}
+        missing = [s for s, v in registry["notebooks"].items() if v["id"] not in api_ids]
+        if missing:
+            print(f"\nNot found in API (may need sharing): {', '.join(missing)}")
+
+
+async def cmd_sync_registry():
+    """Sync registry with live notebook data from the API."""
+    from notebooklm import NotebookLMClient
+
+    registry = load_registry()
+
+    async with NotebookLMClient.from_storage() as client:
+        notebooks = await client.notebooks.list()
+        api_map = {}
+        for nb in notebooks:
+            nb_id = nb.id if hasattr(nb, "id") else str(nb)
+            api_map[nb_id] = nb
+
+        updated = 0
+        for slug, entry in registry["notebooks"].items():
+            nb = api_map.get(entry["id"])
+            if nb and hasattr(nb, "title"):
+                old_title = entry.get("title", "")
+                new_title = nb.title
+                if old_title != new_title:
+                    entry["title"] = new_title
+                    updated += 1
+                    print(f"  Updated {slug}: {old_title!r} -> {new_title!r}")
+
+    if updated:
+        save_registry(registry)
+        print(f"\nSynced {updated} notebook(s) to {REGISTRY_PATH}")
+    else:
+        print("Registry already up to date.")
+
+
+async def cmd_add_source(slug, source_path):
+    """Add a URL or file as a source to a course notebook."""
+    from notebooklm import NotebookLMClient
+
+    notebook_id = get_notebook_id(slug)
+
+    async with NotebookLMClient.from_storage() as client:
+        if source_path.startswith("http://") or source_path.startswith("https://"):
+            result = await client.sources.add_url(notebook_id, source_path)
+            print(f"Added URL source to {slug}: {source_path}")
+        elif os.path.isfile(source_path):
+            result = await client.sources.add_file(notebook_id, source_path)
+            print(f"Added file source to {slug}: {source_path}")
+        else:
+            print(f"Error: '{source_path}' is not a valid URL or existing file.")
+            sys.exit(1)
+
+
+async def cmd_generate_audio(slug):
+    """Generate an audio overview for a course notebook."""
+    from notebooklm import NotebookLMClient
+
+    notebook_id = get_notebook_id(slug)
+
+    async with NotebookLMClient.from_storage() as client:
+        print(f"Generating audio for {slug}... (this may take a few minutes)")
+        result = await client.artifacts.generate_audio(notebook_id)
+        print(f"Audio generated for {slug}.")
+        if hasattr(result, "url"):
+            print(f"URL: {result.url}")
+        elif hasattr(result, "download_url"):
+            print(f"Download: {result.download_url}")
+        else:
+            print(f"Result: {result}")
+
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+COMMANDS = {
+    "status": (cmd_status, 0),
+    "list": (cmd_list, 0),
+    "sync-registry": (cmd_sync_registry, 0),
+    "add-source": (cmd_add_source, 2),
+    "generate-audio": (cmd_generate_audio, 1),
+}
+
+
+def usage():
+    print(__doc__.strip())
+    print(f"\nCommands: {', '.join(COMMANDS.keys())}")
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+
+    cmd = sys.argv[1]
+    if cmd in ("-h", "--help", "help"):
+        usage()
+
+    if cmd not in COMMANDS:
+        print(f"Unknown command: {cmd}")
+        usage()
+
+    func, nargs = COMMANDS[cmd]
+    args = sys.argv[2:]
+    if len(args) < nargs:
+        print(f"Error: '{cmd}' requires {nargs} argument(s), got {len(args)}")
+        usage()
+
+    asyncio.run(func(*args[:nargs]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary\n\n- Install `notebooklm-py` to programmatically manage the 11 course AI Study Companion notebooks\n- Add `data/notebooklm-registry.json` as central registry of course-to-notebook ID mappings\n- Add `scripts/notebooklm-manage.py` CLI for listing, syncing, adding sources, and generating audio\n- Add `docs/notebooklm-setup.md` setup guide and `requirements.txt` for Python deps\n\n## Test plan\n\n- [ ] `python3 -m json.tool data/notebooklm-registry.json > /dev/null` validates JSON\n- [ ] `python3 scripts/notebooklm-manage.py --help` shows usage\n- [ ] After `notebooklm login`, `python3 scripts/notebooklm-manage.py status` confirms auth\n\nhttps://claude.ai/code/session_01NRc4SAmna5iTpDwbKYD612"