### PR TITLE
Add accessibility statement page, README badges, and cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ImpactMojo
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/f9e879bf-4792-42aa-96ea-c3a3b396f8b8/deploy-status)](https://app.netlify.com/sites/impactmojo/deploys)
+[![Accessibility: WCAG 2.1 AA](https://img.shields.io/badge/Accessibility-WCAG_2.1_AA-success.svg)](https://www.impactmojo.in/accessibility.html)
+[![axe-core audit](https://github.com/ImpactMojo/ImpactMojo/actions/workflows/accessibility.yml/badge.svg?branch=main)](https://github.com/ImpactMojo/ImpactMojo/actions/workflows/accessibility.yml)
 [![Code License: MIT](https://img.shields.io/badge/Code-MIT-green.svg)](LICENSE)
 [![Content License: CC BY-NC-ND 4.0](https://img.shields.io/badge/Content-CC_BY--NC--ND_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-nd/4.0/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/about.html
+++ b/about.html
@@ -2231,6 +2231,10 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <p class="section-subtitle" style="margin-top: 32px;">
                 We also offer interactive labs for hands-on practice, educational games that make complex concepts engaging, premium tools for advanced practitioners, one-on-one coaching, and organizational workshops tailored to your team's needs.
             </p>
+
+            <p class="section-subtitle" style="margin-top: 24px;">
+                Every core page on ImpactMojo targets <strong>WCAG 2.1 Level AA</strong>, audited on every pull request by axe-core and pa11y-ci. Read the full <a href="/accessibility.html">Accessibility Statement</a> for scope, known limitations, and how to report a barrier.
+            </p>
         </section>
         
         <!-- Philosophy Section -->

--- a/accessibility.html
+++ b/accessibility.html
@@ -1,0 +1,1758 @@
+<!DOCTYPE html>
+<!--
+    +===============================================================================+
+    |  IMPACTMOJO - ACCESSIBILITY STATEMENT PAGE                                    |
+    |  Version: 1.0.0 - April 8, 2026                                               |
+    |                                                                               |
+    |  Formal WCAG 2.1 Level AA conformance statement. Based on PAGE-TEMPLATE v3.0. |
+    |  Covers: commitment, conformance status, how we test, accessibility features, |
+    |  known limitations, and how to report a barrier.                              |
+    |                                                                               |
+    |  INCLUDED FEATURES (ALL Required Elements):                                   |
+    |  [OK] Google Analytics (G-JRCMEB9TBW)                                            |
+    |  [OK] UserWay Accessibility Widget (account: EksmhlPg9k)                         |
+    |  [OK] Cache Control Meta Tags                                                    |
+    |  [OK] Auto-refresh on back/forward navigation (pageshow)                         |
+    |  [OK] Theme Toggle (Sun/Moon) with localStorage sync                             |
+    |  [OK] CSS Variables (Dark/Light mode matching index.html)                        |
+    |  [OK] Google Fonts (Amaranth body + Inter headings)                               |
+    |  [OK] Favicons (all 4 sizes + manifest.json)                                     |
+    |  [OK] Full Navigation with Dropdowns (Learn, Services, About Us)                 |
+    |  [OK] V3 Design Elements (Paper Planes, Gradient Blobs)                          |
+    |  [OK] Full 4-Section Footer (About, Legal IT Act, Quick Links, Resources)        |
+    |  [OK] Mojini Chatbot with FAQ bank                                               |
+    |  [OK] Cookie Consent Banner                                                      |
+    |  [OK] Speed Dial Toolbox (Bookmarks, Notes, Streak)                              |
+    |  [OK] Mobile Responsive Design with Fixed Menu                                   |
+    |  [OK] Tour Disabled on Mobile                                                    |
+    +===============================================================================+
+-->
+<html lang="en">
+<head>
+<!-- Early Mobile Menu Functions - Must load before DOM -->
+<script>
+/* Mobile Menu Functions - Defined early for onclick handlers */
+function toggleMobileMenu() {
+    var navLinks = document.getElementById('navLinks');
+    var toggle = document.getElementById('mobile-menu-btn');
+    var overlay = document.getElementById('mobileMenuOverlay');
+    var authSection = document.getElementById('mobileAuthSection');
+    
+    if (!navLinks) return;
+    
+    var isOpen = navLinks.classList.contains('active');
+    
+    if (isOpen) {
+        navLinks.classList.remove('active');
+        if (toggle) toggle.classList.remove('active');
+        if (overlay) overlay.classList.remove('active');
+        if (authSection) authSection.classList.remove('active');
+        document.body.classList.remove('menu-open');
+        document.body.style.overflow = '';
+        document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(item) {
+            item.classList.remove('open');
+        });
+    } else {
+        navLinks.classList.add('active');
+        if (toggle) toggle.classList.add('active');
+        if (overlay) overlay.classList.add('active');
+        if (authSection) authSection.classList.add('active');
+        document.body.classList.add('menu-open');
+        document.body.style.overflow = 'hidden';
+    }
+}
+
+function closeMobileMenu() {
+    var navLinks = document.getElementById('navLinks');
+    var toggle = document.getElementById('mobile-menu-btn');
+    var overlay = document.getElementById('mobileMenuOverlay');
+    var authSection = document.getElementById('mobileAuthSection');
+    
+    if (navLinks) navLinks.classList.remove('active');
+    if (toggle) toggle.classList.remove('active');
+    if (overlay) overlay.classList.remove('active');
+    if (authSection) authSection.classList.remove('active');
+    document.body.classList.remove('menu-open');
+    document.body.style.overflow = '';
+    
+    document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(item) {
+        item.classList.remove('open');
+    });
+}
+
+function toggleMobileDropdown(event, element) {
+    event.preventDefault();
+    event.stopPropagation();
+    
+    var li = element.closest('li.has-dropdown');
+    if (!li) return;
+    
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nav-links > li.has-dropdown.open').forEach(function(item) {
+            if (item !== li) item.classList.remove('open');
+        });
+        li.classList.toggle('open');
+    }
+}
+
+/* Disable tour on mobile */
+(function() {
+    var isMobile = window.innerWidth <= 768 || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    if (isMobile) {
+        window.shepherdTourDisabled = true;
+        window.tourDisabled = true;
+        window.startTour = function() { console.log('Tour disabled on mobile'); };
+    }
+})();
+</script>
+
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<!-- Google tag (gtag.js) - G-JRCMEB9TBW -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<!-- Cache Control - Force fresh content -->
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate, max-age=0">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="-1">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta name="version" content="3.0.0.20251206">
+
+<!-- Auto-refresh on back/forward navigation -->
+<script>
+window.addEventListener('pageshow', function(event) {
+    if (event.persisted) {
+        window.location.reload();
+    }
+});
+</script>
+
+<!-- SEO Meta Tags -->
+<meta name="description" content="ImpactMojo Accessibility Statement — our commitment to WCAG 2.1 Level AA conformance, the tools and audits we run on every pull request, and how to report an accessibility barrier.">
+<meta property="og:title" content="Accessibility Statement | ImpactMojo">
+<meta property="og:description" content="ImpactMojo's commitment to WCAG 2.1 Level AA — axe-core + pa11y-ci on every PR, known limitations, and how to report an accessibility barrier.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.impactmojo.in/accessibility.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Accessibility Statement | ImpactMojo">
+<meta name="twitter:description" content="ImpactMojo's commitment to WCAG 2.1 Level AA — axe-core + pa11y-ci on every PR, known limitations, and how to report an accessibility barrier.">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+
+<title>Accessibility Statement | ImpactMojo</title>
+
+<!-- Favicons -->
+<link href="assets/images/favicon.png" rel="icon" type="image/png">
+<link href="assets/images/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+<link href="assets/images/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
+<link href="assets/images/apple-touch-icon.png" rel="apple-touch-icon">
+<link href="manifest.json" rel="manifest">
+<meta name="theme-color" content="#0EA5E9">
+
+<!-- Google Fonts - Amaranth & Inter -->
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;display=swap" rel="stylesheet">
+
+<style>
+/* ========================================
+   CSS RESET
+   ======================================== */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+/* ========================================
+   CSS VARIABLES - V3 Design System
+   ======================================== */
+:root {
+    --primary-bg: #F8FAFC;
+    --secondary-bg: #FFFFFF;
+    --accent-color: #0284C7;
+    --accent-hover: #0369A1;
+    --text-primary: #0F172A;
+    --text-secondary: #475569;
+    --text-muted: #64748B;
+    --card-bg: #FFFFFF;
+    --hover-bg: #F1F5F9;
+    --border-color: #E2E8F0;
+    --nav-bg: rgba(248, 250, 252, 0.95);
+    --nav-text: #0F172A;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.03);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.05);
+    --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.08);
+}
+@media (prefers-color-scheme: dark) { :root {
+    /* Primary Colors - Sky Blue Accent */
+    --primary-bg: #0F172A;
+    --secondary-bg: #1E293B;
+    --accent-color: #0EA5E9;
+    --accent-hover: #0284C7;
+    --secondary-accent: #6366F1;
+    --success-color: #10B981;
+    --warning-color: #F59E0B;
+    --danger-color: #EF4444;
+    
+    /* Text Colors */
+    --text-primary: #F1F5F9;
+    --text-secondary: #CBD5E1;
+    --text-muted: #94A3B8;
+    
+    /* Card & Surface */
+    --card-bg: #1E293B;
+    --hover-bg: #334155;
+    --border-color: #334155;
+    
+    /* Gradients */
+    --gradient-primary: linear-gradient(135deg, #0369A1 0%, #4338CA 100%);
+    --gradient-accent: linear-gradient(135deg, #0EA5E9 0%, #10B981 100%);
+    --gradient-hero: linear-gradient(180deg, rgba(14, 165, 233, 0.1) 0%, transparent 50%);
+    
+    /* Navigation */
+    --nav-bg: rgba(15, 23, 42, 0.95);
+    --nav-text: #F1F5F9;
+    
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.2);
+    --shadow-xl: 0 20px 40px rgba(0, 0, 0, 0.3);
+} }
+body.light-mode, [data-theme="light"] {
+    --primary-bg: #F8FAFC;
+    --secondary-bg: #FFFFFF;
+    --accent-color: #0284C7;
+    --accent-hover: #0369A1;
+    --text-primary: #0F172A;
+    --text-secondary: #475569;
+    --text-muted: #64748B;
+    --card-bg: #FFFFFF;
+    --hover-bg: #F1F5F9;
+    --border-color: #E2E8F0;
+    --nav-bg: rgba(248, 250, 252, 0.95);
+    --nav-text: #0F172A;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.03);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.05);
+    --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.08);
+}
+body.dark-mode, [data-theme="dark"] {
+    /* Primary Colors - Sky Blue Accent */
+    --primary-bg: #0F172A;
+    --secondary-bg: #1E293B;
+    --accent-color: #0EA5E9;
+    --accent-hover: #0284C7;
+    --secondary-accent: #6366F1;
+    --success-color: #10B981;
+    --warning-color: #F59E0B;
+    --danger-color: #EF4444;
+    
+    /* Text Colors */
+    --text-primary: #F1F5F9;
+    --text-secondary: #CBD5E1;
+    --text-muted: #94A3B8;
+    
+    /* Card & Surface */
+    --card-bg: #1E293B;
+    --hover-bg: #334155;
+    --border-color: #334155;
+    
+    /* Gradients */
+    --gradient-primary: linear-gradient(135deg, #0369A1 0%, #4338CA 100%);
+    --gradient-accent: linear-gradient(135deg, #0EA5E9 0%, #10B981 100%);
+    --gradient-hero: linear-gradient(180deg, rgba(14, 165, 233, 0.1) 0%, transparent 50%);
+    
+    /* Navigation */
+    --nav-bg: rgba(15, 23, 42, 0.95);
+    --nav-text: #F1F5F9;
+    
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.2);
+    --shadow-xl: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+/* Light Mode Variables */
+[data-theme="light"],
+
+
+/* ========================================
+   BASE STYLES
+   ======================================== */
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: 'Amaranth', sans-serif;
+    background: var(--primary-bg);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+}
+
+a {
+    color: var(--accent-color);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+a:hover {
+    color: var(--accent-hover);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Inter', sans-serif;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+/* ========================================
+   V3 DECORATIVE ELEMENTS - Paper Planes & Blobs
+   ======================================== */
+.v3-decoration-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.v3-paper-plane {
+    position: fixed;
+    top: 15%;
+    right: 8%;
+    width: 140px;
+    height: 140px;
+    opacity: 0.25;
+    z-index: 0;
+    pointer-events: none;
+    animation: v3-float-plane 25s ease-in-out infinite;
+}
+@keyframes v3-float-plane {
+    0% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(-60px, 40px) rotate(10deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+    100% { transform: translate(0, 0) rotate(0deg); }
+}
+@media (max-width: 768px) {
+    .v3-paper-plane { width: 100px; height: 100px; top: 10%; right: 5%; opacity: 0.15; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .v3-paper-plane { animation: none !important; }
+}
+
+.v3-blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.15;
+    animation: pulseBlob 15s ease-in-out infinite;
+}
+
+.v3-blob-1 {
+    top: 10%;
+    right: 10%;
+    width: 400px;
+    height: 400px;
+    background: var(--accent-color);
+    animation-delay: 0s;
+}
+
+.v3-blob-2 {
+    bottom: 20%;
+    left: 5%;
+    width: 300px;
+    height: 300px;
+    background: var(--secondary-accent);
+    animation-delay: -5s;
+}
+
+@keyframes pulseBlob {
+    0%, 100% { transform: scale(1); opacity: 0.15; }
+    50% { transform: scale(1.1); opacity: 0.2; }
+}
+
+/* ========================================
+   HEADER & NAVIGATION
+   ======================================== */
+.header {
+    position: fixed; left: 0; right: 0;
+    top: 0;
+    z-index: 1000;
+    background: var(--nav-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.nav-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 0.75rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.logo-container {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+}
+
+.logo-svg img {
+    width: 48px;
+    height: 48px;
+    border-radius: 10px;
+    object-fit: contain;
+}
+
+.logo-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.logo-main {
+    font-family: 'Inter', sans-serif;
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.2;
+}
+
+.logo-tagline {
+    font-size: 0.7rem;
+    color: var(--accent-color);
+    font-weight: 500;
+    letter-spacing: 0.5px;
+}
+
+/* Mobile Menu Toggle */
+.mobile-menu-toggle {
+    display: none;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    cursor: pointer;
+    width: 48px;
+    height: 48px;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 5px;
+    padding: 10px;
+    z-index: 9999;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+}
+
+.mobile-menu-toggle .hamburger-line {
+    width: 22px;
+    height: 2px;
+    background: var(--text-primary);
+    border-radius: 2px;
+    transition: all 0.3s ease;
+    display: block;
+}
+
+.mobile-menu-toggle.active .hamburger-line:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+}
+
+.mobile-menu-toggle.active .hamburger-line:nth-child(2) {
+    opacity: 0;
+}
+
+.mobile-menu-toggle.active .hamburger-line:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+}
+
+/* Navigation Links */
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    list-style: none;
+}
+
+.nav-links > li > a {
+    padding: 0.6rem 1rem;
+    color: var(--nav-text);
+    font-weight: 500;
+    font-size: 0.95rem;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-links > li > a:hover {
+    background: var(--hover-bg);
+    color: var(--accent-color);
+}
+
+/* Sargam inline icons */
+.v3-inline-icon {
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+    vertical-align: middle;
+    filter: brightness(0) saturate(100%) invert(56%) sepia(92%) saturate(1500%) hue-rotate(175deg) brightness(96%) contrast(91%);
+}
+
+/* Dropdown Menu */
+.has-dropdown {
+    position: relative;
+}
+
+.dropdown-arrow {
+    width: 14px;
+    height: 14px;
+    transition: transform 0.3s ease;
+}
+
+.has-dropdown:hover .dropdown-arrow {
+    transform: rotate(180deg);
+}
+
+.dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 0.5rem;
+    min-width: 200px;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+    transition: all 0.3s ease;
+    box-shadow: var(--shadow-lg);
+    z-index: 100;
+    list-style: none;
+}
+
+.has-dropdown:hover .dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.dropdown-menu a {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    color: var(--text-primary);
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.dropdown-menu a:hover {
+    background: var(--hover-bg);
+    color: var(--accent-color);
+    padding-left: 1.25rem;
+}
+
+.dropdown-divider {
+    height: 1px;
+    background: var(--border-color);
+    margin: 0.5rem 0;
+}
+
+/* Nav Buttons */
+.nav-buttons {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.theme-toggle {
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+}
+
+.theme-toggle:hover {
+    background: var(--hover-bg);
+    border-color: var(--accent-color);
+}
+
+.theme-toggle svg {
+    width: 20px;
+    height: 20px;
+    stroke: var(--text-primary);
+    fill: none;
+    stroke-width: 2;
+}
+
+.theme-toggle .icon-moon {
+    display: none;
+}
+
+.light-mode .theme-toggle .icon-sun {
+    display: none;
+}
+
+.light-mode .theme-toggle .icon-moon {
+    display: block;
+}
+
+/* Mobile Menu Overlay */
+.mobile-menu-overlay,
+.mobile-auth-section {
+    display: none;
+}
+
+/* ========================================
+   PAGE CONTENT AREA
+   ======================================== */
+.page-content {
+    flex: 1;
+    position: relative;
+    z-index: 1;
+}
+
+.page-hero {
+    padding: 4rem 2rem;
+    text-align: center;
+    background: var(--gradient-hero);
+    position: relative;
+}
+
+.page-hero h1 {
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+    background: var(--gradient-primary);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.page-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary);
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 2rem;
+}
+
+/* Cards Grid */
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 1.5rem;
+    transition: all 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--accent-color);
+}
+
+/* Buttons */
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.875rem 1.5rem;
+    background: var(--gradient-primary);
+    color: white;
+    font-weight: 600;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(14, 165, 233, 0.3);
+    color: white;
+}
+
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.875rem 1.5rem;
+    background: var(--card-bg);
+    color: var(--text-primary);
+    font-weight: 600;
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-secondary:hover {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+/* ========================================
+   FOOTER
+   ======================================== */
+.footer {
+    background: var(--secondary-bg);
+    border-top: 1px solid var(--border-color);
+    padding: 3rem 2rem 1.5rem;
+    position: relative;
+    z-index: 1;
+}
+
+.footer-content {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.footer-section h4 {
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.footer-section ul {
+    list-style: none;
+}
+
+.footer-section li {
+    margin-bottom: 0.5rem;
+}
+
+.footer-section a {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    transition: color 0.2s ease;
+}
+
+.footer-section a:hover {
+    color: var(--accent-color);
+}
+
+.footer-bottom {
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.footer-copyright {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.footer-social {
+    display: flex;
+    gap: 1rem;
+}
+
+.footer-social a {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+}
+
+.footer-social a:hover {
+    background: var(--accent-color);
+    border-color: var(--accent-color);
+    color: white;
+}
+
+.footer-social svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+/* ========================================
+   SPEED DIAL TOOLBOX
+   ======================================== */
+/* ========================================
+   MOJINI CHATBOT
+   ======================================== */
+.feedback-fab {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--gradient-primary);
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-lg);
+    z-index: 9000;
+    transition: all 0.3s ease;
+}
+
+.feedback-fab:hover {
+    transform: scale(1.1);
+    box-shadow: var(--shadow-xl);
+}
+
+.feedback-fab svg {
+    width: 24px;
+    height: 24px;
+    stroke: white;
+    fill: none;
+    stroke-width: 2;
+}
+
+.chatbot-modal {
+    display: none;
+    position: fixed;
+    bottom: 90px;
+    right: 24px;
+    width: 380px;
+    max-width: calc(100vw - 48px);
+    max-height: 500px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    box-shadow: var(--shadow-xl);
+    z-index: 9001;
+    overflow: hidden;
+    flex-direction: column;
+}
+
+.chatbot-modal.open {
+    display: flex;
+}
+
+.chat-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    background: var(--gradient-primary);
+    color: white;
+}
+
+.chat-header h3 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.chat-header svg {
+    width: 20px;
+    height: 20px;
+    stroke: white;
+    fill: none;
+}
+
+.chat-close {
+    background: rgba(255,255,255,0.2);
+    border: none;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease;
+}
+
+.chat-close:hover {
+    background: rgba(255,255,255,0.3);
+}
+
+.chat-close svg {
+    width: 16px;
+    height: 16px;
+    stroke: white;
+}
+
+.chat-messages {
+    flex: 1;
+    padding: 16px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 300px;
+}
+
+.bot-message {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.bot-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--gradient-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.bot-avatar svg {
+    width: 18px;
+    height: 18px;
+    stroke: white;
+    fill: none;
+}
+
+.bot-bubble {
+    background: var(--secondary-bg);
+    padding: 12px 16px;
+    border-radius: 12px;
+    border-top-left-radius: 4px;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    max-width: 85%;
+}
+
+.chat-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 0 16px 12px;
+}
+
+.chat-option {
+    padding: 8px 14px;
+    background: var(--secondary-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.chat-option:hover {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+.chat-input-area {
+    display: flex;
+    gap: 10px;
+    padding: 16px;
+    border-top: 1px solid var(--border-color);
+    background: var(--secondary-bg);
+}
+
+.chat-input-area input {
+    flex: 1;
+    padding: 10px 14px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    outline: none;
+}
+
+.chat-input-area input:focus {
+    border-color: var(--accent-color);
+}
+
+.chat-send {
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    background: var(--gradient-primary);
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease;
+}
+
+.chat-send:hover {
+    transform: scale(1.05);
+}
+
+.chat-send svg {
+    width: 18px;
+    height: 18px;
+    stroke: white;
+    fill: none;
+}
+
+/* ========================================
+   MOBILE RESPONSIVE STYLES
+   ======================================== */
+@media (max-width: 768px) {
+    /* Hide tour on mobile */
+    .tour-toggle,
+    .shepherd-element,
+    .imx-tour-welcome,
+    .imx-tour-tooltip {
+        display: none !important;
+    }
+    
+    /* Header mobile */
+    .nav-container {
+        padding: 0.75rem 1rem;
+    }
+    
+    /* Show hamburger */
+    .mobile-menu-toggle {
+        display: flex !important;
+    }
+    
+    .logo-tagline {
+        display: none;
+    }
+    
+    /* Hide desktop nav */
+    .nav-links {
+        display: none;
+        position: fixed;
+        top: 70px;
+        left: 0;
+        right: 0;
+        width: 100%;
+        background: var(--card-bg);
+        flex-direction: column;
+        padding: 1rem;
+        border-top: 1px solid var(--border-color);
+        box-shadow: var(--shadow-lg);
+        z-index: 9998;
+        max-height: calc(100vh - 70px);
+        overflow-y: auto;
+    }
+    
+    .nav-links.active {
+        display: flex;
+    }
+    
+    .nav-links > li {
+        width: 100%;
+        border-bottom: 1px solid var(--border-color);
+    }
+    
+    .nav-links > li > a {
+        padding: 1rem;
+        justify-content: space-between;
+    }
+    
+    /* Mobile dropdowns */
+    .dropdown-menu {
+        position: static;
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+        max-height: 0;
+        overflow: hidden;
+        padding: 0;
+        border: none;
+        box-shadow: none;
+        background: var(--secondary-bg);
+        transition: max-height 0.3s ease;
+    }
+    
+    .has-dropdown.open .dropdown-menu {
+        max-height: 500px;
+        padding: 0.5rem 0;
+    }
+    
+    .has-dropdown.open .dropdown-arrow {
+        transform: rotate(180deg);
+    }
+    
+    /* Mobile menu overlay */
+    .mobile-menu-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0,0,0,0.5);
+        z-index: 9997;
+    }
+    
+    .mobile-menu-overlay.active {
+        display: block;
+    }
+    
+    /* Mobile auth section */
+    .mobile-auth-section {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 1rem;
+        background: var(--secondary-bg);
+        border-top: 1px solid var(--border-color);
+        z-index: 9999;
+        gap: 0.75rem;
+    }
+    
+    .mobile-auth-section.active {
+        display: flex;
+    }
+    
+    .mobile-auth-btn {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.875rem;
+        border-radius: 10px;
+        font-weight: 600;
+        text-decoration: none;
+    }
+    
+    .mobile-auth-login {
+        background: var(--card-bg);
+        color: var(--text-primary);
+        border: 1px solid var(--border-color);
+    }
+    
+    .mobile-auth-signup {
+        background: var(--gradient-primary);
+        color: white;
+    }
+    
+    /* Body scroll lock */
+    body.menu-open {
+        overflow: hidden;
+    }
+    
+    /* Hide desktop nav buttons on mobile */
+    .nav-buttons .auth-btn {
+        display: none;
+    }
+    
+    /* Page hero mobile */
+    .page-hero {
+        padding: 2.5rem 1.25rem;
+    }
+    
+    .page-hero h1 {
+        font-size: 1.75rem;
+    }
+    
+    .page-hero p {
+        font-size: 1rem;
+    }
+    
+    /* Container mobile */
+    .container {
+        padding: 2rem 1.25rem;
+    }
+    
+    /* Cards mobile */
+    .cards-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    /* Footer mobile */
+    .footer {
+        padding: 2rem 1.25rem 1rem;
+    }
+    
+    .footer-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+    
+    .footer-bottom {
+        flex-direction: column;
+        text-align: center;
+    }
+    
+    /* FABs mobile */
+    .feedback-fab {
+        bottom: 80px;
+        right: 16px;
+    }
+    
+    .chatbot-modal {
+        bottom: 140px;
+        right: 16px;
+        left: 16px;
+        width: auto;
+        max-height: 60vh;
+    }
+    
+    /* Cookie consent mobile */
+    /* Decorative elements mobile */
+    .v3-paper-plane {
+        width: 100px;
+        height: 100px;
+        top: 10%;
+        right: 5%;
+        opacity: 0.15;
+    }
+    
+    .v3-blob {
+        display: none;
+    }
+}
+
+@media (max-width: 480px) {
+    .footer-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .page-hero h1 {
+        font-size: 1.5rem;
+    }
+}
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+</style>
+</head>
+<body>
+
+<!-- V3 Decorative Elements - Paper Planes & Blobs -->
+<div class="v3-decoration-container">
+    <!-- Gradient Blobs -->
+    <div class="v3-blob v3-blob-1"></div>
+    <div class="v3-blob v3-blob-2"></div>
+</div>
+<svg class="v3-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+
+<!-- Header -->
+<header class="header">
+    <nav class="nav-container">
+        <a class="logo-container" href="index.html">
+            <div class="logo-svg">
+                <img alt="ImpactMojo logo" src="assets/images/ImpactMojo%20Logo.png" width="48" height="48" loading="lazy">
+            </div>
+            <div class="logo-text">
+                <div class="logo-main">ImpactMojo</div>
+                <div class="logo-tagline">Development Know-How</div>
+            </div>
+        </a>
+        
+        <button class="mobile-menu-toggle" id="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" type="button">
+            <span class="hamburger-line"></span>
+            <span class="hamburger-line"></span>
+            <span class="hamburger-line"></span>
+        </button>
+        
+        <!-- Mobile Auth Section -->
+        <div class="mobile-auth-section" id="mobileAuthSection">
+            <a href="login.html" class="mobile-auth-btn mobile-auth-login" onclick="closeMobileMenu()">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
+                Log In
+            </a>
+            <a href="signup.html" class="mobile-auth-btn mobile-auth-signup" onclick="closeMobileMenu()">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>
+                Sign Up
+            </a>
+        </div>
+        
+        <ul class="nav-links" id="navLinks">
+            <li><a href="index.html">Home</a></li>
+            
+            <!-- Learn Dropdown -->
+            <li class="has-dropdown">
+                <a href="javascript:void(0)" onclick="toggleMobileDropdown(event, this)">Learn
+                    <svg class="dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                </a>
+                <ul class="dropdown-menu">
+                    <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="handouts.html">Resources</a></li>
+                    <li class="dropdown-divider"></li>
+                    <li><a href="premium.html">Premium</a></li>
+                </ul>
+            </li>
+            
+            <!-- Services Dropdown -->
+            <li class="has-dropdown">
+                <a href="javascript:void(0)" onclick="toggleMobileDropdown(event, this)">Services
+                    <svg class="dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                </a>
+                <ul class="dropdown-menu">
+                    <li><a href="coaching.html">Coaching</a></li>
+                    <li><a href="workshops.html">Workshops</a></li>
+                </ul>
+            </li>
+            
+            <!-- About Us Dropdown -->
+            <li class="has-dropdown">
+                <a href="javascript:void(0)" onclick="toggleMobileDropdown(event, this)">About Us
+                    <svg class="dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                </a>
+                <ul class="dropdown-menu">
+                    <li><a href="about.html">About ImpactMojo</a></li>
+                    <li><a href="contact.html">Contact</a></li>
+                    <li class="dropdown-divider"></li>
+                    <li><a href="community/">Community</a></li>
+                </ul>
+            </li>
+            
+            <li><a href="blog.html">Blog <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Article.svg" alt="" class="v3-inline-icon" loading="lazy"></a></li>
+            <li><a href="podcast.html">Podcast <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Album.svg" alt="" class="v3-inline-icon" loading="lazy"></a></li>
+        </ul>
+        
+        <div class="nav-buttons">
+            <button class="theme-toggle" onclick="toggleTheme()" title="Toggle Dark/Light Mode">
+                <svg class="icon-sun" viewBox="0 0 24 24">
+                    <circle cx="12" cy="12" r="5"></circle>
+                    <line x1="12" y1="1" x2="12" y2="3"></line>
+                    <line x1="12" y1="21" x2="12" y2="23"></line>
+                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                    <line x1="1" y1="12" x2="3" y2="12"></line>
+                    <line x1="21" y1="12" x2="23" y2="12"></line>
+                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                </svg>
+                <svg class="icon-moon" viewBox="0 0 24 24">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+            </button>
+        </div>
+    </nav>
+</header>
+
+<!-- Mobile Menu Overlay -->
+<div class="mobile-menu-overlay" id="mobileMenuOverlay" onclick="closeMobileMenu()"></div>
+
+<!-- PAGE CONTENT -->
+<main class="page-content" id="main-content">
+    <section class="page-hero">
+        <h1>Accessibility Statement</h1>
+        <p>Our commitment to WCAG 2.1 Level AA conformance, how we test for it, and how to report a barrier you run into.</p>
+    </section>
+
+    <div class="container" style="max-width: 860px; padding: 2rem 1.5rem 4rem;">
+
+        <section aria-labelledby="commitment-heading" style="margin-bottom: 3rem;">
+            <h2 id="commitment-heading">Our commitment</h2>
+            <p>ImpactMojo is a free platform for development education across South Asia. A platform that cannot be used by people with disabilities &mdash; by screen reader users, keyboard-only users, people with low vision, people with motor impairments, people with cognitive differences &mdash; is not actually free. It is free only to those whose bodies already match what the web assumed.</p>
+            <p>We treat accessibility as a baseline, not a feature. Every page we ship should be usable with a screen reader, navigable with a keyboard, readable at any zoom level up to 200%, and legible to someone with moderate colour-vision differences or low-contrast sensitivity.</p>
+        </section>
+
+        <section aria-labelledby="conformance-heading" style="margin-bottom: 3rem;">
+            <h2 id="conformance-heading">Conformance status</h2>
+            <p><strong>Target:</strong> <a href="https://www.w3.org/TR/WCAG21/" rel="noopener">Web Content Accessibility Guidelines (WCAG) 2.1</a>, Level AA.</p>
+            <p><strong>Current status:</strong> Partially conformant. The core public pages of impactmojo.in meet WCAG 2.1 Level AA as measured by automated tooling (see below). Some third-party embedded content and legacy pages have known limitations that we are working through.</p>
+            <p><strong>Scope:</strong> This statement covers everything under <code>https://www.impactmojo.in/</code>, including the homepage, course catalog, 11 flagship courses, 38 foundational 101 decks, 16 games, 11 labs, book summaries, blog, and policy pages. It does <em>not</em> cover external sites we link to.</p>
+            <p><strong>Statement last updated:</strong> 8 April 2026.</p>
+        </section>
+
+        <section aria-labelledby="how-we-test-heading" style="margin-bottom: 3rem;">
+            <h2 id="how-we-test-heading">How we test</h2>
+            <p>Every pull request to <code>main</code> runs two independent accessibility audits before it can be merged. If either finds a serious or critical WCAG 2.1 AA violation, the build fails and the change does not ship.</p>
+
+            <h3>axe-core WCAG 2.1 AA audit</h3>
+            <p>We run <a href="https://github.com/dequelabs/axe-core" rel="noopener">axe-core</a> against five high-traffic pages on every PR &mdash; the homepage, About, Catalog, BCT Repository, and a representative flagship course (<code>courses/mel/index.html</code>). The audit fails if it finds any <em>serious</em> or <em>critical</em> impact violation. Warnings at <em>moderate</em> or <em>minor</em> impact are reported but do not block merging.</p>
+
+            <h3>pa11y-ci sitewide audit</h3>
+            <p>We run <a href="https://github.com/pa11y/pa11y-ci" rel="noopener">pa11y-ci</a> against thirteen pages that cover the breadth of the site: Home, Login, Signup, About, Catalog, BCT Repository, Premium, Account, Coaching, FAQ, Dojos, Dataverse, and Handouts. The standard is WCAG 2.1 AA. Four narrowly scoped rules are ignored &mdash; three are known HTML_CodeSniffer false positives on our input name attributes and one on a known-good contrast token &mdash; and these exceptions are documented in <code>.pa11yci</code>.</p>
+
+            <h3>Manual review</h3>
+            <p>Automated tools catch roughly 30&ndash;50% of real accessibility issues. For the rest, we do manual keyboard-only navigation testing, screen reader testing with VoiceOver and NVDA when we ship major new sections, and we read our own pages at 200% zoom to check that nothing reflows off the screen or becomes unreachable.</p>
+
+            <p style="margin-top: 1.5rem;">For the full story of how we got here &mdash; including the day we discovered our own site was lying about its accessibility state &mdash; read <a href="/blog/making-accessible-websites.html">What It Actually Takes to Make an Accessible Website</a> on our blog.</p>
+        </section>
+
+        <section aria-labelledby="features-heading" style="margin-bottom: 3rem;">
+            <h2 id="features-heading">Accessibility features</h2>
+            <ul>
+                <li><strong>Semantic HTML5</strong> throughout &mdash; proper landmarks (<code>&lt;nav&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>), heading hierarchy, and form labels.</li>
+                <li><strong>Keyboard navigation</strong> on every interactive element, with visible <code>:focus-visible</code> outlines that survive colour-theme changes.</li>
+                <li><strong>Skip-to-content</strong> links on pages with long navigation headers.</li>
+                <li><strong>High-contrast colour tokens</strong> &mdash; body text meets at least 6.2:1 on light and 6.96:1 on dark, well above the WCAG AA requirement of 4.5:1.</li>
+                <li><strong>Dark mode + system-preference default</strong> &mdash; pages follow your OS setting on first paint, and an explicit System / Light / Dark toggle lets you override.</li>
+                <li><strong>200% zoom</strong> without horizontal scrolling on any core page.</li>
+                <li><strong>Reduced-motion support</strong> &mdash; decorative animations disable automatically when <code>prefers-reduced-motion: reduce</code> is set.</li>
+                <li><strong>Inline link underlines</strong> in body text so links are distinguishable without relying on colour alone (WCAG 2.1 §1.4.1).</li>
+                <li><strong>UserWay accessibility widget</strong> available on every page for quick on-the-fly adjustments to text size, spacing, contrast, and readable fonts.</li>
+                <li><strong>Language translation</strong> via a built-in widget on key pages &mdash; Hindi, Tamil, Bengali, Marathi, and more are being rolled out.</li>
+                <li><strong>Captions and transcripts</strong> on video content where we produce it. Podcast episodes include show notes.</li>
+            </ul>
+        </section>
+
+        <section aria-labelledby="limitations-heading" style="margin-bottom: 3rem;">
+            <h2 id="limitations-heading">Known limitations</h2>
+            <p>We are honest about what is not yet fully conformant:</p>
+            <ul>
+                <li><strong>Gamma-hosted foundational courses.</strong> 34 of our 38 foundational 101 courses are currently embedded as <a href="https://gamma.app" rel="noopener">Gamma.app</a> iframes. These are third-party slide decks and we have partial control over their keyboard trap behaviour, colour contrast, and screen-reader labelling. We are progressively rewriting these as native HTML slide decks &mdash; 4 are already done (dev-economics, mel-basics, climate-essentials, inequality-basics).</li>
+                <li><strong>Course lexicons built with Parcel bundling.</strong> 17 book-companion pages were originally shipped without a full <code>&lt;head&gt;</code> tag because of the bundler. Meta tags have since been restored, but keyboard focus order on these pages may still feel inconsistent.</li>
+                <li><strong>Interactive games and labs.</strong> Some of our 16 games and 11 labs use custom canvas-based interactions (drag and drop, charts, timed simulations) that are challenging to make fully screen-reader accessible. We provide text alternatives and keyboard fallbacks where we can, but coverage is not yet complete.</li>
+                <li><strong>Embedded third-party widgets.</strong> The UserWay accessibility widget itself, the Intro.js tour system, and Google Translate are excluded from our automated audits because they are out of our source control. We audit manually where feasible.</li>
+                <li><strong>Automated tool coverage.</strong> Even a perfect axe-core + pa11y-ci pass only tests about a third to a half of the WCAG success criteria. Issues involving meaningful reading order, cognitive load, and genuinely equivalent alternatives for visual content can only be found by humans.</li>
+            </ul>
+        </section>
+
+        <section aria-labelledby="report-heading" style="margin-bottom: 3rem;">
+            <h2 id="report-heading">How to report an accessibility barrier</h2>
+            <p>If you run into something that stops you from using ImpactMojo, please tell us. We treat accessibility reports as high-priority bugs, not feature requests.</p>
+            <ul>
+                <li><strong>Email:</strong> <a href="mailto:hello@impactmojo.in?subject=Accessibility%20issue">hello@impactmojo.in</a> with "Accessibility issue" in the subject line.</li>
+                <li><strong>GitHub:</strong> <a href="https://github.com/ImpactMojo/ImpactMojo/issues/new" rel="noopener">Open an issue</a> in our public repository. Please add the <code>accessibility</code> label.</li>
+                <li><strong>In the message:</strong> tell us the page URL, what you were trying to do, what happened instead, and (if you can) what assistive technology and browser you were using. Screenshots or screen recordings are helpful but not required.</li>
+            </ul>
+            <p><strong>Our response commitment:</strong> we aim to acknowledge accessibility reports within two working days and to ship a fix or a clear plan within two weeks for serious or critical issues.</p>
+        </section>
+
+        <section aria-labelledby="standards-heading" style="margin-bottom: 3rem;">
+            <h2 id="standards-heading">Standards and references</h2>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG21/" rel="noopener">Web Content Accessibility Guidelines (WCAG) 2.1</a> &mdash; the target we conform to.</li>
+                <li><a href="https://www.w3.org/WAI/standards-guidelines/atag/" rel="noopener">Authoring Tool Accessibility Guidelines (ATAG) 2.0</a> &mdash; relevant to the premium authoring tools we build.</li>
+                <li><a href="https://dequeuniversity.com/rules/axe/" rel="noopener">Deque University axe Rules Reference</a>.</li>
+                <li><a href="https://www.accessibility.gov.in/" rel="noopener">Accessibility standards under Section 46 of the Rights of Persons with Disabilities Act, 2016 (India)</a>.</li>
+            </ul>
+        </section>
+
+        <section aria-labelledby="changes-heading" style="margin-bottom: 2rem;">
+            <h2 id="changes-heading">Changes to this statement</h2>
+            <p>We update this statement whenever our testing infrastructure, known limitations, or scope of conformance changes materially. Historical edits are tracked in our <a href="https://github.com/ImpactMojo/ImpactMojo/blob/main/docs/changelog.md" rel="noopener">public changelog</a>.</p>
+        </section>
+
+    </div>
+</main>
+
+<!-- Footer -->
+<footer class="footer">
+    <div class="footer-content">
+        <div class="footer-grid">
+            <div class="footer-section">
+                <h4>About</h4>
+                <ul>
+                    <li><a href="about.html">About ImpactMojo</a></li>
+                    <li><a href="contact.html">Contact Us</a></li>
+                    <li><a href="community/">Community</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Legal & IT Act</h4>
+                <ul>
+                    <li><a href="/terms-of-service">Terms of Service</a></li>
+                    <li><a href="/privacy-policy">Privacy Policy</a></li>
+                    <li><a href="/refund-policy">Refund Policy</a></li>
+                    <li><a href="/accessibility.html">Accessibility Statement</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Quick Links</h4>
+                <ul>
+                    <li><a href="catalog.html">Course Catalog</a></li>
+                    <li><a href="premium.html">Premium Access</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Resources</h4>
+                <ul>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="podcast.html">Podcast</a></li>
+                    <li><a href="handouts.html">Handouts</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p class="footer-copyright">© 2026 ImpactMojo. All rights reserved. Made with <3 in India.</p>
+            <div class="footer-social">
+                <a href="https://www.linkedin.com/company/impactmojo" target="_blank" rel="noopener" title="LinkedIn">
+                    <svg viewBox="0 0 24 24"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+                </a>
+                <a href="https://www.instagram.com/impactmojo" target="_blank" rel="noopener" title="Instagram">
+                    <svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>
+                </a>
+                <a href="https://twitter.com/impactmojo" target="_blank" rel="noopener" title="X (Twitter)">
+                    <svg viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+                </a>
+            </div>
+        </div>
+    </div>
+</footer>
+
+
+<!-- Mojini Chatbot FAB -->
+<button class="feedback-fab" id="mojini-chat-toggle" onclick="openChatbot()" title="Chat with Mojini">
+    <svg viewBox="0 0 24 24">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+    </svg>
+</button>
+
+<!-- Chatbot Modal -->
+<div class="chatbot-modal" id="chatbotModal">
+    <div class="chat-header">
+        <h3>
+            <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/></svg>
+            Mojini
+        </h3>
+        <button class="chat-close" aria-label="Close chat" onclick="closeChatbot()">
+            <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+    </div>
+    <div class="chat-messages" id="chatMessages">
+        <div class="message bot-message">
+            <div class="bot-avatar">
+                <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/></svg>
+            </div>
+            <div class="bot-bubble">Hey there! 👋 I'm Mojini, your ImpactMojo assistant. How can I help you today?</div>
+        </div>
+    </div>
+    <div class="chat-options">
+        <button class="chat-option" onclick="selectOption('courses')">📚 Courses</button>
+        <button class="chat-option" onclick="selectOption('contact')">📧 Contact</button>
+        <button class="chat-option" onclick="selectOption('feedback')">💬 Feedback</button>
+    </div>
+    <div class="chat-input-area">
+        <input type="text" id="chatInput" placeholder="Type your message..." onkeypress="handleChatKeyPress(event)">
+        <button class="chat-send" aria-label="Send message" onclick="sendChatMessage()">
+            <svg viewBox="0 0 24 24"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+    </div>
+</div>
+
+<!-- UserWay Accessibility Widget -->
+<script>
+    (function(d) {
+      var s = d.createElement("script");
+      s.setAttribute("data-position", 2);
+      s.setAttribute("data-widget_layout", "full");
+      s.setAttribute("data-account", "EksmhlPg9k");
+      s.setAttribute("src", "https://cdn.userway.org/widget.js");
+      (d.body || d.head).appendChild(s);
+    })(document);
+</script>
+
+<!-- JavaScript -->
+<script>
+// Theme Management
+function toggleTheme() {
+    document.body.classList.toggle('light-mode');
+    const isLight = document.body.classList.contains('light-mode');
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
+}
+
+function initTheme() {
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    
+    if (savedTheme === 'light' || (!savedTheme && !prefersDark)) {
+        document.body.classList.add('light-mode');
+    }
+}
+
+// Speed Dial
+function toggleSpeedDial() {
+    document.getElementById('imxSpeedDial').classList.toggle('open');
+}
+
+// Chatbot
+function openChatbot() {
+    document.getElementById('chatbotModal').classList.add('open');
+}
+
+function closeChatbot() {
+    document.getElementById('chatbotModal').classList.remove('open');
+}
+
+function selectOption(option) {
+    const messages = document.getElementById('chatMessages');
+    let response = '';
+    
+    switch(option) {
+        case 'courses':
+            response = 'We offer free courses on MEAL, Theory of Change, Research Methods, Gender Studies, and more! Visit our <a href="catalog.html">Catalog</a> to browse all courses.';
+            break;
+        case 'contact':
+            response = 'You can reach us at <a href="mailto:hello@impactmojo.in">hello@impactmojo.in</a> or visit our <a href="contact.html">Contact page</a>.';
+            break;
+        case 'feedback':
+            response = 'We love hearing from you! Please share your feedback, suggestions, or bug reports. Your input helps us improve ImpactMojo for everyone.';
+            break;
+        default:
+            response = 'How can I help you today?';
+    }
+    
+    const userMsg = document.createElement('div');
+    userMsg.className = 'message';
+    userMsg.innerHTML = `<div class="bot-bubble" style="margin-left: auto; background: var(--gradient-primary); color: white; border-radius: 12px; border-top-right-radius: 4px;">${option.charAt(0).toUpperCase() + option.slice(1)}</div>`;
+    messages.appendChild(userMsg);
+    
+    setTimeout(() => {
+        const botMsg = document.createElement('div');
+        botMsg.className = 'message bot-message';
+        botMsg.innerHTML = `
+            <div class="bot-avatar">
+                <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="10" rx="2"></rect><circle cx="12" cy="5" r="2"></circle><path d="M12 7v4"></path></svg>
+            </div>
+            <div class="bot-bubble">${response}</div>
+        `;
+        messages.appendChild(botMsg);
+        messages.scrollTop = messages.scrollHeight;
+    }, 500);
+}
+
+function handleChatKeyPress(event) {
+    if (event.key === 'Enter') {
+        sendChatMessage();
+    }
+}
+
+function sendChatMessage() {
+    const input = document.getElementById('chatInput');
+    const message = input.value.trim();
+    
+    if (!message) return;
+    
+    const messages = document.getElementById('chatMessages');
+    
+    const userMsg = document.createElement('div');
+    userMsg.className = 'message';
+    userMsg.innerHTML = `<div class="bot-bubble" style="margin-left: auto; background: var(--gradient-primary); color: white; border-radius: 12px; border-top-right-radius: 4px;">${message}</div>`;
+    messages.appendChild(userMsg);
+    
+    input.value = '';
+    
+    setTimeout(() => {
+        let response = "Thanks for your message! For detailed assistance, please email us at <a href='mailto:hello@impactmojo.in'>hello@impactmojo.in</a> or visit our <a href='faq.html'>FAQ page</a>.";
+        
+        const lowerMsg = message.toLowerCase();
+        if (lowerMsg.includes('course') || lowerMsg.includes('learn')) {
+            response = "We offer free courses on MEAL, Theory of Change, Research Methods, and more! Check our <a href='catalog.html'>Catalog</a> for all courses.";
+        } else if (lowerMsg.includes('workshop') || lowerMsg.includes('training')) {
+            response = "We offer customized workshops for NGOs and development teams. Visit our <a href='workshops.html'>Workshops page</a> for details.";
+        } else if (lowerMsg.includes('coach') || lowerMsg.includes('mentor')) {
+            response = "Our coaching services provide personalized guidance for your development career. Learn more on our <a href='coaching.html'>Coaching page</a>.";
+        } else if (lowerMsg.includes('free') || lowerMsg.includes('cost') || lowerMsg.includes('price')) {
+            response = "All core educational content on ImpactMojo is completely free! We follow a 'pay what you think is fair' philosophy.";
+        }
+        
+        const botMsg = document.createElement('div');
+        botMsg.className = 'message bot-message';
+        botMsg.innerHTML = `
+            <div class="bot-avatar">
+                <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="10" rx="2"></rect><circle cx="12" cy="5" r="2"></circle><path d="M12 7v4"></path></svg>
+            </div>
+            <div class="bot-bubble">${response}</div>
+        `;
+        messages.appendChild(botMsg);
+        messages.scrollTop = messages.scrollHeight;
+    }, 800);
+}
+
+// Initialization
+document.addEventListener('DOMContentLoaded', function() {
+    initTheme();
+});
+
+// Close dropdowns when clicking outside
+document.addEventListener('click', function(e) {
+    if (!e.target.closest('.has-dropdown') && window.innerWidth <= 768) {
+        document.querySelectorAll('.has-dropdown.open').forEach(el => {
+            el.classList.remove('open');
+        });
+    }
+});
+
+// Close speed dial when clicking outside
+document.addEventListener('click', function(e) {
+    if (!e.target.closest('});
+</script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script defer src="js/translate.js"></script>
+
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+</body>
+</html>

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -5859,6 +5859,22 @@
     ]
   },
   {
+    "id": "accessibility",
+    "title": "Accessibility Statement",
+    "description": "ImpactMojo's commitment to WCAG 2.1 Level AA conformance, audited on every PR with axe-core and pa11y-ci. Known limitations and how to report a barrier.",
+    "type": "page",
+    "category": "Legal",
+    "url": "/accessibility.html",
+    "tags": [
+      "accessibility",
+      "wcag",
+      "a11y",
+      "inclusive",
+      "legal",
+      "statement"
+    ]
+  },
+  {
     "id": "catalog",
     "title": "Full Catalog",
     "description": "Browse the complete catalog of courses, labs, games, tools, and resources available on ImpactMojo.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.16.0 — April 8, 2026
+
+### Added
+- **Accessibility Statement page** at `/accessibility.html` — formal WCAG 2.1 Level AA conformance statement covering our commitment, how we test (axe-core + pa11y-ci on every PR), accessibility features, known limitations (Gamma iframes, canvas-based games, third-party widgets), and how to report a barrier. Linked from the footer Legal section, the About page, and the UserWay widget's statement link.
+- **README badges** — new "Accessibility: WCAG 2.1 AA" shield and a live GitHub Actions status badge for the `accessibility.yml` workflow, so the repo README reflects current CI truth.
+- **About page accessibility callout** — a brief paragraph in "What We Offer" announcing WCAG 2.1 AA conformance with a link to the full statement.
+
+### Changed
+- **UserWay widget** — the commented-out `data-statement_url` and `data-statement_text` config was wired up to point at the new `/accessibility.html` page. The UserWay button now surfaces "Our Accessibility Statement" as a direct link.
+
 ## v10.15.0 — April 8, 2026
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -13726,6 +13726,7 @@ window.addEventListener('authStateChanged', function(e) {
 <ul>
 <li><a href='/privacy-policy'>Privacy Policy</a></li>
 <li><a href='/terms-of-service'>Terms of Service</a></li>
+<li><a href='/accessibility.html'>Accessibility Statement</a></li>
 <li><a href='/disclaimer'>Disclaimer</a></li>
 <li><a href='/grievance'>Grievance Redressal</a></li>
 <li><a href='/refund-policy'>Refund Policy</a></li>
@@ -14096,8 +14097,8 @@ PASTE THIS ENTIRE BLOCK JUST BEFORE
       /* s.setAttribute("data-language", "language");*/
       /* s.setAttribute("data-color", "#053e67");*/
       /* s.setAttribute("data-type", "1");*/
-      /* s.setAttribute("data-statement_text:", "Our Accessibility Statement");*/
-      /* s.setAttribute("data-statement_url", "http://www.example.com/accessibility"); */
+      s.setAttribute("data-statement_text", "Our Accessibility Statement");
+      s.setAttribute("data-statement_url", "https://www.impactmojo.in/accessibility.html");
       /* s.setAttribute("data-mobile", true);*/
       /* s.setAttribute("data-trigger", "triggerId")*/
       /* s.setAttribute("data-z-index", 10001);*/

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -227,6 +227,12 @@
         <priority>0.4</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/accessibility.html</loc>
+        <lastmod>2026-04-08</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/terms-of-service.html</loc>
         <lastmod>2026-03-21</lastmod>
         <changefreq>yearly</changefreq>


### PR DESCRIPTION
## Summary

Formalizes ImpactMojo's WCAG 2.1 Level AA accessibility work that's been shipping via `axe-core` + `pa11y-ci` CI gates but wasn't advertised anywhere users could find it. Follow-up to ImpactMojo/ImpactMojo#368.

## Changes

### New: `/accessibility.html`
Built from `PAGE-TEMPLATE.html` so it inherits the full V3 brand system (topbar, nav, footer, UserWay widget, GA, favicons, paper-plane decoration) with zero drift. Content covers:

- **Our commitment** — why we treat a11y as a baseline, not a feature
- **Conformance status** — WCAG 2.1 AA target, current "partially conformant" status, scope, last-updated date
- **How we test** — axe-core (5 pages, fails on serious+), pa11y-ci (13 pages, WCAG2AA, 4 documented exceptions), manual keyboard/screen-reader review, plus a cross-link to the recent blog post "What It Actually Takes to Make an Accessible Website"
- **Accessibility features** — semantic HTML5, keyboard nav, skip links, high-contrast tokens (6.2:1 / 6.96:1), dark mode, 200% zoom, reduced-motion support, UserWay widget, language translation, captions
- **Known limitations** — honest list: 34 Gamma iframes, 17 Parcel-bundled book companion pages, canvas-based games, third-party widgets excluded from automated audits, automated-tool coverage ceiling
- **How to report a barrier** — email, GitHub issues, what to include, response-time commitment (2 working days acknowledgement, 2 weeks fix/plan for serious+)
- **Standards & references** — WCAG 2.1, ATAG 2.0, Deque axe rules, India RPWD Act 2016

### Cross-references wired up

| File | Change |
|---|---|
| `index.html` footer | New "Accessibility Statement" link in "Legal (IT Act Compliance)" section, between Terms of Service and Disclaimer |
| `index.html` UserWay widget | Uncommented and populated `data_statement_text` + `data_statement_url` — previously had placeholder `http://www.example.com/accessibility`. The UserWay button now surfaces "Our Accessibility Statement" |
| `about.html` "What We Offer" section | Brief WCAG 2.1 AA callout paragraph linking to the full statement |
| `README.md` badge row | Two new shields: static "Accessibility: WCAG 2.1 AA" linking to the page + live GitHub Actions badge for `accessibility.yml` workflow |
| `sitemap.xml` | New `<url>` entry at priority 0.5 |
| `data/search-index.json` | New `"type": "page"` entry under Legal category |
| `docs/changelog.md` | v10.16.0 entry |

## Known scope notes

1. **Theme-toggle pattern.** The new page uses `PAGE-TEMPLATE.html`'s `toggleTheme` pattern (simple sun/moon) rather than the newer `im-theme-selector` + `applyTheme` 3-mode pattern used on `transparency.html`. `PAGE-TEMPLATE.html` itself predates the new pattern, so matching the template was the right call for this PR. Upgrading `PAGE-TEMPLATE.html` + downstream pages to the new pattern is a separate task — I can open a follow-up issue if helpful.

2. **catalog.html JS data drift.** Still tracked in `.claude/memory.md` as a follow-up from #368 — unrelated to this PR.

## Test plan

- [x] `accessibility.html` has no remaining `[PAGE_*]` placeholders
- [x] Python HTML parser passes on the new page
- [x] `python3 -m json.tool data/search-index.json` passes
- [x] `sitemap.xml` parses as valid XML
- [x] All 7 cross-reference files (accessibility.html, index.html, about.html, README.md, sitemap.xml, search-index.json, docs/changelog.md) mention `accessibility.html`
- [x] Brand pre-flight: logo, GA, fonts, viewport, favicons, UserWay + EksmhlPg9k account, paper plane all present
- [x] UserWay `data_statement_url` points to `https://www.impactmojo.in/accessibility.html` (not the old example.com placeholder)
- [x] README badge row preserved — existing 9 badges still present, new 2 inserted in a sensible spot (after Netlify Status)
- [ ] Will verify on merge: axe-core and pa11y-ci pass on the new page (neither currently tests `/accessibility.html` directly — consider adding it to `.pa11yci` in a follow-up)

## Follow-ups I'd suggest (separate issues/PRs)

1. Add `/accessibility.html` to `.pa11yci` and to the axe-core test page list in `tests/axe-accessibility.js` so it's audited by the same CI gates it describes.
2. Upgrade `PAGE-TEMPLATE.html` to the `im-theme-selector` + `applyTheme` 3-mode theme pattern to match `transparency.html` and the brand-guidelines skill.
3. Add the accessibility link to other standalone policy pages' footers (`privacy-policy.html`, `terms-of-service.html`, etc.) for footer consistency.

https://claude.ai/code/session_01SdRhGj2Vm7MFgbeLPQLfmf