### PR TITLE
newsletter: parse '### For Learners' instead of '### Added'

### DIFF
--- a/.claude/rules/content-management.md
+++ b/.claude/rules/content-management.md
@@ -13,6 +13,7 @@ When adding or modifying content:
    ```
 4. **Update docs**: `docs/games-guide.md`, `docs/labs-guide.md`, `docs/content-guide.md` as relevant
 5. **Update changelog**: `docs/changelog.md` for user-facing changes
+   - **5a. Learner-facing additions** (new games, labs, courses, book summaries, deep dives, blog posts, premium tools): also add a `- **Title** — short description` bullet to a `### For Learners` subsection in the release entry. The monthly newsletter (`netlify/functions/monthly-newsletter.mjs`) parses **only** that subsection — anything in `### Added` / `### Changed` / `### Fixed` or topic-specific sections is treated as internal/dev-facing and ignored. Keep bullets short and benefit-focused; never include infra terms (Formspree, drip, RLS, Edge Function, migration, cron, webhook, etc.) — a defensive blocklist will strip them anyway.
 6. **Update sitemap**: add `<url>` entry to `sitemap.xml`
 7. **Update catalog**: `catalog.html` / `catalog_data.json` for courses
 8. **Check stale links**: `grep -rn "101.impactmojo.in" index.html courses/` for refs that should be self-hosted

--- a/netlify/functions/monthly-newsletter.mjs
+++ b/netlify/functions/monthly-newsletter.mjs
@@ -2,9 +2,16 @@
  * Netlify Scheduled Function — Monthly Newsletter
  *
  * Runs on the 15th of every month at 10:00 IST (04:30 UTC).
- * Reads CHANGELOG.md and docs/changelog.md for what's new in the past 30 days,
- * reads search-index.json for current content counts, and sends a monthly
- * update email to all users via the send-notification Edge Function.
+ *
+ * Pulls learner-facing highlights from `### For Learners` subsections in
+ * docs/changelog.md (dated within the last 35 days) and reads
+ * search-index.json for current content counts. Sends a monthly update
+ * email via the send-notification Edge Function.
+ *
+ * IMPORTANT: only bullets under a `### For Learners` subsection are picked up.
+ * Anything in `### Added`, `### Changed`, `### Fixed`, or topic-specific
+ * subsections is treated as internal/dev-facing and ignored. See
+ * `.claude/rules/content-management.md` step 5a.
  *
  * Environment variables (set in Netlify dashboard):
  *   SUPABASE_URL              — Supabase project URL
@@ -15,7 +22,7 @@ const SUPABASE_URL = process.env.SUPABASE_URL || "https://ddyszmfffyedolkcugld.s
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const SITE_URL = "https://www.impactmojo.in";
 
-// Parse the user-facing changelog (docs/changelog.md) for recent "Added" items
+// Parse docs/changelog.md for recent `### For Learners` bullets.
 async function getRecentChanges() {
   try {
     const resp = await fetch(`${SITE_URL}/docs/changelog.md`);
@@ -28,32 +35,36 @@ async function getRecentChanges() {
     const highlights = [];
     const lines = text.split("\n");
     let currentDate = null;
-    let inAdded = false;
+    let inSection = false;
 
     for (const line of lines) {
       // Match version headers like "## v10.16.0 — April 8, 2026"
       const versionMatch = line.match(/^## .+?—\s*(.+)$/);
       if (versionMatch) {
-        const parsed = new Date(versionMatch[1].trim());
+        // Strip parenthetical suffix like "April 8, 2026 (some note)" so
+        // Date.parse() gets a clean string.
+        const dateStr = versionMatch[1].trim().replace(/\s*\(.*\)\s*$/, "");
+        const parsed = new Date(dateStr);
         if (!isNaN(parsed.getTime())) {
           currentDate = parsed;
         }
-        inAdded = false;
+        inSection = false;
         continue;
       }
 
-      // Track if we're in an "Added" section
-      if (line.match(/^### Added/i)) {
-        inAdded = true;
+      // Only the curated `### For Learners` subsection is learner-facing.
+      // Internal `### Added` / `### Changed` / `### Fixed` / topic sections
+      // are ignored on purpose — see file header comment.
+      if (line.match(/^### For Learners\b/i)) {
+        inSection = true;
         continue;
       }
       if (line.match(/^### /)) {
-        inAdded = false;
+        inSection = false;
         continue;
       }
 
-      // Only collect "Added" items from recent dates
-      if (inAdded && currentDate && currentDate >= cutoff) {
+      if (inSection && currentDate && currentDate >= cutoff) {
         const itemMatch = line.match(/^- \*\*(.+?)\*\*\s*[—–-]\s*(.+)/);
         if (itemMatch) {
           highlights.push({
@@ -64,7 +75,12 @@ async function getRecentChanges() {
       }
     }
 
-    return highlights.slice(0, 5); // Max 5 highlights
+    // Defensive blocklist: even if a contributor accidentally drops infra
+    // language into `### For Learners`, drop it before the email ships.
+    const BLOCK = /\b(Formspree|drip|streak[ -]?tracking|RLS|Edge Function|migration|SUPABASE|cron|webhook|infrastructure|Netlify Function|API key|service.role)\b/i;
+    return highlights
+      .filter((h) => !BLOCK.test(`${h.title} ${h.description}`))
+      .slice(0, 5);
   } catch (err) {
     console.error("Failed to parse changelog:", err);
     return [];


### PR DESCRIPTION
## Summary

The May 15 monthly newsletter leaked 5 internal/infra entries (Formspree migration, drip pipeline, streak tracking, post-cert email, the newsletter itself) because `monthly-newsletter.mjs` pulled every bullet under `### Added` in the last 35 days of `docs/changelog.md`, with no notion of user-facing vs internal.

- Parser now reads only `### For Learners` subsections; `### Added` / `### Changed` / `### Fixed` are ignored
- Defensive blocklist (Formspree, drip, streak-tracking, RLS, Edge Function, migration, cron, webhook, infrastructure, etc.) strips infra terms even if they slip into `### For Learners`
- Date-header parser tolerates parenthetical suffixes like `May 1, 2026 (Handouts audit)`
- `.claude/rules/content-management.md` step 5a documents the convention going forward

## Test plan

- [x] `node --check netlify/functions/monthly-newsletter.mjs` passes
- [x] Dry-run against current `docs/changelog.md` → 0 hits → falls back to evergreen highlights (correct safe default; no `### For Learners` sections exist yet)
- [x] Synthetic test with mixed `### For Learners` + `### Added` sections → For-Learners bullets pass through, Added bullets ignored, blocklist drops "Streak tracking" and "Engagement drip" even when planted inside For-Learners
- [ ] First real run: June 15, 2026 — populate a `### For Learners` block on the next release entry between now and then

## Out of scope

- No edits to historic changelog entries (v10.17.0 etc.)
- Not resending a corrected May 15 newsletter — would be more confusing than the original
- `send-notification` Edge Function on Supabase unchanged (input shape preserved)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LKgXPvExviLsGvEN7qjgqs)_