### PR TITLE
Mark 10 unbuilt placeholder courses as Coming Soon

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -939,6 +939,46 @@ body.dark-mode .v3-blob-4 { background: radial-gradient(circle, rgba(245, 158, 1
     color: var(--text-secondary);
 }
 
+/* Coming Soon cards — non-clickable placeholders for unbuilt courses */
+.card-coming-soon {
+    cursor: default;
+    opacity: 0.72;
+    position: relative;
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    background: var(--card-bg, #fff);
+    border: 1px dashed var(--border-color, #cbd5e1);
+    border-radius: var(--radius, 12px);
+    padding: 20px;
+}
+.card-coming-soon:hover {
+    transform: none;
+    box-shadow: none;
+    opacity: 0.85;
+}
+.card-coming-soon .card-title,
+.card-coming-soon .card-description {
+    color: var(--text-secondary, #64748b);
+}
+.card-coming-soon-badge {
+    display: inline-block;
+    padding: 3px 10px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #92400e;
+    background: #fef3c7;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+body.dark-mode .card-coming-soon-badge,
+[data-theme="dark"] .card-coming-soon-badge {
+    color: #fbbf24;
+    background: rgba(251, 191, 36, 0.12);
+}
+
 /* Empty State */
 .empty-state {
     text-align: center;
@@ -2231,18 +2271,18 @@ const allContent = [
     { id: 'c2', type: 'course', title: 'Theory of Change 101', description: 'Learn to design robust theories of change that articulate impact pathways.', track: 'mel', rating: 4.9, users: '2.1K', url: '/Labs/toc-lab.html' },
     { id: 'c3', type: 'course', title: 'Data Literacy 101', description: 'Build essential data skills for collecting, analyzing, and interpreting information.', track: 'data-tech', rating: 4.8, users: '1.8K', url: '/101-courses/data-lit.html' },
     { id: 'c4', type: 'course', title: 'Qualitative Methods 101', description: 'Master qualitative research techniques including interviews, focus groups, and ethnography.', track: 'mel', rating: 4.8, users: '1.6K', url: '/101-courses/qual-methods.html' },
-    { id: 'c5', type: 'course', title: 'Survey Design 101', description: 'Create effective questionnaires and sampling strategies for field research.', track: 'mel', rating: 4.8, users: '1.5K', url: 'https://101.impactmojo.in/survey-design' },
+    { id: 'c5', type: 'course', title: 'Survey Design 101', description: 'Create effective questionnaires and sampling strategies for field research.', track: 'mel', comingSoon: true, url: null },
     { id: 'c6', type: 'course', title: 'Research Ethics 101', description: 'Navigate ethical considerations in development research and protect vulnerable populations.', track: 'mel', rating: 4.8, users: '1.3K', url: '/101-courses/research-ethics.html' },
-    { id: 'c7', type: 'course', title: 'Gender Mainstreaming 101', description: 'Integrate gender perspectives across all stages of development programming.', track: 'gender', rating: 4.8, users: '1.4K', url: 'https://101.impactmojo.in/gender-mainstreaming' },
+    { id: 'c7', type: 'course', title: 'Gender Mainstreaming 101', description: 'Integrate gender perspectives across all stages of development programming.', track: 'gender', comingSoon: true, url: null },
     { id: 'c8', type: 'course', title: 'Development Economics 101', description: 'Understand core economic concepts shaping development policy and practice.', track: 'policy', rating: 4.8, users: '1.7K', url: '/101-courses/dev-economics.html' },
     { id: 'c9', type: 'course', title: 'Public Health 101', description: 'Explore epidemiology, health systems, and disease prevention strategies.', track: 'health', rating: 4.8, users: '1.2K', url: '/101-courses/pub-health-basics.html' },
     { id: 'c10', type: 'course', title: 'Visual Ethnography 101', description: 'Learn to document and analyze social phenomena through photography and video.', track: 'health', rating: 4.8, users: '890', url: '/101-courses/visual-eth.html' },
-    { id: 'c11', type: 'course', title: 'Mixed Methods 101', description: 'Combine quantitative and qualitative approaches for comprehensive research.', track: 'mel', rating: 4.8, users: '1.1K', url: 'https://101.impactmojo.in/mixed-methods' },
-    { id: 'c12', type: 'course', title: 'Impact Evaluation 101', description: 'Design rigorous impact evaluations using experimental and quasi-experimental methods.', track: 'mel', rating: 4.8, users: '1.3K', url: 'https://101.impactmojo.in/impact-eval' },
-    { id: 'c13', type: 'course', title: 'Maternal Health 101', description: 'Understand maternal health challenges and evidence-based interventions.', track: 'health', rating: 4.8, users: '980', url: 'https://101.impactmojo.in/maternal-health' },
-    { id: 'c14', type: 'course', title: 'Child Development 101', description: 'Explore early childhood development and nutrition interventions.', track: 'health', rating: 4.8, users: '1.0K', url: 'https://101.impactmojo.in/child-development' },
+    { id: 'c11', type: 'course', title: 'Mixed Methods 101', description: 'Combine quantitative and qualitative approaches for comprehensive research.', track: 'mel', comingSoon: true, url: null },
+    { id: 'c12', type: 'course', title: 'Impact Evaluation 101', description: 'Design rigorous impact evaluations using experimental and quasi-experimental methods.', track: 'mel', comingSoon: true, url: null },
+    { id: 'c13', type: 'course', title: 'Maternal Health 101', description: 'Understand maternal health challenges and evidence-based interventions.', track: 'health', comingSoon: true, url: null },
+    { id: 'c14', type: 'course', title: 'Child Development 101', description: 'Explore early childhood development and nutrition interventions.', track: 'health', comingSoon: true, url: null },
     { id: 'c15', type: 'course', title: 'Sexual Health 101', description: 'Navigate sensitive topics in sexual and reproductive health programming.', track: 'health', rating: 4.8, users: '780', url: '/101-courses/SRHR-basics.html' },
-    { id: 'c16', type: 'course', title: 'Feminist Research 101', description: 'Apply feminist methodologies to challenge power dynamics in knowledge production.', track: 'gender', rating: 4.8, users: '1.1K', url: 'https://101.impactmojo.in/feminist-research' },
+    { id: 'c16', type: 'course', title: 'Feminist Research 101', description: 'Apply feminist methodologies to challenge power dynamics in knowledge production.', track: 'gender', comingSoon: true, url: null },
     { id: 'c17', type: 'course', title: 'Marginalised Identities 101', description: 'Examine how caste, ethnicity, disability, and other identity markers create overlapping systems.', track: 'gender', rating: 4.8, users: '1.4K', url: '/101-courses/social-margins.html' },
     { id: 'c18', type: 'course', title: 'Decolonial Development 101', description: 'Challenge dominant development paradigms through postcolonial frameworks.', track: 'policy', rating: 4.8, users: '1.0K', url: '/101-courses/decolonize-dev.html' },
     { id: 'c19', type: 'course', title: 'Community Development 101', description: 'Master participatory approaches to community mobilization and asset-based development.', track: 'mel', rating: 4.8, users: '1.5K', url: '/101-courses/community-dev.html' },
@@ -2300,7 +2340,7 @@ const allContent = [
     { id: 'p4', type: 'premium', title: 'RQ Builder Pro', description: 'Advanced research question formulation and hypothesis development framework.', track: 'mel', rating: 4.9, users: '540', url: '/premium-tools/rq-builder.html' },
     { id: 'p5', type: 'premium', title: 'Code Converter Pro', description: 'Seamlessly translate statistical code between R, Stata, SPSS, and Python.', track: 'data-tech', rating: 4.8, users: '380', url: '/premium-tools/code-converter-pro.html' },
     { id: 'p6', type: 'premium', title: 'Team Training Dashboard', description: 'Centralized dashboard to track your entire teams learning progress.', track: 'mel', rating: 5.0, users: '120', url: 'mailto:hello@impactmojo.in' },
-    { id: 'p7', type: 'premium', title: 'VaniScribe: AI Transcription for Development', description: 'Transcribe field interviews, FGDs, and KIIs in Hindi, Tamil, Bengali, and 10+ South Asian languages. Speaker diarization, timestamping, and structured exports.', track: 'data-tech', rating: 4.9, users: '280', url: 'https://101.impactmojo.in/vaniscribe' }
+    { id: 'p7', type: 'premium', title: 'VaniScribe: AI Transcription for Development', description: 'Transcribe field interviews, FGDs, and KIIs in Hindi, Tamil, Bengali, and 10+ South Asian languages. Speaker diarization, timestamping, and structured exports.', track: 'data-tech', comingSoon: true, url: null }
 ];
 
 // =====================================================
@@ -2509,7 +2549,24 @@ function renderCards() {
     grid.style.display = 'grid';
     emptyState.style.display = 'none';
     
-    grid.innerHTML = filtered.map(item => `
+    grid.innerHTML = filtered.map(item => {
+        if (item.comingSoon) {
+            return `
+        <div class="card card-coming-soon" aria-disabled="true">
+            <div class="card-header">
+                <span class="card-type ${item.type}">${item.type}</span>
+                <span class="card-coming-soon-badge">Coming Soon</span>
+            </div>
+            <h3 class="card-title">${item.title}</h3>
+            <p class="card-description">${item.description}</p>
+            <div class="card-meta">
+                <span class="card-track">${item.track.toUpperCase()}</span>
+                <span class="card-users">In development</span>
+            </div>
+        </div>
+    `;
+        }
+        return `
         <a href="${item.url}" target="_blank" class="card">
             <div class="card-header">
                 <span class="card-type ${item.type}">${item.type}</span>
@@ -2522,7 +2579,8 @@ function renderCards() {
                 <span class="card-users">${item.users} users</span>
             </div>
         </a>
-    `).join('');
+    `;
+    }).join('');
 }
 
 // =====================================================

--- a/catalog_data.json
+++ b/catalog_data.json
@@ -68,7 +68,8 @@
       "type": "Course",
       "track": "Policy & Economics",
       "level": "Intro",
-      "link": "https://101.impactmojo.in/economics-101"
+      "link": null,
+      "comingSoon": true
     },
     {
       "title": "Data Feminism",
@@ -512,7 +513,8 @@
       "type": "Premium",
       "track": "Monitoring, Evaluation & Learning",
       "level": "Core",
-      "link": "https://101.impactmojo.in/vaniscribe"
+      "link": null,
+      "comingSoon": true
     },
     {
       "title": "Behavior Change Technique Repository",


### PR DESCRIPTION
Follow-up to #350.

That PR rewrote 121 of 131 stale `101.impactmojo.in` links to self-hosted equivalents and intentionally left 10 untouched because they advertise courses that were announced but never built.

This PR marks them as **Coming Soon** so visitors still see what's planned, without clicking into dead mirrors or seeing fabricated ratings.

## Changes

### `catalog.html` — 8 placeholder cards
| ID | Title |
|---|---|
| `c5` | Survey Design 101 |
| `c7` | Gender Mainstreaming 101 |
| `c11` | Mixed Methods 101 |
| `c12` | Impact Evaluation 101 |
| `c13` | Maternal Health 101 |
| `c14` | Child Development 101 |
| `c16` | Feminist Research 101 |
| `p7` | VaniScribe: AI Transcription for Development |

For each:
- Added `comingSoon: true`, set `url: null`
- Removed the (fabricated) ratings and user counts
- `renderCards()` now detects `comingSoon` and emits a non-clickable `<div>` with a "Coming Soon" badge instead of an `<a>`
- New CSS: `.card-coming-soon` (dashed border, 72% opacity) + `.card-coming-soon-badge` (amber pill, dark-mode aware via both `body.dark-mode` and `[data-theme="dark"]`)

### `catalog_data.json` — 2 entries
- `Economics 101: A Policy Primer` and `VaniScribe`: `link` set to `null`, added `"comingSoon": true`
- Any downstream consumer (MCP server, admin analytics) should check for the flag before surfacing these to users

## Verification
- `catalog.html` now has 0 references to `101.impactmojo.in`
- `catalog_data.json` now has 0 references to `101.impactmojo.in`
- Parsed the `allContent` array: 76 items total, 8 carry `comingSoon: true`
- `python3 -m json.tool catalog_data.json` passes

https://claude.ai/code/session_01PV6opcHjmKddEUhLUL5JUK