### PR TITLE
Grant pull-requests:write to a11y audit jobs so sticky PR comments work

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -13,6 +13,12 @@ jobs:
   axe-accessibility:
     name: axe-core WCAG 2.1 AA audit
     runs-on: ubuntu-latest
+    # Scoped permissions: read the repo, write sticky PR comments.
+    # Required by the 'Comment on PR with axe-core results' step below,
+    # which uses marocchino/sticky-pull-request-comment@v3.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
   accessibility:
     name: Accessibility audit (pa11y-ci)
     runs-on: ubuntu-latest
+    # Scoped permissions: read the repo, write sticky PR comments.
+    # Required by the 'Comment on PR with accessibility results' step below,
+    # which uses marocchino/sticky-pull-request-comment@v3.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Both the axe-core workflow (`accessibility.yml`) and the pa11y-ci job in `ci.yml` use `marocchino/sticky-pull-request-comment@v3` to post audit results back to the PR, but neither had a `permissions:` block — so the `GITHUB_TOKEN` defaulted to read-only and the commenting step failed on every PR with:

> `Resource not accessible by integration - https://docs.github.com/rest/issues/comments#create-an-issue-comment`

## Fix
Added a scoped `permissions:` block at the **job level** (not workflow level) for only the two jobs that post PR comments:

- `axe-accessibility` in `accessibility.yml`
- `accessibility` (pa11y-ci) in `ci.yml`

Each grants the minimum it needs:
```yaml
permissions:
  contents: read
  pull-requests: write
```

The other CI jobs (`broken-links`, `html-validate`) keep the default read-only token since they don't post comments.

https://claude.ai/code/session_01PV6opcHjmKddEUhLUL5JUK